### PR TITLE
Revert "Don't treat language model datasets special"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ Load the Wikitext-2 dataset, for example:
 
     >>> import gluonnlp as nlp
     >>> train = nlp.data.WikiText2(segment='train')
-    >>> train[:5]
+    >>> train[0][0:5]
     ['=', 'Valkyria', 'Chronicles', 'III', '=']
 
 `Vocabulary Construction <http://gluon-nlp.mxnet.io/master/api/vocab.html>`__
@@ -102,7 +102,7 @@ Build vocabulary based on the above dataset, for example:
 
 .. code:: python
 
-    >>> vocab = nlp.Vocab(counter=nlp.data.Counter(train))
+    >>> vocab = nlp.Vocab(counter=nlp.data.Counter(train[0]))
     >>> vocab
     Vocab(size=33280, unk="<unk>", reserved="['<pad>', '<bos>', '<eos>']")
 

--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -104,6 +104,7 @@ load custom datasets.
 
     TextLineDataset
     CorpusDataset
+    LanguageModelDataset
 
 Transforms
 ----------

--- a/docs/examples/language_model/language_model.ipynb
+++ b/docs/examples/language_model/language_model.ipynb
@@ -107,10 +107,10 @@
     "                                                               skip_empty=False)\n",
     "                                            for segment in ['train', 'val', 'test']]\n",
     "\n",
-    "vocab = nlp.Vocab(nlp.data.Counter(train_dataset), padding_token=None, bos_token=None)\n",
+    "vocab = nlp.Vocab(nlp.data.Counter(train_dataset[0]), padding_token=None, bos_token=None)\n",
     "\n",
-    "bptt_batchify = nlp.data.batchify.LanguageModelBPTT(vocab, batch_size, bptt, last_batch='discard')\n",
-    "train_data, val_data, test_data = [bptt_batchify(x)\n",
+    "train_data, val_data, test_data = [x.bptt_batchify(vocab, bptt, batch_size,\n",
+    "                                                   last_batch='discard')\n",
     "                                   for x in [train_dataset, val_dataset, test_dataset]]"
    ]
   },
@@ -323,37 +323,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[Epoch 0 Batch 100/745] loss 8.03, ppl 3065.94, throughput 1715.26 samples/s\n",
-      "[Epoch 0 Batch 200/745] loss 7.25, ppl 1403.39, throughput 1772.06 samples/s\n",
-      "[Epoch 0 Batch 300/745] loss 6.94, ppl 1033.97, throughput 1785.40 samples/s\n",
-      "[Epoch 0 Batch 400/745] loss 6.67, ppl 787.56, throughput 1786.35 samples/s\n",
-      "[Epoch 0 Batch 500/745] loss 6.48, ppl 649.69, throughput 1786.77 samples/s\n",
-      "[Epoch 0 Batch 600/745] loss 6.31, ppl 550.47, throughput 1779.51 samples/s\n",
-      "[Epoch 0 Batch 700/745] loss 6.20, ppl 492.56, throughput 1776.04 samples/s\n",
-      "[Epoch 0] throughput 1774.25 samples/s\n",
-      "[Epoch 0] time cost 36.75s, valid loss 5.94, valid ppl 378.13\n",
+      "[Epoch 0 Batch 100/745] loss 8.03, ppl 3065.94, throughput 1697.82 samples/s\n",
+      "[Epoch 0 Batch 200/745] loss 7.25, ppl 1403.39, throughput 1734.12 samples/s\n",
+      "[Epoch 0 Batch 300/745] loss 6.94, ppl 1033.97, throughput 1746.13 samples/s\n",
+      "[Epoch 0 Batch 400/745] loss 6.67, ppl 787.56, throughput 1757.77 samples/s\n",
+      "[Epoch 0 Batch 500/745] loss 6.48, ppl 649.69, throughput 1751.55 samples/s\n",
+      "[Epoch 0 Batch 600/745] loss 6.31, ppl 550.47, throughput 1758.80 samples/s\n",
+      "[Epoch 0 Batch 700/745] loss 6.20, ppl 492.56, throughput 1757.13 samples/s\n",
+      "[Epoch 0] throughput 1744.91 samples/s\n",
+      "[Epoch 0] time cost 37.30s, valid loss 5.94, valid ppl 378.13\n",
       "test loss 5.86, test ppl 352.40\n",
