### PR TITLE
Return py.test exit status even when running codecov.sh

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,9 @@ stage("Unit Test") {
           make clean
           python setup.py install
           py.test -v --capture=no --durations=0 --cov=gluonnlp --cov=scripts tests/unittest scripts
+          EXIT_STATUS=\$?
           bash ./codecov.sh
+          exit \$EXIT_STATUS
           """
         }
       }


### PR DESCRIPTION
## Description ##
Previously the exit status of codecov.sh was returned in the PY3 tests, causing them to pass as long as the code coverage report was successfully submitted. This is of course not what we want.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix Python3 tests on CI
