### PR TITLE
Small bug fix + doc fix

### DIFF
--- a/gluonnlp/data/batchify.py
+++ b/gluonnlp/data/batchify.py
@@ -140,21 +140,17 @@ class Pad(object):
     Input of the function will be N samples. Each sample should contain a single element that
     can be 1) numpy.ndarray, 2) mxnet.nd.NDArray, 3) list of numbers
 
-    You need to set the `index` parameter to determine which part of the sample requires
-    padding. Also, you can set the `pad_axis` and `pad_val` to determine the padding axis and
-    value.
-
-    The arrays will be padded to the largest dimension at `pad_axis` and then
+    The arrays will be padded to the largest dimension at `axis` and then
     stacked to form the final output. In addition, the function will output the original dimensions
-    at the `pad_axis` if ret_length is turned on.
+    at the `axis` if ret_length is turned on.
 
     Parameters
     ----------
     axis : int, default 0
         The axis to pad the arrays. The arrays will be padded to the largest dimension at
-        pad_axis. For example, assume the input arrays have shape
-        (10, 8, 5), (6, 8, 5), (3, 8, 5) and the pad_axis is 0. Each input will be padded into
-        (10, 8, 5) and then stacked to form the final output.
+        `axis`. For example, assume the input arrays have shape
+        (10, 8, 5), (6, 8, 5), (3, 8, 5) and the `axis` is 0. Each input will be padded into
+        (10, 8, 5) and then stacked to form the final output, which has shape（3, 10, 8, 5).
     pad_val : float or int, default 0
         The padding value.
     ret_length : bool, default False
@@ -242,13 +238,13 @@ class Pad(object):
 
 
 class Tuple(object):
-    """Wrap multiple batchify functions to form a function apply each input function on each
-    input fields respectively.
+    """Wrap multiple batchify functions together. The input functions will be applied to the corresponding
+    input fields.
 
     Each data sample should be a list or tuple containing multiple attributes. The `i`th batchify
     function stored in `Tuple` will be applied on the `i`th attribute. For example, each
     data sample is (nd_data, label). You can wrap two batchify functions using
-    `Warp(DataBatchify, LabelBatchify)` to batchify nd_data and label correspondingly.
+    `Tuple(DataBatchify, LabelBatchify)` to batchify nd_data and label correspondingly.
 
     Parameters
     ----------

--- a/gluonnlp/data/batchify.py
+++ b/gluonnlp/data/batchify.py
@@ -238,8 +238,8 @@ class Pad(object):
 
 
 class Tuple(object):
-    """Wrap multiple batchify functions together. The input functions will be applied to the corresponding
-    input fields.
+    """Wrap multiple batchify functions together. The input functions will be applied
+    to the corresponding input fields.
 
     Each data sample should be a list or tuple containing multiple attributes. The `i`th batchify
     function stored in `Tuple` will be applied on the `i`th attribute. For example, each

--- a/scripts/nmt/train_gnmt.py
+++ b/scripts/nmt/train_gnmt.py
@@ -219,11 +219,11 @@ data_train_lengths = get_data_lengths(data_train)
 data_val_lengths = get_data_lengths(data_val)
 data_test_lengths = get_data_lengths(data_test)
 
-with io.open(os.path.join(args.save_dir, 'val_gt.txt'), 'w') as of:
+with io.open(os.path.join(args.save_dir, 'val_gt.txt'), 'w', encoding='utf-8') as of:
     for ele in val_tgt_sentences:
         of.write(' '.join(ele) + '\n')
 
-with io.open(os.path.join(args.save_dir, 'test_gt.txt'), 'w') as of:
+with io.open(os.path.join(args.save_dir, 'test_gt.txt'), 'w', encoding='utf-8') as of:
     for ele in test_tgt_sentences:
         of.write(' '.join(ele) + '\n')
 

--- a/scripts/nmt/train_transformer.py
+++ b/scripts/nmt/train_transformer.py
@@ -259,11 +259,11 @@ data_train_lengths = get_data_lengths(data_train)
 data_val_lengths = get_data_lengths(data_val)
 data_test_lengths = get_data_lengths(data_test)
 
-with io.open(os.path.join(args.save_dir, 'val_gt.txt'), 'w') as of:
+with io.open(os.path.join(args.save_dir, 'val_gt.txt'), 'w', encoding='utf-8') as of:
     for ele in val_tgt_sentences:
         of.write(' '.join(ele) + '\n')
 
-with io.open(os.path.join(args.save_dir, 'test_gt.txt'), 'w') as of:
+with io.open(os.path.join(args.save_dir, 'test_gt.txt'), 'w', encoding='utf-8') as of:
     for ele in test_tgt_sentences:
         of.write(' '.join(ele) + '\n')
 


### PR DESCRIPTION
## Description ##
Set the encoding to be UTF-8 in the NMT examples + Fix the docstring of batchify

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Batchify doc fix
- [ ] Set encoding to UTF-8 in NMT examples.

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