-      "[Epoch 1 Batch 100/745] loss 6.08, ppl 439.13, throughput 1771.13 samples/s\n",
-      "[Epoch 1 Batch 200/745] loss 5.99, ppl 399.40, throughput 1791.90 samples/s\n",
-      "[Epoch 1 Batch 300/745] loss 5.93, ppl 377.05, throughput 1790.47 samples/s\n",
-      "[Epoch 1 Batch 400/745] loss 5.88, ppl 356.80, throughput 1791.31 samples/s\n",
-      "[Epoch 1 Batch 500/745] loss 5.77, ppl 320.72, throughput 1778.47 samples/s\n",
-      "[Epoch 1 Batch 600/745] loss 5.69, ppl 296.44, throughput 1789.30 samples/s\n",
-      "[Epoch 1 Batch 700/745] loss 5.62, ppl 276.54, throughput 1781.07 samples/s\n",
-      "[Epoch 1] throughput 1785.87 samples/s\n",
-      "[Epoch 1] time cost 36.54s, valid loss 5.55, valid ppl 255.98\n",
+      "[Epoch 1 Batch 100/745] loss 6.08, ppl 439.13, throughput 1725.42 samples/s\n",
+      "[Epoch 1 Batch 200/745] loss 5.99, ppl 399.40, throughput 1751.87 samples/s\n",
+      "[Epoch 1 Batch 300/745] loss 5.93, ppl 377.05, throughput 1743.20 samples/s\n",
+      "[Epoch 1 Batch 400/745] loss 5.88, ppl 356.80, throughput 1746.66 samples/s\n",
+      "[Epoch 1 Batch 500/745] loss 5.77, ppl 320.72, throughput 1752.17 samples/s\n",
+      "[Epoch 1 Batch 600/745] loss 5.69, ppl 296.44, throughput 1751.97 samples/s\n",
+      "[Epoch 1 Batch 700/745] loss 5.62, ppl 276.54, throughput 1752.15 samples/s\n",
+      "[Epoch 1] throughput 1747.56 samples/s\n",
+      "[Epoch 1] time cost 37.31s, valid loss 5.55, valid ppl 255.98\n",
       "test loss 5.46, test ppl 236.26\n",
-      "[Epoch 2 Batch 100/745] loss 5.62, ppl 274.64, throughput 1774.99 samples/s\n",
-      "[Epoch 2 Batch 200/745] loss 5.55, ppl 257.08, throughput 1783.87 samples/s\n",
-      "[Epoch 2 Batch 300/745] loss 5.52, ppl 248.41, throughput 1783.25 samples/s\n",
-      "[Epoch 2 Batch 400/745] loss 5.50, ppl 245.33, throughput 1787.02 samples/s\n",
-      "[Epoch 2 Batch 500/745] loss 5.41, ppl 223.72, throughput 1798.73 samples/s\n",
-      "[Epoch 2 Batch 600/745] loss 5.35, ppl 210.89, throughput 1785.37 samples/s\n",
-      "[Epoch 2 Batch 700/745] loss 5.32, ppl 204.93, throughput 1793.54 samples/s\n",
-      "[Epoch 2] throughput 1788.93 samples/s\n",
-      "[Epoch 2] time cost 36.48s, valid loss 5.27, valid ppl 195.28\n",
+      "[Epoch 2 Batch 100/745] loss 5.62, ppl 274.64, throughput 1740.72 samples/s\n",
+      "[Epoch 2 Batch 200/745] loss 5.55, ppl 257.08, throughput 1761.69 samples/s\n",
+      "[Epoch 2 Batch 300/745] loss 5.52, ppl 248.41, throughput 1744.27 samples/s\n",
+      "[Epoch 2 Batch 400/745] loss 5.50, ppl 245.33, throughput 1744.38 samples/s\n",
+      "[Epoch 2 Batch 500/745] loss 5.41, ppl 223.72, throughput 1762.50 samples/s\n",
+      "[Epoch 2 Batch 600/745] loss 5.35, ppl 210.89, throughput 1753.80 samples/s\n",
+      "[Epoch 2 Batch 700/745] loss 5.32, ppl 204.93, throughput 1747.81 samples/s\n",
+      "[Epoch 2] throughput 1753.63 samples/s\n",
+      "[Epoch 2] time cost 37.19s, valid loss 5.27, valid ppl 195.28\n",
       "test loss 5.19, test ppl 179.94\n",
