### PR TITLE
Fix language_model.ipynb

### DIFF
--- a/docs/examples/language_model/language_model.ipynb
+++ b/docs/examples/language_model/language_model.ipynb
@@ -110,7 +110,7 @@
     "vocab = nlp.Vocab(nlp.data.Counter(train_dataset[0]), padding_token=None, bos_token=None)\n",
     "\n",
     "train_data, val_data, test_data = [x.bptt_batchify(vocab, bptt, batch_size,\n",
-    "                                                   last_batch='keep')\n",
+    "                                                   last_batch='discard')\n",
     "                                   for x in [train_dataset, val_dataset, test_dataset]]"
    ]
   },
@@ -135,7 +135,7 @@
       "    (0): Embedding(33278 -> 200, float32)\n",
       "    (1): Dropout(p = 0.2, axes=())\n",
       "  )\n",
-      "  (encoder): LSTM(200 -> 200.0, TNC, num_layers=2, dropout=0.2)\n",
+      "  (encoder): LSTM(200 -> 200, TNC, num_layers=2, dropout=0.2)\n",
       "  (decoder): HybridSequential(\n",
       "    (0): Dense(200 -> 33278, linear)\n",
       "  )\n",
@@ -323,37 +323,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[Epoch 0 Batch 100/746] loss 8.05, ppl 3147.06, throughput 1125.76 samples/s\n",
-      "[Epoch 0 Batch 200/746] loss 7.25, ppl 1402.82, throughput 1201.12 samples/s\n",
-      "[Epoch 0 Batch 300/746] loss 6.95, ppl 1047.72, throughput 1207.49 samples/s\n",
-      "[Epoch 0 Batch 400/746] loss 6.70, ppl 810.72, throughput 1213.90 samples/s\n",
-      "[Epoch 0 Batch 500/746] loss 6.51, ppl 670.70, throughput 1214.49 samples/s\n",
-      "[Epoch 0 Batch 600/746] loss 6.33, ppl 562.60, throughput 1211.53 samples/s\n",
-      "[Epoch 0 Batch 700/746] loss 6.21, ppl 498.81, throughput 1203.75 samples/s\n",
-      "[Epoch 0] throughput 1195.34 samples/s\n",
-      "[Epoch 0] time cost 54.93s, valid loss 5.90, valid ppl 364.40\n",
-      "test loss 5.82, test ppl 336.80\n",
-      "[Epoch 1 Batch 100/746] loss 6.10, ppl 446.09, throughput 1190.65 samples/s\n",
-      "[Epoch 1 Batch 200/746] loss 6.00, ppl 404.99, throughput 1207.26 samples/s\n",
-      "[Epoch 1 Batch 300/746] loss 5.94, ppl 378.32, throughput 1200.87 samples/s\n",
-      "[Epoch 1 Batch 400/746] loss 5.88, ppl 356.80, throughput 1197.75 samples/s\n",
-      "[Epoch 1 Batch 500/746] loss 5.77, ppl 320.43, throughput 1208.13 samples/s\n",
-      "[Epoch 1 Batch 600/746] loss 5.68, ppl 292.73, throughput 1203.65 samples/s\n",
-      "[Epoch 1 Batch 700/746] loss 5.63, ppl 277.95, throughput 1217.44 samples/s\n",
-      "[Epoch 1] throughput 1206.55 samples/s\n",
-      "[Epoch 1] time cost 54.37s, valid loss 5.49, valid ppl 241.20\n",
-      "test loss 5.40, test ppl 221.14\n",
-      "[Epoch 2 Batch 100/746] loss 5.61, ppl 273.02, throughput 1188.24 samples/s\n",
-      "[Epoch 2 Batch 200/746] loss 5.53, ppl 252.61, throughput 1202.37 samples/s\n",
-      "[Epoch 2 Batch 300/746] loss 5.50, ppl 245.29, throughput 1200.85 samples/s\n",
-      "[Epoch 2 Batch 400/746] loss 5.50, ppl 244.17, throughput 1202.60 samples/s\n",
-      "[Epoch 2 Batch 500/746] loss 5.40, ppl 222.01, throughput 1213.11 samples/s\n",
-      "[Epoch 2 Batch 600/746] loss 5.34, ppl 208.07, throughput 1208.37 samples/s\n",
-      "[Epoch 2 Batch 700/746] loss 5.31, ppl 203.18, throughput 1208.56 samples/s\n",
-      "[Epoch 2] throughput 1205.63 samples/s\n",
-      "[Epoch 2] time cost 54.39s, valid loss 5.25, valid ppl 190.18\n",
-      "test loss 5.16, test ppl 174.20\n",
-      "Total training throughput 990.11 samples/s\n"
+      "[Epoch 0 Batch 100/745] loss 8.03, ppl 3065.94, throughput 1697.82 samples/s\n",
+      "[Epoch 0 Batch 200/745] loss 7.25, ppl 1403.39, throughput 1734.12 samples/s\n",
+      "[Epoch 0 Batch 300/745] loss 6.94, ppl 1033.97, throughput 1746.13 samples/s\n",
+      "[Epoch 0 Batch 400/745] loss 6.67, ppl 787.56, throughput 1757.77 samples/s\n",
+      "[Epoch 0 Batch 500/745] loss 6.48, ppl 649.69, throughput 1751.55 samples/s\n",
+      "[Epoch 0 Batch 600/745] loss 6.31, ppl 550.47, throughput 1758.80 samples/s\n",
+      "[Epoch 0 Batch 700/745] loss 6.20, ppl 492.56, throughput 1757.13 samples/s\n",
+      "[Epoch 0] throughput 1744.91 samples/s\n",
+      "[Epoch 0] time cost 37.30s, valid loss 5.94, valid ppl 378.13\n",
+      "test loss 5.86, test ppl 352.40\n",
+      "[Epoch 1 Batch 100/745] loss 6.08, ppl 439.13, throughput 1725.42 samples/s\n",
+      "[Epoch 1 Batch 200/745] loss 5.99, ppl 399.40, throughput 1751.87 samples/s\n",
+      "[Epoch 1 Batch 300/745] loss 5.93, ppl 377.05, throughput 1743.20 samples/s\n",
+      "[Epoch 1 Batch 400/745] loss 5.88, ppl 356.80, throughput 1746.66 samples/s\n",
+      "[Epoch 1 Batch 500/745] loss 5.77, ppl 320.72, throughput 1752.17 samples/s\n",
+      "[Epoch 1 Batch 600/745] loss 5.69, ppl 296.44, throughput 1751.97 samples/s\n",
+      "[Epoch 1 Batch 700/745] loss 5.62, ppl 276.54, throughput 1752.15 samples/s\n",
+      "[Epoch 1] throughput 1747.56 samples/s\n",
+      "[Epoch 1] time cost 37.31s, valid loss 5.55, valid ppl 255.98\n",
+      "test loss 5.46, test ppl 236.26\n",
+      "[Epoch 2 Batch 100/745] loss 5.62, ppl 274.64, throughput 1740.72 samples/s\n",
+      "[Epoch 2 Batch 200/745] loss 5.55, ppl 257.08, throughput 1761.69 samples/s\n",
+      "[Epoch 2 Batch 300/745] loss 5.52, ppl 248.41, throughput 1744.27 samples/s\n",
+      "[Epoch 2 Batch 400/745] loss 5.50, ppl 245.33, throughput 1744.38 samples/s\n",
+      "[Epoch 2 Batch 500/745] loss 5.41, ppl 223.72, throughput 1762.50 samples/s\n",
+      "[Epoch 2 Batch 600/745] loss 5.35, ppl 210.89, throughput 1753.80 samples/s\n",
+      "[Epoch 2 Batch 700/745] loss 5.32, ppl 204.93, throughput 1747.81 samples/s\n",
+      "[Epoch 2] throughput 1753.63 samples/s\n",
+      "[Epoch 2] time cost 37.19s, valid loss 5.27, valid ppl 195.28\n",
+      "test loss 5.19, test ppl 179.94\n",
+      "Total training throughput 1453.99 samples/s\n"
      ]
     }
    ],
