### PR TITLE
add function _get_home_dir()

### DIFF
--- a/gluonnlp/data/conll.py
+++ b/gluonnlp/data/conll.py
@@ -35,6 +35,7 @@ from mxnet.gluon.utils import download, check_sha1
 
 from .. import _constants as C
 from .registry import register
+from .utils import _get_home_dir
 
 
 class _CoNLLSequenceTagging(SimpleDataset):
@@ -111,10 +112,10 @@ class CoNLL2000(_CoNLLSequenceTagging):
     ----------
     segment : {'train', 'test'}, default 'train'
         Dataset segment.
-    root : str, default '~/.mxnet/datasets/conll2000'
+    root : str, default '~/.mxnet/datasets/conll2000' or '$MXNET_HOME/datasets/conll2000'
         Path to temp folder for storing data.
     """
-    def __init__(self, segment='train', root=os.path.join('~', '.mxnet', 'datasets', 'conll2000')):
+    def __init__(self, segment='train', root=os.path.join(_get_home_dir(), 'datasets', 'conll2000')):
         self._data_file = {'train': ('train.txt.gz',
                                      '9f31cf936554cebf558d07cce923dca0b7f31864'),
                            'test': ('test.txt.gz',
@@ -140,11 +141,11 @@ class CoNLL2001(_CoNLLSequenceTagging):
         Part number of the dataset.
     segment : {'train', 'testa', 'testb'}, default 'train'
         Dataset segment.
-    root : str, default '~/.mxnet/datasets/conll2001'
+    root : str, default '~/.mxnet/datasets/conll2001' or '$MXNET_HOME/datasets/conll2001'
         Path to temp folder for storing data.
     """
     def __init__(self, part, segment='train',
-                 root=os.path.join('~', '.mxnet', 'datasets', 'conll2001')):
+                 root=os.path.join(_get_home_dir(), 'datasets', 'conll2001')):
         self._part = part
         self._data_file = [
             {'train': ('train1',
@@ -198,11 +199,11 @@ class CoNLL2002(_CoNLLSequenceTagging):
         Dataset language.
     segment : {'train', 'testa', 'testb'}, default 'train'
         Dataset segment.
-    root : str, default '~/.mxnet/datasets/conll2002'
+    root : str, default '~/.mxnet/datasets/conll2002' or or '$MXNET_HOME/datasets/conll2002'
         Path to temp folder for storing data.
     """
     def __init__(self, lang, segment='train',
-                 root=os.path.join('~', '.mxnet', 'datasets', 'conll2002')):
+                 root=os.path.join(_get_home_dir(), 'datasets', 'conll2002')):
         self._lang = lang
         self._data_file = {
             'esp': {'train': ('esp.train.gz',
@@ -247,11 +248,11 @@ class CoNLL2004(_CoNLLSequenceTagging):
     ----------
     segment : {'train', 'dev', 'test'}, default 'train'
         Dataset segment.
-    root : str, default '~/.mxnet/datasets/conll2004'
+    root : str, default '~/.mxnet/datasets/conll2004' or '$MXNET_HOME/datasets/conll2004'
         Path to temp folder for storing data.
     """
     def __init__(self, segment='train',
-                 root=os.path.join('~', '.mxnet', 'datasets', 'conll2004')):
+                 root=os.path.join(_get_home_dir(), 'datasets', 'conll2004')):
         self._archive_file = ('conll04st-release.tar.gz',
                               '09ef957d908d34fa0abd745cbe43e279414f076c')
         self._data_file = {
@@ -323,11 +324,11 @@ class UniversalDependencies21(_CoNLLSequenceTagging):
         Dataset language.
     segment : str, default 'train'
         Dataset segment.
-    root : str, default '~/.mxnet/datasets/ud2.1'
+    root : str, default '~/.mxnet/datasets/ud2.1' or '$MXNET_HOME/datasets/ud2.1''
         Path to temp folder for storing data.
     """
     def __init__(self, lang='en', segment='train',
-                 root=os.path.join('~', '.mxnet', 'datasets', 'ud2.1')):
+                 root=os.path.join(_get_home_dir(), 'datasets', 'ud2.1')):
         self._archive_file = ('ud-treebanks-v2.1.tgz',
                               '77657b897951e21d2eca6b29958e663964eb57ae')
         self._lang = lang

--- a/gluonnlp/data/language_model.py
+++ b/gluonnlp/data/language_model.py
@@ -86,7 +86,7 @@ class WikiText2(_WikiText):
         The token to add at the begining of each sentence. If None, nothing is added.
     eos : str or None, default '<eos>'
         The token to add at the end of each sentence. If None, nothing is added.
-    root : str, default '~/.mxnet/datasets/wikitext-2' or '~/.mxnet/datasets/wikitext-2'
+    root : str, default '~/.mxnet/datasets/wikitext-2' or '$MXNET_HOME/datasets/wikitext-2'
         Path to temp folder for storing data.
     """
     def __init__(self, segment='train', skip_empty=True, bos=None, eos=C.EOS_TOKEN,

--- a/gluonnlp/data/language_model.py
+++ b/gluonnlp/data/language_model.py
@@ -31,6 +31,7 @@ from mxnet.gluon.utils import download, check_sha1, _get_repo_file_url
 from .. import _constants as C
 from .dataset import LanguageModelDataset
 from .registry import register
+from .utils import _get_home_dir
 
 
 class _WikiText(LanguageModelDataset):
@@ -85,11 +86,11 @@ class WikiText2(_WikiText):
         The token to add at the begining of each sentence. If None, nothing is added.
     eos : str or None, default '<eos>'
         The token to add at the end of each sentence. If None, nothing is added.
-    root : str, default '~/.mxnet/datasets/wikitext-2'
+    root : str, default '~/.mxnet/datasets/wikitext-2' or '~/.mxnet/datasets/wikitext-2'
         Path to temp folder for storing data.
     """
     def __init__(self, segment='train', skip_empty=True, bos=None, eos=C.EOS_TOKEN,
-                 root=os.path.join('~', '.mxnet', 'datasets', 'wikitext-2')):
+                 root=os.path.join(_get_home_dir(), 'datasets', 'wikitext-2')):
         self._archive_file = ('wikitext-2-v1.zip', '3c914d17d80b1459be871a5039ac23e752a53cbe')
         self._data_file = {'train': ('wiki.train.tokens',
                                      '863f29c46ef9d167fff4940ec821195882fe29d1'),
@@ -120,11 +121,11 @@ class WikiText103(_WikiText):
         The token to add at the begining of each sentence. If None, nothing is added.
     eos : str or None, default '<eos>'
         The token to add at the end of each sentence. If None, nothing is added.
-    root : str, default '~/.mxnet/datasets/wikitext-103'
+    root : str, default '~/.mxnet/datasets/wikitext-103' or '$MXNET_HOME/datasets/wikitext-103'
         Path to temp folder for storing data.
     """
     def __init__(self, segment='train', skip_empty=True, bos=None, eos=C.EOS_TOKEN,
-                 root=os.path.join('~', '.mxnet', 'datasets', 'wikitext-103')):
+                 root=os.path.join(_get_home_dir(), 'datasets', 'wikitext-103')):
         self._archive_file = ('wikitext-103-v1.zip', '0aec09a7537b58d4bb65362fee27650eeaba625a')
         self._data_file = {'train': ('wiki.train.tokens',
                                      'b7497e2dfe77e72cfef5e3dbc61b7b53712ac211'),

--- a/gluonnlp/data/sentiment.py
+++ b/gluonnlp/data/sentiment.py
@@ -28,6 +28,7 @@ import os
 from mxnet.gluon.data import SimpleDataset
 from mxnet.gluon.utils import download, check_sha1, _get_repo_file_url
 from .registry import register
+from .utils import _get_home_dir
 
 
 @register(segment=['train', 'test', 'unsup'])
@@ -41,10 +42,10 @@ class IMDB(SimpleDataset):
     ----------
     segment : str, default 'train'
         Dataset segment. Options are 'train', 'test', and 'unsup' for unsupervised.
-    root : str, default '~/.mxnet/datasets/imdb'
+    root : str, default '~/.mxnet/datasets/imdb' or '$MXNET_HOME/datasets/imdb'
         Path to temp folder for storing data.
     """
-    def __init__(self, segment='train', root=os.path.join('~', '.mxnet', 'datasets', 'imdb')):
+    def __init__(self, segment='train', root=os.path.join(_get_home_dir(), 'datasets', 'imdb')):
         self._data_file = {'train': ('train.json',
                                      '516a0ba06bca4e32ee11da2e129f4f871dff85dc'),
                            'test': ('test.json',

--- a/gluonnlp/data/translation.py
+++ b/gluonnlp/data/translation.py
@@ -34,6 +34,7 @@ from mxnet.gluon.data import ArrayDataset
 from .dataset import TextLineDataset
 from ..vocab import Vocab
 from .registry import register
+from .utils import _get_home_dir
 
 
 def _get_pair_key(src_lang, tgt_lang):
@@ -163,11 +164,11 @@ class IWSLT2015(_TranslationDataset):
         The source language. Option for source and target languages are 'en' <-> 'vi'
     tgt_lang : str, default 'vi'
         The target language. Option for source and target languages are 'en' <-> 'vi'
-    root : str, default '~/.mxnet/datasets/iwslt2015'
+    root : str, default '~/.mxnet/datasets/iwslt2015' or '$MXNET_HOME/datasets/iwslt2015'
         Path to temp folder for storing data.
     """
     def __init__(self, segment='train', src_lang='en', tgt_lang='vi',
-                 root=os.path.join('~', '.mxnet', 'datasets', 'iwslt2015')):
+                 root=os.path.join(_get_home_dir(), 'datasets', 'iwslt2015')):
         self._supported_segments = ['train', 'val', 'test']
         self._archive_file = {_get_pair_key('en', 'vi'):
                                   ('iwslt15.zip', '15a05df23caccb1db458fb3f9d156308b97a217b')}
@@ -209,11 +210,11 @@ class WMT2016BPE(_TranslationDataset):
         The source language. Option for source and target languages are 'en' <-> 'de'
     tgt_lang : str, default 'de'
         The target language. Option for source and target languages are 'en' <-> 'de'
-    root : str, default '~/.mxnet/datasets/wmt2016'
+    root : str, default '~/.mxnet/datasets/wmt2016' or '$MXNET_HOME/datasets/wmt2016'
         Path to temp folder for storing data.
     """
     def __init__(self, segment='train', src_lang='en', tgt_lang='de',
-                 root=os.path.join('~', '.mxnet', 'datasets', 'wmt2016')):
+                 root=os.path.join(_get_home_dir(), 'datasets', 'wmt2016')):
         self._supported_segments = ['train'] + ['newstest%d' % i for i in range(2012, 2017)]
         self._archive_file = {_get_pair_key('de', 'en'):
                                   ('wmt2016_de_en.zip',

--- a/gluonnlp/data/utils.py
+++ b/gluonnlp/data/utils.py
@@ -265,3 +265,9 @@ def _load_vocab_file(file_path):
     with open(file_path, 'r') as f:
         from ..vocab import Vocab
         return Vocab.from_json(f.read())
+
+
+def _get_home_dir():
+    """Get home directory for storing datasets/models/pre-trained word embeddings"""
+    _home_dir = os.environ.get('MXNET_HOME', os.path.join('~', '.mxnet'))
+    return _home_dir

--- a/gluonnlp/data/word_embedding_evaluation.py
+++ b/gluonnlp/data/word_embedding_evaluation.py
@@ -30,6 +30,7 @@ from mxnet.gluon.utils import check_sha1, _get_repo_file_url
 from .. import _constants as C
 from .dataset import CorpusDataset
 from .registry import register
+from .utils import _get_home_dir
 
 try:
     import requests
@@ -204,7 +205,7 @@ class WordSim353(WordSimilarityEvaluationDataset):
     ----------
     segment : str
         'relatedness', 'similiarity' or 'all'
-    root : str, default '~/.mxnet/datasets/wordsim353'
+    root : str, default '~/.mxnet/datasets/wordsim353' or '$MXNET_HOME/datasets/wordsim353'
         Path to temp folder for storing data.
 
     """
@@ -235,7 +236,7 @@ class WordSim353(WordSimilarityEvaluationDataset):
     max = 10
 
     def __init__(self, segment='all', root=os.path.join(
-            '~', '.mxnet', 'datasets', 'wordsim353')):
+            _get_home_dir(), 'datasets', 'wordsim353')):
         if segment is not None:
             assert segment in ['all', 'relatedness', 'similarity']
 
@@ -275,7 +276,7 @@ class MEN(WordSimilarityEvaluationDataset):
 
     Parameters
     ----------
-    root : str, default '~/.mxnet/datasets/men'
+    root : str, default '~/.mxnet/datasets/men' or '$MXNET_HOME/datasets/men'
         Path to temp folder for storing data.
     segment : str, default 'train'
         Dataset segment. Options are 'train', 'dev', 'test'.
@@ -315,7 +316,7 @@ class MEN(WordSimilarityEvaluationDataset):
     max = 50
 
     def __init__(self, segment='dev', root=os.path.join(
-            '~', '.mxnet', 'datasets', 'men')):
+            _get_home_dir(), 'datasets', 'men')):
         self.segment = segment
         super(MEN, self).__init__(root=root)
 