-      "Total training throughput 1457.25 samples/s\n"
+      "Total training throughput 1453.99 samples/s\n"
      ]
     }
    ],
@@ -379,13 +379,13 @@
      "text": [
       "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
       "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "100 4982k  100 4982k    0     0  22.4M      0 --:--:-- --:--:-- --:--:-- 22.4M\n",
+      "100 4982k  100 4982k    0     0  24.0M      0 --:--:-- --:--:-- --:--:-- 23.9M\n",
       "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
       "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "100  390k  100  390k    0     0  4337k      0 --:--:-- --:--:-- --:--:-- 4386k\n",
+      "100  390k  100  390k    0     0  4539k      0 --:--:-- --:--:-- --:--:-- 4539k\n",
       "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
       "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "100  439k  100  439k    0     0  4529k      0 --:--:-- --:--:-- --:--:-- 4529k\n",
+      "100  439k  100  439k    0     0  4993k      0 --:--:-- --:--:-- --:--:-- 4993k\n",
       "['ptb.test.txt', 'ptb.train.txt', 'ptb.valid.txt']\n"
      ]
     }
@@ -400,33 +400,16 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[nltk_data] Downloading package perluniprops to\n",
-      "[nltk_data]     /home/ubuntu/nltk_data...\n",
-      "[nltk_data]   Package perluniprops is already up-to-date!\n",
-      "[nltk_data] Downloading package nonbreaking_prefixes to\n",
-      "[nltk_data]     /home/ubuntu/nltk_data...\n",
-      "[nltk_data]   Package nonbreaking_prefixes is already up-to-date!\n",
-      "[nltk_data] Downloading package punkt to /home/ubuntu/nltk_data...\n",
-      "[nltk_data]   Package punkt is already up-to-date!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import nltk\n",
-    "nltk.download(['perluniprops', 'nonbreaking_prefixes', 'punkt'])\n",
     "moses_tokenizer = nlp.data.NLTKMosesTokenizer()\n",
     "\n",
-    "ptb_val = nlp.data.CorpusDataset('ptb.valid.txt',\n",
-    "                                    flatten=True,\n",
-    "                                    sample_splitter=nltk.tokenize.sent_tokenize,\n",
-    "                                    tokenizer=moses_tokenizer, eos='<eos>')\n",
+    "ptb_val = nlp.data.LanguageModelDataset('ptb.valid.txt',\n",
+    "                                        sample_splitter=nltk.tokenize.sent_tokenize,\n",
+    "                                        tokenizer=moses_tokenizer, eos='<eos>')\n",
     "\n",
-    "ptb_val_data = nlp.data.batchify.LanguageModelBPTT(vocab, batch_size, bptt, last_batch='discard')(ptb_val)"
+    "ptb_val_data = ptb_val.bptt_batchify(vocab, bptt, batch_size, last_batch='discard')"
    ]
   },
   {
@@ -456,16 +439,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[Epoch 0] throughput 1409.67 samples/s\n",
-      "[Epoch 0] time cost 2.49s, valid loss 5.80, valid ppl 329.53\n",
+      "[Epoch 0] throughput 1734.68 samples/s\n",
+      "[Epoch 0] time cost 2.19s, valid loss 5.80, valid ppl 329.53\n",
       "test loss 5.80, test ppl 329.53\n",
-      "[Epoch 1] throughput 1764.51 samples/s\n",
-      "[Epoch 1] time cost 2.13s, valid loss 5.75, valid ppl 313.96\n",
+      "[Epoch 1] throughput 1707.44 samples/s\n",
+      "[Epoch 1] time cost 2.21s, valid loss 5.75, valid ppl 313.96\n",
       "test loss 5.75, test ppl 313.96\n",
-      "[Epoch 2] throughput 1763.15 samples/s\n",
-      "[Epoch 2] time cost 2.13s, valid loss 4.91, valid ppl 135.13\n",
+      "[Epoch 2] throughput 1715.08 samples/s\n",
+      "[Epoch 2] time cost 2.17s, valid loss 4.91, valid ppl 135.13\n",
       "test loss 4.91, test ppl 135.13\n",
-      "Total training throughput 608.55 samples/s\n"
+      "Total training throughput 553.33 samples/s\n"
      ]
     }
    ],