@@ -379,13 +379,13 @@
      "text": [
       "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
       "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "100 4982k  100 4982k    0     0  29.1M      0 --:--:-- --:--:-- --:--:-- 28.9M\n",
+      "100 4982k  100 4982k    0     0  24.0M      0 --:--:-- --:--:-- --:--:-- 23.9M\n",
       "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
       "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "100  390k  100  390k    0     0  5205k      0 --:--:-- --:--:-- --:--:-- 5205k\n",
+      "100  390k  100  390k    0     0  4539k      0 --:--:-- --:--:-- --:--:-- 4539k\n",
       "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
       "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "100  439k  100  439k    0     0  4724k      0 --:--:-- --:--:-- --:--:-- 4724k\n",
+      "100  439k  100  439k    0     0  4993k      0 --:--:-- --:--:-- --:--:-- 4993k\n",
       "['ptb.test.txt', 'ptb.train.txt', 'ptb.valid.txt']\n"
      ]
     }
@@ -409,7 +409,7 @@
     "                                        sample_splitter=nltk.tokenize.sent_tokenize,\n",
     "                                        tokenizer=moses_tokenizer, eos='<eos>')\n",
     "\n",
-    "ptb_val_data = ptb_val.bptt_batchify(vocab, bptt, batch_size, last_batch='keep')"
+    "ptb_val_data = ptb_val.bptt_batchify(vocab, bptt, batch_size, last_batch='discard')"
    ]
   },
   {
@@ -421,7 +421,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Best validation loss 6.49, test ppl 660.12\n"
+      "Best validation loss 6.48, test ppl 653.59\n"
      ]
     }
    ],