@@ -342,7 +343,7 @@ class RadinskyMTurk(WordSimilarityEvaluationDataset):
 
     Parameters
     ----------
-    root : str, default '~/.mxnet/datasets/radinskymturk'
+    root : str, default '~/.mxnet/datasets/radinskymturk' or '$MXNET_HOME/datasets/radinskymturk'
         Path to temp folder for storing data.
 
     """
@@ -353,7 +354,7 @@ class RadinskyMTurk(WordSimilarityEvaluationDataset):
     min = 1
     max = 5
 
-    def __init__(self, root=os.path.join('~', '.mxnet', 'datasets',
+    def __init__(self, root=os.path.join(_get_home_dir(), 'datasets',
                                          'radinskymturk')):
         super(RadinskyMTurk, self).__init__(root=root)
 
@@ -378,7 +379,7 @@ class RareWords(WordSimilarityEvaluationDataset):
 
     Parameters
     ----------
-    root : str, default '~/.mxnet/datasets/rarewords'
+    root : str, default '~/.mxnet/datasets/rarewords' or '$MXNET_HOME/datasets/rarewords'
         Path to temp folder for storing data.
 
     """
@@ -389,7 +390,7 @@ class RareWords(WordSimilarityEvaluationDataset):
     min = 0
     max = 10
 