--- a/gluonnlp/__init__.py
+++ b/gluonnlp/__init__.py
@@ -25,7 +25,7 @@ from . import embedding
 from . import model
 from .vocab import *
 
-__version__ = '0.3.dev'
+__version__ = '0.2.1'
 
 __all__ = ['data',
            'model',

--- a/gluonnlp/data/__init__.py
+++ b/gluonnlp/data/__init__.py
@@ -30,7 +30,7 @@ from .sampler import *
 
 from .dataset import *
 
-from .wikitext import *
+from .language_model import *
 
 from .sentiment import *
 
@@ -43,6 +43,6 @@ from .translation import *
 from . import batchify
 
 __all__ = (utils.__all__ + transforms.__all__ + sampler.__all__ +
-           dataset.__all__ + wikitext.__all__ + sentiment.__all__ +
+           dataset.__all__ + language_model.__all__ + sentiment.__all__ +
            word_embedding_evaluation.__all__ + conll.__all__ +
            translation.__all__ + registry.__all__)

--- a/gluonnlp/data/language_model.py
+++ b/gluonnlp/data/language_model.py
@@ -29,12 +29,12 @@ import shutil
 from mxnet.gluon.utils import download, check_sha1, _get_repo_file_url
 
 from .. import _constants as C
-from .dataset import CorpusDataset
+from .dataset import LanguageModelDataset
 from .registry import register
 from .utils import _get_home_dir
 
 
-class _WikiText(CorpusDataset):
+class _WikiText(LanguageModelDataset):
     def __init__(self, namespace, segment, bos, eos, skip_empty, root,
                  **kwargs):
         root = os.path.expanduser(root)
@@ -52,9 +52,9 @@ class _WikiText(CorpusDataset):
         root = self._root
         path = os.path.join(root, data_file_name)
         if not os.path.exists(path) or not check_sha1(path, data_hash):
-            downloaded_file_path = download(
-                _get_repo_file_url(self._namespace, archive_file_name),
-                path=root, sha1_hash=archive_hash)
+            downloaded_file_path = download(_get_repo_file_url(self._namespace, archive_file_name),
+                                            path=root,
+                                            sha1_hash=archive_hash)
 
             with zipfile.ZipFile(downloaded_file_path, 'r') as zf:
                 for member in zf.namelist():
@@ -80,14 +80,9 @@ class WikiText2(_WikiText):
     ----------
     segment : {'train', 'val', 'test'}, default 'train'
         Dataset segment.
-    flatten : bool, default True
-        Whether to return all samples as flattened tokens. If True, each sample
-        is a token. Useful for language models.
     skip_empty : bool, default True
         Whether to skip the empty samples produced from sample_splitters. If False, `bos` and `eos`
         will be added in empty samples.
-    sample_splitter : function, default str.splitlines
-        A function that splits the dataset string into samples.
     tokenizer : function, default str.split
         A function that splits each sample string into list of tokens.
     bos : str or None, default None
@@ -99,25 +94,20 @@ class WikiText2(_WikiText):
         MXNET_HOME defaults to '~/.mxnet'.
     """
 
-    def __init__(self, segment='train', flatten=True, skip_empty=True,
-                 sample_splitter=lambda s: s.splitlines(),
+    def __init__(self, segment='train', skip_empty=True,
                  tokenizer=lambda s: s.split(),
                  bos=None, eos=C.EOS_TOKEN, root=os.path.join(
                      _get_home_dir(), 'datasets', 'wikitext-2'), **kwargs):
-        self._archive_file = ('wikitext-2-v1.zip',
-                              '3c914d17d80b1459be871a5039ac23e752a53cbe')
-        self._data_file = {
-            'train': ('wiki.train.tokens',
-                      '863f29c46ef9d167fff4940ec821195882fe29d1'),
-            'val': ('wiki.valid.tokens',
-                    '0418625c8b4da6e4b5c7a0b9e78d4ae8f7ee5422'),
-            'test': ('wiki.test.tokens',
-                     'c7b8ce0aa086fb34dab808c5c49224211eb2b172')
-        }
-        super(WikiText2, self).__init__(
-            'wikitext-2', segment=segment, flatten=flatten,
-            skip_empty=skip_empty, sample_splitter=sample_splitter, root=root,
-            tokenizer=tokenizer, bos=bos, eos=eos, **kwargs)
+        self._archive_file = ('wikitext-2-v1.zip', '3c914d17d80b1459be871a5039ac23e752a53cbe')
+        self._data_file = {'train': ('wiki.train.tokens',
+                                     '863f29c46ef9d167fff4940ec821195882fe29d1'),
+                           'val': ('wiki.valid.tokens',
+                                   '0418625c8b4da6e4b5c7a0b9e78d4ae8f7ee5422'),
+                           'test': ('wiki.test.tokens',
+                                    'c7b8ce0aa086fb34dab808c5c49224211eb2b172')}
+        super(WikiText2,
+              self).__init__('wikitext-2', segment, bos, eos, skip_empty, root,
+                             tokenizer=tokenizer, **kwargs)
 
 
 @register(segment=['train', 'val', 'test'])
@@ -133,14 +123,9 @@ class WikiText103(_WikiText):
     ----------
     segment : {'train', 'val', 'test'}, default 'train'
         Dataset segment.
-    flatten : bool, default True
-        Whether to return all samples as flattened tokens. If True, each sample
-        is a token. Useful for language models.
     skip_empty : bool, default True
         Whether to skip the empty samples produced from sample_splitters. If False, `bos` and `eos`
         will be added in empty samples.
-    sample_splitter : function, default str.splitlines
-        A function that splits the dataset string into samples.
     tokenizer : function, default str.split
         A function that splits each sample string into list of tokens.
     bos : str or None, default None
@@ -152,8 +137,7 @@ class WikiText103(_WikiText):
         MXNET_HOME defaults to '~/.mxnet'.
     """
 
-    def __init__(self, segment='train', flatten=True, skip_empty=True,
-                 sample_splitter=lambda s: s.splitlines(),
+    def __init__(self, segment='train', skip_empty=True,
                  tokenizer=lambda s: s.split(),
                  bos=None, eos=C.EOS_TOKEN, root=os.path.join(
                      _get_home_dir(), 'datasets', 'wikitext-103'), **kwargs):
@@ -167,10 +151,9 @@ class WikiText103(_WikiText):
             'test': ('wiki.test.tokens',
                      '8a5befc548865cec54ed4273cf87dbbad60d1e47')
         }
-        super(WikiText103, self).__init__(
-            'wikitext-103', segment=segment, flatten=flatten,
-            skip_empty=skip_empty, sample_splitter=sample_splitter, root=root,
-            tokenizer=tokenizer, bos=bos, eos=eos, **kwargs)
+        super(WikiText103,
+              self).__init__('wikitext-103', segment, bos, eos, skip_empty,
+                             root, tokenizer=tokenizer, **kwargs)
 
 
 @register(segment=['train', 'val', 'test'])
@@ -186,32 +169,26 @@ class WikiText2Raw(_WikiText):
     ----------
     segment : {'train', 'val', 'test'}, default 'train'
         Dataset segment.
-    flatten : bool, default True
-        Whether to return all samples as flattened tokens. If True, each sample
-        is a token. Useful for language models.
     skip_empty : bool, default True
         Whether to skip the empty samples produced from sample_splitters. If False, `bos` and `eos`
         will be added in empty samples.
-    sample_splitter : function, default str.splitlines
-        A function that splits the dataset string into samples.
-    tokenizer : function, default list
+    tokenizer : function, default s.encode('utf-8')
         A function that splits each sample string into list of tokens.
         The tokenizer can also be used to convert everything to lowercase.
-        E.g. with tokenizer=lambda s: list(s.lower().encode('utf-8'))
+        E.g. with tokenizer=lambda s: s.lower().encode('utf-8')
     bos : str or None, default None
         The token to add at the begining of each sentence. If None, nothing is added.
-    eos : str or None, default None
+    eos : str or None, default '<eos>'
         The token to add at the end of each sentence. If None, nothing is added.
     root : str, default '$MXNET_HOME/datasets/wikitext-2'
         Path to temp folder for storing data.
         MXNET_HOME defaults to '~/.mxnet'.
     """
 
-    def __init__(self, segment='train', flatten=True, skip_empty=True,
-                 sample_splitter=lambda s: s.splitlines(),
-                 tokenizer=lambda s: list(s.encode('utf-8')), bos=None,
-                 eos=None, root=os.path.join(_get_home_dir(), 'datasets',
-                                             'wikitext-2'), **kwargs):
+    def __init__(self, segment='train', skip_empty=True, bos=None, eos=None,
+                 tokenizer=lambda s: s.encode('utf-8'),
+                 root=os.path.join(_get_home_dir(), 'datasets',
+                                   'wikitext-2'), **kwargs):
         self._archive_file = ('wikitext-2-raw-v1.zip',
                               '3b6993c138fc61c95f7fffd900fef68f8411371d')
         self._data_file = {
@@ -223,10 +200,9 @@ class WikiText2Raw(_WikiText):
                      '6f1fe2054a940eebfc76b284b09680763b37f5ea')
         }
 
-        super(WikiText2Raw, self).__init__(
-            'wikitext-2', segment=segment, flatten=flatten,
-            skip_empty=skip_empty, sample_splitter=sample_splitter, root=root,
-            tokenizer=tokenizer, bos=bos, eos=eos, **kwargs)
+        super(WikiText2Raw,
+              self).__init__('wikitext-2', segment, bos, eos, skip_empty, root,
+                             tokenizer=tokenizer, **kwargs)
 
 
 @register(segment=['train', 'val', 'test'])
@@ -242,30 +218,24 @@ class WikiText103Raw(_WikiText):
     ----------
     segment : {'train', 'val', 'test'}, default 'train'
         Dataset segment.
-    flatten : bool, default True
-        Whether to return all samples as flattened tokens. If True, each sample
-        is a token. Useful for language models.
     skip_empty : bool, default True
         Whether to skip the empty samples produced from sample_splitters. If False, `bos` and `eos`
         will be added in empty samples.
-    sample_splitter : function, default str.splitlines
-        A function that splits the dataset string into samples.
-    tokenizer : function, default list
+    tokenizer : function, default s.encode('utf-8')
         A function that splits each sample string into list of tokens.
         The tokenizer can also be used to convert everything to lowercase.
-        E.g. with tokenizer=lambda s: list(s.lower().encode('utf-8'))
+        E.g. with tokenizer=lambda s: s.lower().encode('utf-8')
     bos : str or None, default None
         The token to add at the begining of each sentence. If None, nothing is added.
-    eos : str or None, default None
+    eos : str or None, default '<eos>'
         The token to add at the end of each sentence. If None, nothing is added.
     root : str, default '$MXNET_HOME/datasets/wikitext-103'
         Path to temp folder for storing data.
         MXNET_HOME defaults to '~/.mxnet'.
     """
 
-    def __init__(self, segment='train', flatten=True, skip_empty=True,
-                 sample_splitter=lambda s: s.splitlines(),
-                 tokenizer=lambda s: list(s.encode('utf-8')), bos=None,
+    def __init__(self, segment='train', skip_empty=True,
+                 tokenizer=lambda s: s.encode('utf-8'), bos=None,
                  eos=None, root=os.path.join(_get_home_dir(), 'datasets',
                                              'wikitext-103'), **kwargs):
         self._archive_file = ('wikitext-103-raw-v1.zip',
@@ -278,7 +248,6 @@ class WikiText103Raw(_WikiText):
             'test': ('wiki.test.raw',
                      '6f1fe2054a940eebfc76b284b09680763b37f5ea')
         }
-        super(WikiText103Raw, self).__init__(
-            'wikitext-103', segment=segment, flatten=flatten,
-            skip_empty=skip_empty, sample_splitter=sample_splitter, root=root,
-            tokenizer=tokenizer, bos=bos, eos=eos, **kwargs)
+        super(WikiText103Raw,
+              self).__init__('wikitext-103', segment, bos, eos, skip_empty,
+                             root, tokenizer=tokenizer, **kwargs)

--- a/scripts/language_model/word_language_model.py
+++ b/scripts/language_model/word_language_model.py
@@ -128,16 +128,13 @@ train_dataset, val_dataset, test_dataset = \
                         skip_empty=False, bos=None, eos='<eos>')
      for segment in ['train', 'val', 'test']]
 
