### PR TITLE
Enable test coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ stage("Unit Test") {
         python -m nltk.downloader all
         make clean
         python setup.py install
-        py.test -v --capture=no --durations=0 tests/unittest scripts
+        py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
         """
       }
     }
@@ -43,7 +43,7 @@ stage("Unit Test") {
         python -m nltk.downloader all
         make clean
         python setup.py install
-        py.test -v --capture=no --durations=0 tests/unittest scripts
+        py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
         """
       }
     }

--- a/env/py2.yml
+++ b/env/py2.yml
@@ -10,5 +10,6 @@ dependencies:
   - nltk
   - pytest
   - flaky
+  - pytest-cov
   - pip:
     - mxnet>=1.2.0b20180415

--- a/env/py3.yml
+++ b/env/py3.yml
@@ -10,5 +10,6 @@ dependencies:
   - nltk
   - pytest
   - flaky
+  - pytest-cov
   - pip:
     - mxnet>=1.2.0b20180415


### PR DESCRIPTION
Let's enable test coverage reports. We can visualize them later with https://codecov.io/ once the toolkit is made open source. For now they will just be shown as short textual summary at the bottom of the CI test output.

Test coverage reports will help us to catch untested parts of our code, and subsequently finding bugs which may be present in those untested code-paths.