-    def __init__(self, root=os.path.join('~', '.mxnet', 'datasets',
+    def __init__(self, root=os.path.join(_get_home_dir(), 'datasets',
                                          'rarewords')):
         super(RareWords, self).__init__(root=root)
 
@@ -441,7 +442,7 @@ class SimLex999(WordSimilarityEvaluationDataset):
 
     Parameters
     ----------
-    root : str, default '~/.mxnet/datasets/simlex999'
+    root : str, default '~/.mxnet/datasets/simlex999' or '$MXNET_HOME/datasets/simlex999'
         Path to temp folder for storing data.
 
     """
@@ -458,7 +459,7 @@ class SimLex999(WordSimilarityEvaluationDataset):
 
     score = 'SimLex999'
 
-    def __init__(self, root=os.path.join('~', '.mxnet', 'datasets',
+    def __init__(self, root=os.path.join(_get_home_dir(), 'datasets',
                                          'simlex999')):
         super(SimLex999, self).__init__(root=root)
 
@@ -494,7 +495,7 @@ class SimVerb3500(WordSimilarityEvaluationDataset):
 
     Parameters
     ----------
-    root : str, default '~/.mxnet/datasets/simverb3500'
+    root : str, default '~/.mxnet/datasets/simverb3500' or '$MXNET_HOME/datasets/simverb3500'
         Path to temp folder for storing data.
 
     """
@@ -528,7 +529,7 @@ class SimVerb3500(WordSimilarityEvaluationDataset):
     max = 10
 
     def __init__(self, segment='full', root=os.path.join(
-            '~', '.mxnet', 'datasets', 'simverb3500')):
+            _get_home_dir(), 'datasets', 'simverb3500')):
         self.segment = segment
         super(SimVerb3500, self).__init__(root=root)
 
