### PR TITLE
TokenEmbedding: Skip lines with invalid bytes instead of crashing

### DIFF
--- a/gluonnlp/embedding/token_embedding.py
+++ b/gluonnlp/embedding/token_embedding.py
@@ -265,8 +265,15 @@ class TokenEmbedding(object):
         all_elems = []
         tokens = set()
         loaded_unknown_vec = None
-        with io.open(pretrained_file_path, 'r', encoding=encoding) as f:
+        with io.open(pretrained_file_path, 'rb') as f:
             for line_num, line in enumerate(f):
+                try:
+                    line = line.decode(encoding)
+                except ValueError:
+                    warnings.warn('line {} in {}: failed to decode. Skipping.'
+                                  .format(line_num, pretrained_file_path))
+                    continue
+
                 elems = line.rstrip().split(elem_delim)
 
                 assert len(elems) > 1, 'line {} in {}: unexpected data format.'.format(


### PR DESCRIPTION
## Description ##
Currently `TokenEmbedding.from_file` crashes if it the input file has an inconsistent encoding (i.e. not all words can be encoded in the given encoding - usually UTF-8). With this PR, the invalid lines are skipped.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Don't crash on invalid bytes in TokenEmbedding.from_file

## Comments ##
The error can only occur if the input file is invalid. However sometimes users cannot control the input file. An example file is https://s3-us-west-1.amazonaws.com/fasttext-vectors/word-vectors-v2/cc.ko.300.vec.gz which contains inconsistent encodings.
