### PR TITLE
Explicitly specify optional dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,10 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        'extras': ['spacy', 'nltk'],
+        'extras': [
+            'spacy',
+            'nltk',
+            'scipy',
+        ],
     },
 )


### PR DESCRIPTION
Can be installed via `pip install gluonnlp[Name,...]`, eg. `pip install gluonnlp[SpacyTokenizer]`.

This may be obvious for both Spacy and NLTK, but writing down all optional dependencies in the setup.py will allow us to keep an overview when we add more optional dependencies in future.