### PR TITLE
Workaround mxnet nd.topk regression

### DIFF
--- a/docs/examples/word_embedding/word_embedding.ipynb
+++ b/docs/examples/word_embedding/word_embedding.ipynb
@@ -653,16 +653,16 @@
    "outputs": [],
    "source": [
     "def norm_vecs_by_row(x):\n",
-    "    return x / nd.sqrt(nd.sum(x * x, axis=1)).reshape((-1,1))\n",
+    "    return x / nd.sqrt(nd.sum(x * x, axis=1) + 1E-10).reshape((-1,1))\n",
     "\n",
     "def get_knn(vocab, k, word):\n",
     "    word_vec = vocab.embedding[word].reshape((-1, 1))\n",
     "    vocab_vecs = norm_vecs_by_row(vocab.embedding.idx_to_vec)\n",
     "    dot_prod = nd.dot(vocab_vecs, word_vec)\n",
-    "    indices = nd.topk(dot_prod.reshape((len(vocab), )), k=k+5, ret_typ='indices')\n",
+    "    indices = nd.topk(dot_prod.reshape((len(vocab), )), k=k+1, ret_typ='indices')\n",
     "    indices = [int(i.asscalar()) for i in indices]\n",
     "    # Remove unknown and input tokens.\n",
-    "    return vocab.to_tokens(indices[5:])"
+    "    return vocab.to_tokens(indices[1:])"
    ]
   },
   {

--- a/docs/examples/word_embedding/word_embedding.ipynb
+++ b/docs/examples/word_embedding/word_embedding.ipynb
@@ -854,14 +854,9 @@
     "    word_diff = (word_vecs[1] - word_vecs[0] + word_vecs[2]).reshape((-1, 1))\n",
     "    vocab_vecs = norm_vecs_by_row(vocab.embedding.idx_to_vec)\n",
     "    dot_prod = nd.dot(vocab_vecs, word_diff)\n",
-    "    indices = nd.topk(dot_prod.reshape((len(vocab), )), k=k+4, ret_typ='indices')\n",
+    "    indices = nd.topk(dot_prod.reshape((len(vocab), )), k=k, ret_typ='indices')\n",
     "    indices = [int(i.asscalar()) for i in indices]\n",
-    "\n",
-    "    # Filter out unknown tokens.\n",
-    "    if vocab.to_tokens(indices[0]) == vocab.unknown_token:\n",
-    "        return vocab.to_tokens(indices[4:])\n",
-    "    else:\n",
-    "        return vocab.to_tokens(indices[:-4])"
+    "    return vocab.to_tokens(indices)"
    ]
   },
   {


### PR DESCRIPTION
https://github.com/apache/incubator-mxnet/issues/11271

## Description ##
The behavior of nd.topk under the presence of `nan` values changed, causing wrong results in the pretrained word embeddings notebook due to `def norm_vecs_by_row(x)` inducing `nan` values for `0` word vectors. This PR adds a small epsilon to `def norm_vecs_by_row(x)` so that `nan` values are avoided.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix embedding.ipynb for mxnet v1.3 
