### PR TITLE
Use object dtype when serializing TokenEmbedding.idx_to_token

### DIFF
--- a/gluonnlp/embedding/token_embedding.py
+++ b/gluonnlp/embedding/token_embedding.py
@@ -721,7 +721,7 @@ class TokenEmbedding(object):
                 'during deserialization.')
 
         unknown_token = np.array(self.unknown_token)
-        idx_to_token = np.array(self.idx_to_token)
+        idx_to_token = np.array(self.idx_to_token, dtype='O')
         idx_to_vec = self.idx_to_vec.asnumpy()
 
         if not unknown_token:  # Store empty string instead of None

--- a/gluonnlp/embedding/token_embedding.py
+++ b/gluonnlp/embedding/token_embedding.py
@@ -756,7 +756,8 @@ class TokenEmbedding(object):
             Keyword arguments are passed to the TokenEmbedding initializer.
             Useful for attaching unknown_lookup.
         """
-        npz_dict = np.load(file_path, allow_pickle=False)
+        # idx_to_token is of dtype 'O' so we need to allow pickle
+        npz_dict = np.load(file_path, allow_pickle=True)
 
         unknown_token = npz_dict['unknown_token']
         if not unknown_token:

--- a/tests/unittest/test_datasets.py
+++ b/tests/unittest/test_datasets.py
@@ -261,8 +261,6 @@ def test_verb130():
 
 
 @flaky(max_runs=2, min_passes=1)
-@pytest.mark.skipif(datetime.date.today() < datetime.date(2018, 5, 7),
-                    reason='Disabled for 2 weeks due to server downtime.')
 def test_rare_words():
     data = nlp.data.RareWords(
         root=os.path.join('tests', 'externaldata', 'rarewords'))
@@ -390,6 +388,8 @@ def test_conll2002_esp(segment, length):
         assert all(isinstance(n, _str_types) for n in ner), ner
 
 
+@pytest.mark.skipif(datetime.date.today() < datetime.date(2018, 7, 7),
+                    reason='Disabled for 1 weeks due to server downtime.')
 @flaky(max_runs=2, min_passes=1)
 @pytest.mark.parametrize('segment,length', [
     ('train', 8936),


### PR DESCRIPTION
## Description ##
Sometimes users may input faulty embeddings that contain very long words (eg. a word with 50k characters as in https://s3-us-west-1.amazonaws.com/fasttext-vectors/word-vectors-v2/cc.ky.300.vec.gz ).

This should lead to no user-visible changes.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix OOM error during serializing TokenEmbeddings with very long garbage words
