### PR TITLE
Enable lint and tests for notebooks in example folder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,8 @@ stage("Unit Test") {
         py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
         cd docs/examples
         export MXNET_GPU_MEM_POOL_RESERVE=7
-        py.test -v --capture=no --durations=0 --nbsmoke-lint *.ipynb
-        py.test -v --capture=no --durations=0 --nbsmoke-run *.ipynb
+        py.test -v --capture=no --durations=0 --nbsmoke-lint */*.ipynb
+        py.test -v --capture=no --durations=0 --nbsmoke-run */*.ipynb
         """
       }
     }
@@ -50,8 +50,8 @@ stage("Unit Test") {
         py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
         cd docs/examples
         export MXNET_GPU_MEM_POOL_RESERVE=7
-        py.test -v --capture=no --durations=0 --nbsmoke-lint *.ipynb
-        py.test -v --capture=no --durations=0 --nbsmoke-run *.ipynb
+        py.test -v --capture=no --durations=0 --nbsmoke-lint */*.ipynb
+        py.test -v --capture=no --durations=0 --nbsmoke-run */*.ipynb
         """
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,9 @@ stage("Unit Test") {
         make clean
         python setup.py install
         py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
+        cd docs/examples
+        py.test -v --capture=no --durations=0 --nbsmoke-lint *.ipynb
+        py.test -v --capture=no --durations=0 --nbsmoke-run *.ipynb
         """
       }
     }
@@ -44,6 +47,9 @@ stage("Unit Test") {
         make clean
         python setup.py install
         py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
+        cd docs/examples
+        py.test -v --capture=no --durations=0 --nbsmoke-lint *.ipynb
+        py.test -v --capture=no --durations=0 --nbsmoke-run *.ipynb
         """
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,7 @@ stage("Unit Test") {
         python setup.py install
         py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
         cd docs/examples
+        export MXNET_GPU_MEM_POOL_RESERVE=7
         py.test -v --capture=no --durations=0 --nbsmoke-lint *.ipynb
         py.test -v --capture=no --durations=0 --nbsmoke-run *.ipynb
         """
@@ -48,6 +49,7 @@ stage("Unit Test") {
         python setup.py install
         py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
         cd docs/examples
+        export MXNET_GPU_MEM_POOL_RESERVE=7
         py.test -v --capture=no --durations=0 --nbsmoke-lint *.ipynb
         py.test -v --capture=no --durations=0 --nbsmoke-run *.ipynb
         """

--- a/env/py2.yml
+++ b/env/py2.yml
@@ -13,3 +13,4 @@ dependencies:
   - pytest-cov
   - pip:
     - mxnet>=1.2.0b20180415
+    - nbsmoke

--- a/env/py2.yml
+++ b/env/py2.yml
@@ -12,5 +12,5 @@ dependencies:
   - flaky
   - pytest-cov
   - pip:
-    - mxnet>=1.2.0b20180415
+    - mxnet-cu80>=1.2.0b20180415
     - nbsmoke

--- a/env/py3.yml
+++ b/env/py3.yml
@@ -13,3 +13,4 @@ dependencies:
   - pytest-cov
   - pip:
     - mxnet>=1.2.0b20180415
+    - nbsmoke

--- a/env/py3.yml
+++ b/env/py3.yml
@@ -12,5 +12,5 @@ dependencies:
   - flaky
   - pytest-cov
   - pip:
-    - mxnet>=1.2.0b20180415
+    - mxnet-cu80>=1.2.0b20180415
     - nbsmoke

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# when running, seconds allowed per cell (see nbconvert timeout)
+cell_timeout = 1200


### PR DESCRIPTION
## Description ##
This PR enables lint checks and basic tests for the notebooks in the example folder. In particular it is tested that every notebook runs without errors. For that the PR enables the pytest extension [nbsmoke](https://github.com/pyviz/nbsmoke).

Alternatively we could also test that the output of each cell exactly matches the stored output by using https://github.com/computationalmodelling/nbval . This may be problematic as some of our outputs could be non-deterministic.
