### PR TITLE
Add sacremoses

### DIFF
--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -149,9 +149,11 @@ with `Dataset.transform` method.
 
     ClipSequence
     PadSequence
+    NLTKMosesTokenizer
     SacreMosesTokenizer
     SpacyTokenizer
     SacreMosesDetokenizer
+    NLTKMosesDetokenizer
 
 Samplers
 --------

--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -149,9 +149,9 @@ with `Dataset.transform` method.
 
     ClipSequence
     PadSequence
-    NLTKMosesTokenizer
+    SacreMosesTokenizer
     SpacyTokenizer
-    NLTKMosesDetokenizer
+    SacreMosesDetokenizer
 
 Samplers
 --------

--- a/docs/examples/language_model/language_model.ipynb
+++ b/docs/examples/language_model/language_model.ipynb
@@ -447,7 +447,7 @@
    "outputs": [],
    "source": [
     "import nltk\n",
-    "moses_tokenizer = nlp.data.NLTKMosesTokenizer()\n",
+    "moses_tokenizer = nlp.data.SacreMosesTokenizer()\n",
     "\n",
     "sherlockholmes_val = nlp.data.LanguageModelDataset('sherlockholmes.valid.txt',\n",
     "                                        sample_splitter=nltk.tokenize.sent_tokenize,\n",

--- a/env/doc.yml
+++ b/env/doc.yml
@@ -16,3 +16,4 @@ dependencies:
   - pip:
     - mxnet-cu80>=1.3.0b20180725
     - notedown
+    - sacremoses

--- a/env/py2.yml
+++ b/env/py2.yml
@@ -12,4 +12,3 @@ dependencies:
   - pytest-cov
   - pip:
     - mxnet-cu80>=1.3.0b20180725
-

--- a/env/py2.yml
+++ b/env/py2.yml
@@ -7,9 +7,9 @@ dependencies:
   - sphinx=1.7.5
   - spacy
   - nltk
-  - sacremoses
   - pytest
   - flaky
   - pytest-cov
   - pip:
     - mxnet-cu80>=1.3.0b20180725
+    - sacremoses

--- a/env/py2.yml
+++ b/env/py2.yml
@@ -12,4 +12,4 @@ dependencies:
   - pytest-cov
   - pip:
     - mxnet-cu80>=1.3.0b20180725
-    - sacremoses
+

--- a/env/py2.yml
+++ b/env/py2.yml
@@ -7,6 +7,7 @@ dependencies:
   - sphinx=1.7.5
   - spacy
   - nltk
+  - sacremoses
   - pytest
   - flaky
   - pytest-cov

--- a/env/py3.yml
+++ b/env/py3.yml
@@ -7,9 +7,9 @@ dependencies:
   - sphinx=1.7.5
   - spacy
   - nltk
-  - sacremoses
   - pytest
   - flaky
   - pytest-cov
   - pip:
     - mxnet-cu80>=1.3.0b20180725
+    - sacremoses

--- a/env/py3.yml
+++ b/env/py3.yml
@@ -7,6 +7,7 @@ dependencies:
   - sphinx=1.7.5
   - spacy
   - nltk
+  - sacremoses
   - pytest
   - flaky
   - pytest-cov

--- a/gluonnlp/data/transforms.py
+++ b/gluonnlp/data/transforms.py
@@ -23,8 +23,8 @@ clipping, padding, and tokenization."""
 from __future__ import absolute_import
 from __future__ import print_function
 
-__all__ = ['ClipSequence', 'PadSequence', 'NLTKMosesTokenizer', 'SpacyTokenizer',
-           'NLTKMosesDetokenizer', 'JiebaTokenizer', 'NLTKStanfordSegmenter']
+__all__ = ['ClipSequence', 'PadSequence', 'SacreMosesTokenizer', 'SpacyTokenizer',
+           'SacreMosesDetokenizer', 'JiebaTokenizer', 'NLTKStanfordSegmenter']
 
 import os
 
@@ -134,19 +134,19 @@ class PadSequence(object):
                                           'mxnet.NDArray, received type=%s' % str(type(sample)))
 
 
-class NLTKMosesTokenizer(object):
-    r"""Apply the Moses Tokenizer implemented in NLTK.
+class SacreMosesTokenizer(object):
+    r"""Apply the Moses Tokenizer implemented in sacremoses.
 
-    Users of this class are required to `install NLTK <https://www.nltk.org/install.html>`_
-    and install relevant NLTK packages, such as:
+    Users of this class are required to `install sacremoses <https://github.com/alvations/sacremoses>`_.
+    For example, one can use:
 
     .. code:: python
 
-        python -m nltk.downloader perluniprops nonbreaking_prefixes
+        pip install -U sacremoses
 
     Examples
     --------
-    >>> tokenizer = NLTKMosesTokenizer()
+    >>> tokenizer = SacreMosesTokenizer()
     >>> tokenizer("Gluon NLP toolkit provides a suite of text processing tools.")
     ['Gluon',
      'NLP',
@@ -175,11 +175,10 @@ class NLTKMosesTokenizer(object):
     """
     def __init__(self):
         try:
-            from nltk.tokenize.moses import MosesTokenizer
+            from sacremoses import MosesTokenizer
         except ImportError:
-            raise ImportError('NLTK or relevant packages are not installed. You must install NLTK '
-                              'in order to use the NLTKMosesTokenizer. You can refer to the '
-                              'official installation guide in https://www.nltk.org/install.html .')
+            raise ImportError('sacremoses is not installed. You must install sacremoses '
+                              'in order to use the SacreMosesTokenizer. pip install -U sacremoses .')
         self._tokenizer = MosesTokenizer()
 
     def __call__(self, sample, return_str=False):
@@ -283,19 +282,19 @@ class SpacyTokenizer(object):
         return [tok.text for tok in self._nlp(sample)]
 
 
-class NLTKMosesDetokenizer(object):
-    r"""Apply the Moses Detokenizer implemented in NLTK.
+class SacreMosesDetokenizer(object):
+    r"""Apply the Moses Detokenizer implemented in sacremoses.
 
-    Users of this class are required to `install NLTK <https://www.nltk.org/install.html>`_
-    and install relevant NLTK packages, such as:
+    Users of this class are required to `install sacremoses <https://github.com/alvations/sacremoses>`_.
+    For example, one can use:
 
     .. code:: python
 
-        python -m nltk.downloader perluniprops nonbreaking_prefixes
+        pip install -U sacremoses
 
     Examples
     --------
-    >>> detokenizer = NLTKMosesDetokenizer()
+    >>> detokenizer = SacreMosesDetokenizer()
     >>> detokenizer(['Gluon', 'NLP', 'toolkit', 'provides', 'a', 'suite', \
      'of', 'text', 'processing', 'tools', '.'], return_str=True)
     "Gluon NLP toolkit provides a suite of text processing tools."
@@ -306,11 +305,10 @@ class NLTKMosesDetokenizer(object):
     """
     def __init__(self):
         try:
-            from nltk.tokenize.moses import MosesDetokenizer
+            from sacremoses import MosesDetokenizer
         except ImportError:
-            raise ImportError('NLTK or relevant packages are not installed. You must install NLTK '
-                              'in order to use the NLTKMosesTokenizer. You can refer to the '
-                              'official installation guide in https://www.nltk.org/install.html .')
+            raise ImportError('sacremoses is not installed. You must install sacremoses '
+                              'in order to use the SacreMosesTokenizer. pip install -U sacremoses .')
         self._detokenizer = MosesDetokenizer()
 
     def __call__(self, sample, return_str=False):

--- a/gluonnlp/data/transforms.py
+++ b/gluonnlp/data/transforms.py
@@ -136,45 +136,7 @@ class PadSequence(object):
                                           'mxnet.NDArray, received type=%s' % str(type(sample)))
 
 
-class _MosesTokenizer(object):
-    r"""Base class for moses tokenizer.
-    """
-    def __init__(self):
-        try:
-            from sacremoses import MosesTokenizer
-        except ImportError:
-            warnings.warn('MosesTokenizer has been deprecated in nltk 3.3.0. '
-                          'Please use sacremoses or older nltk version, e.g. 3.2.5. '
-                          'To install sacremoses, use pip install -U sacremoses')
-            try:
-                from nltk.tokenize.moses import MosesTokenizer
-            except ImportError:
-                raise ImportError('NLTK or relevant packages are not installed. '
-                                  'You must install NLTK <= 3.2.5 in order to use the '
-                                  'NLTKMosesTokenizer. You can refer to the official '
-                                  'installation guide in https://www.nltk.org/install.html .')
-        self._tokenizer = MosesTokenizer()
-
-    def __call__(self, sample, return_str=False):
-        """
-
-        Parameters
-        ----------
-        sample: str
-            The sentence to tokenize
-        return_str: bool, default False
-            True: return a single string
-            False: return a list of tokens
-
-        Returns
-        -------
-        ret : list of strs or str
-            List of tokens or tokenized text
-        """
-        return self._tokenizer.tokenize(sample, return_str=return_str)
-
-
-class NLTKMosesTokenizer(_MosesTokenizer):
+class NLTKMosesTokenizer(object):
     r"""Apply the Moses Tokenizer implemented in NLTK.
 
     Users of this class are required to `install NLTK <https://www.nltk.org/install.html>`_
@@ -214,10 +176,42 @@ class NLTKMosesTokenizer(_MosesTokenizer):
      '.']
     """
     def __init__(self):
-        super(NLTKMosesTokenizer, self).__init__()
+        try:
+            from nltk.tokenize.moses import MosesTokenizer
+        except ImportError:
+            warnings.warn('NLTK or relevant packages are not installed. '
+                          'You must install NLTK <= 3.2.5 in order to use the '
+                          'NLTKMosesTokenizer. You can refer to the official '
+                          'installation guide in https://www.nltk.org/install.html .'
+                          ' Now try SacreMosesTokenizer using sacremoses ...')
+            try:
+                from sacremoses import MosesTokenizer
+            except ImportError:
+                warnings.warn('sacremoses is also not installed. '
+                              'Please use sacremoses or older nltk version, e.g. 3.2.5. '
+                              'To install sacremoses, use pip install -U sacremoses')
+        self._tokenizer = MosesTokenizer()
+
+    def __call__(self, sample, return_str=False):
+        """
+
+        Parameters
+        ----------
+        sample: str
+            The sentence to tokenize
+        return_str: bool, default False
+            True: return a single string
+            False: return a list of tokens
+
+        Returns
+        -------
+        ret : list of strs or str
+            List of tokens or tokenized text
+        """
+        return self._tokenizer.tokenize(sample, return_str=return_str)
 
 
-class SacreMosesTokenizer(_MosesTokenizer):
+class SacreMosesTokenizer(object):
     r"""Apply the Moses Tokenizer implemented in sacremoses.
 
     Users of this class are required to `install sacremoses
@@ -257,7 +251,38 @@ class SacreMosesTokenizer(_MosesTokenizer):
      '.']
     """
     def __init__(self):
-        super(SacreMosesTokenizer, self).__init__()
+        try:
+            from sacremoses import MosesTokenizer
+        except ImportError:
+            warnings.warn('sacremoses is not installed. '
+                          'To install sacremoses, use pip install -U sacremoses'
+                          ' Now try NLTKMosesTokenizer using NLTK ...')
+            try:
+                from nltk.tokenize.moses import MosesTokenizer
+            except ImportError:
+                warnings.warn('NLTK is also not installed. '
+                              'You must install NLTK <= 3.2.5 in order to use the '
+                              'NLTKMosesTokenizer. You can refer to the official '
+                              'installation guide in https://www.nltk.org/install.html .')
+        self._tokenizer = MosesTokenizer()
+
+    def __call__(self, sample, return_str=False):
+        """
+
+        Parameters
+        ----------
+        sample: str
+            The sentence to tokenize
+        return_str: bool, default False
+            True: return a single string
+            False: return a list of tokens
+
+        Returns
+        -------
+        ret : list of strs or str
+            List of tokens or tokenized text
+        """
+        return self._tokenizer.tokenize(sample, return_str=return_str)
 
 
 class SpacyTokenizer(object):
@@ -342,45 +367,7 @@ class SpacyTokenizer(object):
         return [tok.text for tok in self._nlp(sample)]
 
 
-class _MosesDetokenizer(object):
-    r"""Base class for moses detokenizer.
-    """
-    def __init__(self):
-        try:
-            from sacremoses import MosesDetokenizer
-        except ImportError:
-            warnings.warn('MosesDetokenizer has been deprecated in nltk 3.3.0. '
-                          'Please use sacremoses or older nltk version, e.g. 3.2.5. '
-                          'To install sacremoses, use pip install -U sacremoses')
-            try:
-                from nltk.tokenize.moses import MosesDetokenizer
-            except ImportError:
-                raise ImportError('NLTK or relevant packages are not installed. '
-                                  'You must install NLTK <= 3.2.5 in order to use the '
-                                  'NLTKMosesDetokenizer. You can refer to the official '
-                                  'installation guide in https://www.nltk.org/install.html .')
-        self._detokenizer = MosesDetokenizer()
-
-    def __call__(self, sample, return_str=False):
-        """
-
-        Parameters
-        ----------
-        sample: list(str)
-            The sentence to detokenize
-        return_str: bool, default False
-            True: return a single string
-            False: return a list of words
-
-        Returns
-        -------
-        ret : list of strs or str
-            List of words or detokenized text
-        """
-        return self._detokenizer.detokenize(sample, return_str=return_str)
-
-
-class NLTKMosesDetokenizer(_MosesDetokenizer):
+class NLTKMosesDetokenizer(object):
     r"""Apply the Moses Detokenizer implemented in NLTK.
 
     Users of this class are required to `install NLTK <https://www.nltk.org/install.html>`_