@@ -564,7 +565,7 @@ class SemEval17Task2(WordSimilarityEvaluationDataset):
 
     Parameters
     ----------
-    root : str, default '~/.mxnet/datasets/wordsim353'
+    root : str, default '~/.mxnet/datasets/semeval17task2' or '$MXNET_HOME/datasets/semeval17task2'
         Path to temp folder for storing data.
     segment : str, default 'train'
         Dataset segment. Options are 'trial', 'test'.
@@ -588,7 +589,7 @@ class SemEval17Task2(WordSimilarityEvaluationDataset):
     languages = ('en', 'es', 'de', 'it', 'fa')
 
     def __init__(self, segment='trial', language='en', root=os.path.join(
-            '~', '.mxnet', 'datasets', 'semeval17task2')):
+            _get_home_dir(), 'datasets', 'semeval17task2')):
         assert segment in self.segments
         assert language in self.languages
         self.language = language
@@ -626,7 +627,7 @@ class BakerVerb143(WordSimilarityEvaluationDataset):
 
     Parameters
     ----------
-    root : str, default '~/.mxnet/datasets/wordsim353'
+    root : str, default '~/.mxnet/datasets/bakerverb143' or '$MXNET_HOME/datasets/bakerverb143'
         Path to temp folder for storing data.
 
     """
@@ -641,7 +642,7 @@ class BakerVerb143(WordSimilarityEvaluationDataset):
     min = 0
     max = 10
 
-    def __init__(self, root=os.path.join('~', '.mxnet', 'datasets',
+    def __init__(self, root=os.path.join(_get_home_dir(), 'datasets',
                                          'verb143')):
         super(BakerVerb143, self).__init__(root=root)
 
@@ -663,7 +664,7 @@ class YangPowersVerb130(WordSimilarityEvaluationDataset):
 
     Parameters
     ----------
-    root : str, default '~/.mxnet/datasets/wordsim353'
+    root : str, default '~/.mxnet/datasets/yangpowersverb130' or '$MXNET_HOME/datasets/yangpowersverb130'
         Path to temp folder for storing data.
 
     """