-vocab = nlp.Vocab(counter=nlp.data.Counter(train_dataset), padding_token=None, bos_token=None)
+vocab = nlp.Vocab(counter=nlp.data.Counter(train_dataset[0]), padding_token=None, bos_token=None)
 
-batchify = nlp.data.batchify.LanguageModel(vocab, args.batch_size)
-train_data = batchify(train_dataset)
+train_data = train_dataset.batchify(vocab, args.batch_size)
 val_batch_size = 10
-val_batchify = nlp.data.batchify.LanguageModel(vocab, val_batch_size)
-val_data = val_batchify(val_dataset)
+val_data = val_dataset.batchify(vocab, val_batch_size)
 test_batch_size = 1
-test_batchify = nlp.data.batchify.LanguageModel(vocab, test_batch_size)
-test_data = test_batchify(test_dataset)
+test_data = test_dataset.batchify(vocab, test_batch_size)
 
 if args.test_mode:
     args.emsize = 200

--- a/tests/unittest/test_datasets.py
+++ b/tests/unittest/test_datasets.py
@@ -89,12 +89,12 @@ def test_wikitext2():
         segment='val', root=os.path.join('tests', 'data', 'wikitext-2'))
     test = nlp.data.WikiText2(
         segment='test', root=os.path.join('tests', 'data', 'wikitext-2'))
