### PR TITLE
Revert "Enable test parallelism (#97)"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ stage("Unit Test") {
         python -m nltk.downloader all
         make clean
         python setup.py install
-        py.test -n auto -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
+        py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
         """
       }
     }
@@ -43,7 +43,7 @@ stage("Unit Test") {
         python -m nltk.downloader all
         make clean
         python setup.py install
-        py.test -n auto -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
+        py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
         """
       }
     }

--- a/env/py2.yml
+++ b/env/py2.yml
@@ -11,6 +11,5 @@ dependencies:
   - pytest
   - flaky
   - pytest-cov
-  - pytest-xdist
   - pip:
     - mxnet-cu80>=1.2.0b20180518

--- a/env/py3.yml
+++ b/env/py3.yml
@@ -11,6 +11,5 @@ dependencies:
   - pytest
   - flaky
   - pytest-cov
-  - pytest-xdist
   - pip:
     - mxnet-cu80>=1.2.0b20180518

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
         ],
         'dev': [
             'pytest',
-            'pytest-xdist',
             'recommonmark',
             'sphinx-gallery',
             'sphinx_rtd_theme',


### PR DESCRIPTION
Revert "Enable test parallelism (#97)"

This reverts commit a00cd6f489ee2bec81dad1784b92e63770ac6843.

Race conditions are frequent. Let's disable this until the parallel test workers
tests are set up to use independent environments.