@@ -402,10 +389,42 @@ class NLTKMosesDetokenizer(_MosesDetokenizer):
     'Das Gluon NLP-Toolkit stellt eine Reihe von Textverarbeitungstools zur Verfügung.'
     """
     def __init__(self):
-        super(NLTKMosesDetokenizer, self).__init__()
+        try:
+            from nltk.tokenize.moses import MosesDetokenizer
+        except ImportError:
+            warnings.warn('NLTK or relevant packages are not installed. '
+                          'You must install NLTK <= 3.2.5 in order to use the '
+                          'NLTKMosesDetokenizer. You can refer to the official '
+                          'installation guide in https://www.nltk.org/install.html .'
+                          ' Now try SacreMosesDetokenizer using sacremoses ...')
+            try:
+                from sacremoses import MosesDetokenizer
+            except ImportError:
+                warnings.warn('sacremoses is also not installed. '
+                              'Please use sacremoses or older nltk version, e.g. 3.2.5. '
+                              'To install sacremoses, use pip install -U sacremoses')
+        self._detokenizer = MosesDetokenizer()
+
+    def __call__(self, sample, return_str=False):
+        """
+
+        Parameters
+        ----------
+        sample: list(str)
+            The sentence to detokenize
+        return_str: bool, default False
+            True: return a single string
+            False: return a list of words
+
+        Returns
+        -------
+        ret : list of strs or str
+            List of words or detokenized text
+        """
+        return self._detokenizer.detokenize(sample, return_str=return_str)
 
 
-class SacreMosesDetokenizer(_MosesDetokenizer):
+class SacreMosesDetokenizer(object):
     r"""Apply the Moses Detokenizer implemented in sacremoses.
 
     Users of this class are required to `install sacremoses
@@ -427,7 +446,38 @@ class SacreMosesDetokenizer(_MosesDetokenizer):
     'Das Gluon NLP-Toolkit stellt eine Reihe von Textverarbeitungstools zur Verfügung.'
     """
     def __init__(self):
-        super(SacreMosesDetokenizer, self).__init__()
+        try:
+            from sacremoses import MosesDetokenizer
+        except ImportError:
+            warnings.warn('sacremoses is not installed. '
+                          'To install sacremoses, use pip install -U sacremoses'
+                          ' Now try NLTKMosesDetokenizer using NLTK ...')
+            try:
+                from nltk.tokenize.moses import MosesDetokenizer
+            except ImportError:
+                warnings.warn('NLTK is also not installed. '
+                              'You must install NLTK <= 3.2.5 in order to use the '
+                              'NLTKMosesDetokenizer. You can refer to the official '
+                              'installation guide in https://www.nltk.org/install.html .')
+        self._detokenizer = MosesDetokenizer()
+
+    def __call__(self, sample, return_str=False):
+        """
+
+        Parameters
+        ----------
+        sample: list(str)
+            The sentence to detokenize
+        return_str: bool, default False
+            True: return a single string
+            False: return a list of words
+
+        Returns
+        -------
+        ret : list of strs or str
+            List of words or detokenized text
+        """
+        return self._detokenizer.detokenize(sample, return_str=return_str)
 
 
 class JiebaTokenizer(object):

--- a/gluonnlp/data/transforms.py
+++ b/gluonnlp/data/transforms.py
@@ -180,6 +180,7 @@ class NLTKMosesTokenizer(object):
             from nltk.tokenize.moses import MosesTokenizer
         except ImportError:
             warnings.warn('NLTK or relevant packages are not installed. '
+                          'Due to the LGPL 2.1+, moses has been deprecated in NLTK since 3.3.0. '
                           'You must install NLTK <= 3.2.5 in order to use the '
                           'NLTKMosesTokenizer. You can refer to the official '
                           'installation guide in https://www.nltk.org/install.html .'
@@ -393,6 +394,7 @@ class NLTKMosesDetokenizer(object):
             from nltk.tokenize.moses import MosesDetokenizer
         except ImportError:
             warnings.warn('NLTK or relevant packages are not installed. '
+                          'Due to the LGPL 2.1+, moses has been deprecated in NLTK since 3.3.0. '
                           'You must install NLTK <= 3.2.5 in order to use the '
                           'NLTKMosesDetokenizer. You can refer to the official '
                           'installation guide in https://www.nltk.org/install.html .'

--- a/gluonnlp/data/transforms.py
+++ b/gluonnlp/data/transforms.py
@@ -137,8 +137,8 @@ class PadSequence(object):
 class SacreMosesTokenizer(object):
     r"""Apply the Moses Tokenizer implemented in sacremoses.
 
-    Users of this class are required to `install sacremoses <https://github.com/alvations/sacremoses>`_.
-    For example, one can use:
+    Users of this class are required to `install sacremoses
+    <https://github.com/alvations/sacremoses>`_. For example, one can use:
 
     .. code:: python
 