-    train_freq, val_freq, test_freq = [nlp.data.utils.Counter(x) for x in [train, val, test]]
-    assert len(train) == 2075677, len(train)
+    train_freq, val_freq, test_freq = [nlp.data.utils.Counter(x) for x in [train[0], val[0], test[0]]]
+    assert len(train[0]) == 2075677, len(train[0])
     assert len(train_freq) == 33278, len(train_freq)
-    assert len(val) == 216347, len(val)
+    assert len(val[0]) == 216347, len(val[0])
     assert len(val_freq) == 13777, len(val_freq)
-    assert len(test) == 244102, len(test)
+    assert len(test[0]) == 244102, len(test[0])
     assert len(test_freq) == 14143, len(test_freq)
     assert test_freq['English'] == 32, test_freq['English']
 
@@ -103,25 +103,21 @@ def test_wikitext2():
     assert len(serialized_vocab) == 962190, len(serialized_vocab)
     assert json.loads(serialized_vocab)['idx_to_token'] == vocab._idx_to_token
 
-    bptt_batchify = nlp.data.batchify.LanguageModelBPTT(
-        vocab, seq_len=35, batch_size=80, last_batch='discard')
-    train_data = bptt_batchify(train)
+    train_data = train.bptt_batchify(vocab, 35, 80, last_batch='discard')
     assert len(train_data) == 741, len(train_data)
 
     for i, (data, target) in enumerate(train_data):
         mx.test_utils.assert_almost_equal(data[1:].asnumpy(), target[:-1].asnumpy())
         assert data.shape == target.shape == (35, 80)
 
