### PR TITLE
specify nltk version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     extras_require={
         'extras': [
             'spacy',
-            'nltk',
+            'nltk==3.2.5',
             'scipy',
         ],
         'dev': [


### PR DESCRIPTION
## Description ##
specify nltk version due to incompatible change in nltk 3.3 http://www.nltk.org/news.html?highlight=moses#id1

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)

### Changes ###
- [x] fix nltk version in setup.py