@@ -178,7 +178,8 @@ class SacreMosesTokenizer(object):
             from sacremoses import MosesTokenizer
         except ImportError:
             raise ImportError('sacremoses is not installed. You must install sacremoses '
-                              'in order to use the SacreMosesTokenizer. pip install -U sacremoses .')
+                              'in order to use the SacreMosesTokenizer: '
+                              'pip install -U sacremoses .')
         self._tokenizer = MosesTokenizer()
 
     def __call__(self, sample, return_str=False):
@@ -285,8 +286,8 @@ class SpacyTokenizer(object):
 class SacreMosesDetokenizer(object):
     r"""Apply the Moses Detokenizer implemented in sacremoses.
 
-    Users of this class are required to `install sacremoses <https://github.com/alvations/sacremoses>`_.
-    For example, one can use:
+    Users of this class are required to `install sacremoses
+    <https://github.com/alvations/sacremoses>`_. For example, one can use:
 
     .. code:: python
 
@@ -308,7 +309,8 @@ class SacreMosesDetokenizer(object):
             from sacremoses import MosesDetokenizer
         except ImportError:
             raise ImportError('sacremoses is not installed. You must install sacremoses '
-                              'in order to use the SacreMosesTokenizer. pip install -U sacremoses .')
+                              'in order to use the SacreMosesTokenizer: '
+                              'pip install -U sacremoses .')
         self._detokenizer = MosesDetokenizer()
 
     def __call__(self, sample, return_str=False):

--- a/gluonnlp/data/transforms.py
+++ b/gluonnlp/data/transforms.py
@@ -188,9 +188,9 @@ class NLTKMosesTokenizer(object):
             try:
                 from sacremoses import MosesTokenizer
             except ImportError:
-                warnings.warn('sacremoses is also not installed. '
-                              'Please use sacremoses or older nltk version, e.g. 3.2.5. '
-                              'To install sacremoses, use pip install -U sacremoses')
+                raise ImportError('sacremoses is also not installed. '
+                                  'Please use sacremoses or older nltk version, e.g. 3.2.5. '
+                                  'To install sacremoses, use pip install -U sacremoses')
         self._tokenizer = MosesTokenizer()
 
     def __call__(self, sample, return_str=False):
@@ -261,10 +261,10 @@ class SacreMosesTokenizer(object):
             try:
                 from nltk.tokenize.moses import MosesTokenizer
             except ImportError:
-                warnings.warn('NLTK is also not installed. '
-                              'You must install NLTK <= 3.2.5 in order to use the '
-                              'NLTKMosesTokenizer. You can refer to the official '
-                              'installation guide in https://www.nltk.org/install.html .')
+                raise ImportError('NLTK is also not installed. '
+                                  'You must install NLTK <= 3.2.5 in order to use the '
+                                  'NLTKMosesTokenizer. You can refer to the official '
+                                  'installation guide in https://www.nltk.org/install.html .')
         self._tokenizer = MosesTokenizer()
 
     def __call__(self, sample, return_str=False):
@@ -402,9 +402,9 @@ class NLTKMosesDetokenizer(object):
             try:
                 from sacremoses import MosesDetokenizer
             except ImportError:
-                warnings.warn('sacremoses is also not installed. '
-                              'Please use sacremoses or older nltk version, e.g. 3.2.5. '
-                              'To install sacremoses, use pip install -U sacremoses')
+                raise ImportError('sacremoses is also not installed. '
+                                  'Please use sacremoses or older nltk version, e.g. 3.2.5. '
+                                  'To install sacremoses, use pip install -U sacremoses')
         self._detokenizer = MosesDetokenizer()
 
     def __call__(self, sample, return_str=False):
@@ -457,10 +457,10 @@ class SacreMosesDetokenizer(object):
             try:
                 from nltk.tokenize.moses import MosesDetokenizer
             except ImportError:
-                warnings.warn('NLTK is also not installed. '
-                              'You must install NLTK <= 3.2.5 in order to use the '
-                              'NLTKMosesDetokenizer. You can refer to the official '
-                              'installation guide in https://www.nltk.org/install.html .')
+                raise ImportError('NLTK is also not installed. '
+                                  'You must install NLTK <= 3.2.5 in order to use the '
+                                  'NLTKMosesDetokenizer. You can refer to the official '
+                                  'installation guide in https://www.nltk.org/install.html .')
         self._detokenizer = MosesDetokenizer()
 
     def __call__(self, sample, return_str=False):

--- a/gluonnlp/data/transforms.py
+++ b/gluonnlp/data/transforms.py
@@ -402,7 +402,7 @@ class NLTKMosesDetokenizer(_MosesDetokenizer):
     'Das Gluon NLP-Toolkit stellt eine Reihe von Textverarbeitungstools zur Verfügung.'
     """
     def __init__(self):