-    bptt_batchify = nlp.data.batchify.LanguageModelBPTT(
-        vocab, seq_len=35, batch_size=80, last_batch='keep')
-    train_data = bptt_batchify(train)
+    train_data = train.bptt_batchify(vocab, 35, 80, last_batch='keep')
     assert len(train_data) == 742, len(train_data)
     assert train_data[-1][0].shape[0] < 35
     for i, (data, target) in enumerate(train_data):
         mx.test_utils.assert_almost_equal(data[1:].asnumpy(), target[:-1].asnumpy())
         assert data.shape == target.shape
 
-    train_freq, val_freq, test_freq = [nlp.data.utils.Counter(x) for x in [train, val, test]]
+    train_freq, val_freq, test_freq = [nlp.data.utils.Counter(x) for x in [train[0], val[0], test[0]]]
     train = nlp.data.WikiText2(
         segment='train',
         skip_empty=False,
@@ -134,15 +130,14 @@ def test_wikitext2():
         segment='test',
         skip_empty=False,
         root=os.path.join('tests', 'data', 'wikitext-2'))
-    assert len(train) == 2088628, len(train)
+    assert len(train[0]) == 2088628, len(train[0])
     assert len(train_freq) == 33278, len(train_freq)
-    assert len(val) == 217646, len(val)
+    assert len(val[0]) == 217646, len(val[0])
     assert len(val_freq) == 13777, len(val_freq)
