### PR TITLE
Remove gluon.utils.download copy with verify_ssl support

### DIFF
--- a/env/doc.yml
+++ b/env/doc.yml
@@ -14,5 +14,5 @@ dependencies:
   - nltk
   - pandoc==2.2.1
   - pip:
-    - mxnet-cu80>=1.3.0b20180629
+    - mxnet-cu80>=1.3.0b20180725
     - notedown

--- a/env/py2.yml
+++ b/env/py2.yml
@@ -11,4 +11,4 @@ dependencies:
   - flaky
   - pytest-cov
   - pip:
-    - mxnet-cu80>=1.3.0b20180629
+    - mxnet-cu80>=1.3.0b20180725

--- a/env/py3.yml
+++ b/env/py3.yml
@@ -11,4 +11,4 @@ dependencies:
   - flaky
   - pytest-cov
   - pip:
-    - mxnet-cu80>=1.3.0b20180629
+    - mxnet-cu80>=1.3.0b20180725


### PR DESCRIPTION
## Description ##
The problematic server now servers a valid SSL certificate. Also https://github.com/apache/incubator-mxnet/pull/11546 will add the option upstream.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###


## Comments ##
