### PR TITLE
Remove debugging printenv from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,11 +71,7 @@ stage("Deploy") {
       python setup.py install
       export LD_LIBRARY_PATH=/usr/local/cuda/lib64
       make clean
-      printenv
       make docs
-      EXIT_STATUS=\$?
-      printenv
-      exit \$EXIT_STATUS
       """
 
       if (env.BRANCH_NAME.startsWith("PR-")) {


### PR DESCRIPTION
## Description ##
Once the CI runs stable the debug statements should be removed.