-    assert len(test) == 245569, len(test)
+    assert len(test[0]) == 245569, len(test[0])
     assert len(test_freq) == 14143, len(test_freq)
     assert test_freq['English'] == 32, test_freq['English']
-    batchify = nlp.data.batchify.LanguageModel(vocab, 80)
-    batched_data = batchify(train)
+    batched_data = train.batchify(vocab, 80)
     assert batched_data.shape == (26107, 80)
 
 
@@ -154,13 +149,13 @@ def test_wikitext2_raw():
     test = nlp.data.WikiText2Raw(segment='test', root=os.path.join(
         'tests', 'data', 'wikitext-2'))
     train_freq, val_freq, test_freq = [
-        nlp.data.utils.Counter(x) for x in [train, val, test]
+        nlp.data.utils.Counter(x) for x in [train[0], val[0], test[0]]
     ]
-    assert len(train) == 10843541, len(train)
+    assert len(train[0]) == 10843541, len(train[0])
     assert len(train_freq) == 192, len(train_freq)
-    assert len(val) == 1136862, len(val)
+    assert len(val[0]) == 1136862, len(val[0])
     assert len(val_freq) == 168, len(val_freq)
-    assert len(test) == 1278983, len(test)
+    assert len(test[0]) == 1278983, len(test[0])
     assert len(test_freq) == 177, len(test_freq)
     assert test_freq['a'.encode('utf-8')[0]] == 81512, \
         test_freq['a'.encode('utf-8')[0]]
@@ -174,13 +169,13 @@ def test_wikitext103_raw():
     test = nlp.data.WikiText103Raw(segment='test', root=os.path.join(
         'tests', 'data', 'wikitext-103'))
     train_freq, val_freq, test_freq = [
-        nlp.data.utils.Counter(x) for x in [train, val, test]
+        nlp.data.utils.Counter(x) for x in [train[0], val[0], test[0]]
     ]
-    assert len(train) == 535800393, len(train)
+    assert len(train[0]) == 535800393, len(train[0])
     assert len(train_freq) == 203, len(train_freq)
-    assert len(val) == 1136862, len(val)
+    assert len(val[0]) == 1136862, len(val[0])
     assert len(val_freq) == 168, len(val_freq)
-    assert len(test) == 1278983, len(test)
+    assert len(test[0]) == 1278983, len(test[0])
     assert len(test_freq) == 177, len(test_freq)
     assert test_freq['a'.encode('utf-8')[0]] == 81512, \
         test_freq['a'.encode('utf-8')[0]]

--- a/tests/unittest/test_models.py
+++ b/tests/unittest/test_models.py
@@ -30,9 +30,12 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 
+def get_frequencies(dataset):
+    return nlp.data.utils.Counter(x for tup in dataset for x in tup[0]+tup[1][-1:])
+
 def test_text_models():
     val = nlp.data.WikiText2(segment='val', root='tests/data/wikitext-2')
-    val_freq = nlp.data.utils.Counter(val)
+    val_freq = get_frequencies(val)
     vocab = nlp.Vocab(val_freq)
     text_models = ['standard_lstm_lm_200', 'standard_lstm_lm_650', 'standard_lstm_lm_1500', 'awd_lstm_lm_1150', 'awd_lstm_lm_600']
     pretrained_to_test = {'standard_lstm_lm_1500': 'wikitext-2', 'standard_lstm_lm_650': 'wikitext-2', 'standard_lstm_lm_200': 'wikitext-2', 'awd_lstm_lm_1150': 'wikitext-2', 'awd_lstm_lm_600': 'wikitext-2'}


### PR DESCRIPTION
Reverts dmlc/gluon-nlp#128

There is no consensus that usage of WikiText for non-LM purpose should be supported at the cost of making the LM API more complicated (by eg. making the `bptt_batchify` and `batchify` functions standalone).