### PR TITLE
Enable test parallelization

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ stage("Unit Test") {
         python -m nltk.downloader all
         make clean
         python setup.py install
-        py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
+        py.test -n auto -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
         """
       }
     }
@@ -43,7 +43,7 @@ stage("Unit Test") {
         python -m nltk.downloader all
         make clean
         python setup.py install
-        py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
+        py.test -n auto -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
         """
       }
     }

--- a/env/py2.yml
+++ b/env/py2.yml
@@ -11,5 +11,6 @@ dependencies:
   - pytest
   - flaky
   - pytest-cov
+  - pytest-xdist
   - pip:
     - mxnet>=1.2.0b20180415

--- a/env/py3.yml
+++ b/env/py3.yml
@@ -11,5 +11,6 @@ dependencies:
   - pytest
   - flaky
   - pytest-cov
+  - pytest-xdist
   - pip:
     - mxnet>=1.2.0b20180415

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         ],
         'dev': [
             'pytest',
+            'pytest-xdist',
             'recommonmark',
             'sphinx-gallery',
             'sphinx_rtd_theme',


### PR DESCRIPTION
This enables test parallelization to make use of all CPUs on our CI server and speed up our tests.