@@ -439,16 +439,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[Epoch 0] throughput 1183.07 samples/s\n",
-      "[Epoch 0] time cost 3.79s, valid loss 5.19, valid ppl 179.67\n",
-      "test loss 5.19, test ppl 179.67\n",
-      "[Epoch 1] throughput 1225.89 samples/s\n",
-      "[Epoch 1] time cost 3.71s, valid loss 5.30, valid ppl 200.73\n",
-      "Learning rate now 5.000000\n",
-      "[Epoch 2] throughput 1207.51 samples/s\n",
-      "[Epoch 2] time cost 3.75s, valid loss 4.70, valid ppl 110.38\n",
-      "test loss 4.70, test ppl 110.38\n",
-      "Total training throughput 456.48 samples/s\n"
+      "[Epoch 0] throughput 1734.68 samples/s\n",
+      "[Epoch 0] time cost 2.19s, valid loss 5.80, valid ppl 329.53\n",
+      "test loss 5.80, test ppl 329.53\n",
+      "[Epoch 1] throughput 1707.44 samples/s\n",
+      "[Epoch 1] time cost 2.21s, valid loss 5.75, valid ppl 313.96\n",
+      "test loss 5.75, test ppl 313.96\n",
+      "[Epoch 2] throughput 1715.08 samples/s\n",
+      "[Epoch 2] time cost 2.17s, valid loss 4.91, valid ppl 135.13\n",
+      "test loss 4.91, test ppl 135.13\n",
+      "Total training throughput 553.33 samples/s\n"
      ]
     }
    ],


### PR DESCRIPTION
This adapts the notebook to the changes required after https://github.com/dmlc/gluon-nlp/pull/120 was merged.

For some reason performance drops, however using `last_batch='keep'` and setting a padding token did not help either.