### PR TITLE
fix __call__ for blocks to allow hook

### DIFF
--- a/env/doc.yml
+++ b/env/doc.yml
@@ -13,4 +13,4 @@ dependencies:
   - spacy
   - nltk
   - pip:
-    - mxnet-cu80==1.2.0b20180411
+    - mxnet-cu80>=1.2.0b20180518

--- a/env/py2.yml
+++ b/env/py2.yml
@@ -13,4 +13,4 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - pip:
-    - mxnet>=1.2.0b20180415
+    - mxnet-cu80>=1.2.0b20180518

--- a/env/py3.yml
+++ b/env/py3.yml
@@ -13,4 +13,4 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - pip:
-    - mxnet>=1.2.0b20180415
+    - mxnet-cu80>=1.2.0b20180518

--- a/env/pylint.yml
+++ b/env/pylint.yml
@@ -1,7 +1,7 @@
 name: gluon_nlp_pylint
 dependencies:
   - python
-  - pylint
+  - pylint=1.8.4
   - sphinx=1.7.2
   - pip:
     - pylint-quotes

--- a/scripts/nmt/encoder_decoder.py
+++ b/scripts/nmt/encoder_decoder.py
@@ -160,7 +160,7 @@ class Seq2SeqEncoder(Block):
         outputs : list
             Outputs of the encoder.
         """
-        return self.forward(inputs, valid_length, states)
+        return super(Seq2SeqEncoder, self).__call__(inputs, valid_length, states)
 
     def forward(self, inputs, valid_length=None, states=None):  #pylint: disable=arguments-differ
         raise NotImplementedError
@@ -227,7 +227,7 @@ class Seq2SeqDecoder(Block):
         step_additional_outputs : list
             Additional outputs of the step, e.g, the attention weights
         """
-        return self.forward(step_input, states)
+        return super(Seq2SeqDecoder, self).__call__(step_input, states)
 
     def forward(self, step_input, states):  #pylint: disable=arguments-differ
         raise NotImplementedError
@@ -337,7 +337,7 @@ class GNMTEncoder(Seq2SeqEncoder):
             - outputs of the last RNN layer
             - new_states of all the RNN layers
         """
-        return self.forward(inputs, states, valid_length)
+        return super(GNMTEncoder, self).__call__(inputs, states, valid_length)
 
     def forward(self, inputs, states=None, valid_length=None):  #pylint: disable=arguments-differ
         # TODO(sxjscience) Accelerate the forward using HybridBlock
@@ -508,7 +508,7 @@ class GNMTDecoder(HybridBlock, Seq2SeqDecoder):
             The attention weights will have shape (batch_size, 1, mem_length) or
             (batch_size, num_heads, 1, mem_length)
         """
-        return self.forward(step_input, states)
+        return super(GNMTDecoder, self).__call__(step_input, states)
 
     def forward(self, step_input, states):  #pylint: disable=arguments-differ
         step_output, new_states, step_additional_outputs =\

--- a/scripts/nmt/translation.py
+++ b/scripts/nmt/translation.py
@@ -201,7 +201,7 @@ class NMTModel(Block):
         additional_outputs : list
             Additional outputs, e.g, the attention weights
         """
-        return self.forward(src_seq, tgt_seq, src_valid_length, tgt_valid_length)
+        return super(NMTModel, self).__call__(src_seq, tgt_seq, src_valid_length, tgt_valid_length)
 
     def forward(self, src_seq, tgt_seq, src_valid_length=None, tgt_valid_length=None):  #pylint: disable=arguments-differ
         encoder_outputs = self.encode(src_seq, valid_length=src_valid_length)


### PR DESCRIPTION
## Description ##
fix `__call__` to call the `__call__` of parent class, so that it will work with forward hook in gluon.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] change `self.forward` to `super(XX, self).__call__` as we will use block's `__call__` for forward hook in gluon.
- [x] remove the usage of custom op in attention.