### PR TITLE
fix bug in utils.py

### DIFF
--- a/scripts/word_embeddings/utils.py
+++ b/scripts/word_embeddings/utils.py
@@ -40,6 +40,8 @@ except ImportError:
 def get_context(args):
     if args.gpu is None or args.gpu == '':
         context = [mx.cpu()]
+    elif isinstance(args.gpu, int):
+        context = [mx.gpu(args.gpu)]
     else:
         context = [mx.gpu(int(i)) for i in args.gpu]
     return context


### PR DESCRIPTION
## Description ##

When running `run_all.sh` got a bug:

```
    context = [mx.gpu(int(i)) for i in args.gpu]
TypeError: 'int' object is not iterable
```

Could be worth adding `run_all.sh` to the CI. Also, could `results-vocablimit.csv` be added to the repository?