@@ -772,7 +773,7 @@ class GoogleAnalogyTestSet(WordAnalogyEvaluationDataset):
 
     def __init__(self, group=None,
                  category=None, lowercase=True, root=os.path.join(
-                     '~', '.mxnet', 'datasets', 'google_analogy')):
+                     _get_home_dir(), 'datasets', 'google_analogy')):
 
         assert group is None or group in self.groups
         assert category is None or category in self.categories
@@ -819,7 +820,7 @@ class BiggerAnalogyTestSet(WordAnalogyEvaluationDataset):
 
     Parameters
     ----------
-    root : str, default '~/.mxnet/datasets/simverb3500'
+    root : str, default '~/.mxnet/datasets/bats' or '$MXNET_HOME/datasets/bats'
         Path to temp folder for storing data.
 
     """
@@ -837,7 +838,7 @@ class BiggerAnalogyTestSet(WordAnalogyEvaluationDataset):
 
     def __init__(self, category=None, form_analogy_pairs=True,
                  drop_alternative_solutions=True, root=os.path.join(
-                     '~', '.mxnet', 'datasets', 'simverb3500')):
+                     _get_home_dir(), 'datasets', 'simverb3500')):
         self.form_analogy_pairs = form_analogy_pairs
         self.drop_alternative_solutions = drop_alternative_solutions
         self.category = category

--- a/gluonnlp/embedding/token_embedding.py
+++ b/gluonnlp/embedding/token_embedding.py
@@ -36,7 +36,7 @@ from mxnet import nd, registry
 from mxnet.gluon.utils import download, check_sha1, _get_repo_file_url
 
 from .. import _constants as C
-from ..data.utils import DefaultLookupDict
+from ..data.utils import DefaultLookupDict, _get_home_dir
 
 
 def register(embedding_cls):
@@ -647,7 +647,7 @@ class GloVe(TokenEmbedding):
     ----------
     source : str, default 'glove.6B.50d'
         The name of the pre-trained token embedding file.
-    embedding_root : str, default os.path.join('~', '.mxnet', 'embedding')
+    embedding_root : str, default '~/.mxnet/embedding' or '$MXNET_HOME/embedding'
         The root directory for storing embedding-related files.
     init_unknown_vec : callback
         The callback used to initialize the embedding vector for the unknown token.
@@ -666,7 +666,7 @@ class GloVe(TokenEmbedding):
     source_file_hash = C.GLOVE_NPZ_SHA1
 
     def __init__(self, source='glove.6B.50d',
-                 embedding_root=os.path.join('~', '.mxnet', 'embedding'),
+                 embedding_root=os.path.join(_get_home_dir(), 'embedding'),
                  init_unknown_vec=nd.zeros, **kwargs):
         GloVe._check_source(source)
 
@@ -721,7 +721,7 @@ class FastText(TokenEmbedding):
     ----------
     source : str, default 'glove.6B.50d'
         The name of the pre-trained token embedding file.
-    embedding_root : str, default os.path.join('~', '.mxnet', 'embedding')
+    embedding_root : str, default '~/.mxnet/embedding' or '$MXNET_HOME/embedding'
         The root directory for storing embedding-related files.
     init_unknown_vec : callback
         The callback used to initialize the embedding vector for the unknown token.
@@ -740,7 +740,7 @@ class FastText(TokenEmbedding):
     source_file_hash = C.FAST_TEXT_NPZ_SHA1
 
     def __init__(self, source='wiki.simple',
-                 embedding_root=os.path.join('~', '.mxnet', 'embedding'),
+                 embedding_root=os.path.join(_get_home_dir(), 'embedding'),
                  init_unknown_vec=nd.zeros, **kwargs):
         FastText._check_source(source)
 


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)
* add a function _get_home_dir() to obtain the directory for storing datasets/models/pre-trained word embeddings
* change the functions that specify `os.path.join('~', '.mxnet', ...)` and update the corresponding documentations

## Checklist ##
### Essentials ###
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