-        super(_MosesDetokenizer, self).__init__()
+        super(NLTKMosesDetokenizer, self).__init__()
 
 
 class SacreMosesDetokenizer(_MosesDetokenizer):
@@ -427,7 +427,7 @@ class SacreMosesDetokenizer(_MosesDetokenizer):
     'Das Gluon NLP-Toolkit stellt eine Reihe von Textverarbeitungstools zur Verfügung.'
     """
     def __init__(self):
-        super(_MosesDetokenizer, self).__init__()
+        super(SacreMosesDetokenizer, self).__init__()
 
 
 class JiebaTokenizer(object):

--- a/scripts/nmt/train_transformer.py
+++ b/scripts/nmt/train_transformer.py
@@ -47,7 +47,7 @@ from mxnet import gluon
 from mxnet.gluon.data import ArrayDataset, SimpleDataset
 from mxnet.gluon.data import DataLoader
 import gluonnlp.data.batchify as btf
-from gluonnlp.data import NLTKMosesDetokenizer
+from gluonnlp.data import SacreMosesDetokenizer
 from gluonnlp.data import ConstWidthBucket, LinearWidthBucket, ExpWidthBucket,\
     FixedBucketSampler, IWSLT2015, WMT2016, WMT2016BPE, WMT2014, WMT2014BPE
 from gluonnlp.model import BeamSearchScorer
@@ -356,7 +356,7 @@ loss_function.hybridize(static_alloc=static_alloc)
 test_loss_function = SoftmaxCEMaskedLoss()
 test_loss_function.hybridize(static_alloc=static_alloc)
 
-detokenizer = NLTKMosesDetokenizer()
+detokenizer = SacreMosesDetokenizer()
 
 
 def evaluate(data_loader, context=ctx[0]):

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'extras': [
             'spacy',
             'nltk==3.2.5',
+            'sacremoses',
             'scipy',
             'numba',
             'jieba',

--- a/tests/unittest/test_transforms.py
+++ b/tests/unittest/test_transforms.py
@@ -69,7 +69,7 @@ def test_pad_sequence():
 
 
 def test_moses_tokenizer():
-    tokenizer = NLTKMosesTokenizer()
+    tokenizer = SacreMosesTokenizer()
     text = u"Introducing Gluon: An Easy-to-Use Programming Interface for Flexible Deep Learning."
     try:
         ret = tokenizer(text)
@@ -93,7 +93,7 @@ def test_spacy_tokenizer():
 
 
 def test_moses_detokenizer():
-    detokenizer = NLTKMosesDetokenizer()
+    detokenizer = SacreMosesDetokenizer()
     text = ['Introducing', 'Gluon', ':', 'An', 'Easy-to-Use', 'Programming',
             'Interface', 'for', 'Flexible', 'Deep', 'Learning', '.']
     try:

--- a/tests/unittest/test_transforms.py
+++ b/tests/unittest/test_transforms.py
@@ -19,6 +19,8 @@
 
 from __future__ import print_function
 
+import sys
+import pytest
 from gluonnlp.data.transforms import *
 import numpy as np
 from numpy.testing import assert_allclose
@@ -68,6 +70,8 @@ def test_pad_sequence():
                             assert_allclose(ret_l, gt_npy)
 
 
+@pytest.mark.skipif(sys.version_info < (3,0),
+                    reason="requires python3 or higher")
 def test_moses_tokenizer():
     tokenizer = SacreMosesTokenizer()
     text = u"Introducing Gluon: An Easy-to-Use Programming Interface for Flexible Deep Learning."
@@ -92,6 +96,8 @@ def test_spacy_tokenizer():
     assert len(ret) > 0
 
 
+@pytest.mark.skipif(sys.version_info < (3,0),
+                    reason="requires python3 or higher")
 def test_moses_detokenizer():
     detokenizer = SacreMosesDetokenizer()
     text = ['Introducing', 'Gluon', ':', 'An', 'Easy-to-Use', 'Programming',


### PR DESCRIPTION
## Description ##
nltk has deprecated its moses port due to LGPL 2.1+, and they have creates a new library called [sacremoses](https://github.com/alvations/sacremoses). This pr add dependency on sacremoses.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Feature1, tests, (and when applicable, API doc)
- [x] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
