### PR TITLE
Fix Readme formatting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ stage("Sanity Check") {
       source activate ./conda/lint
       conda list
       make clean
-      make pylint
+      make pylint && python setup.py check --restructuredtext --strict
       """
     }
   }

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ You can install ``MXNet`` and ``GluonNLP`` using pip:
     pip install gluonnlp
 
 Docs 📖
-======
+=======
 
 GluonNLP documentation is available at `our
 website <http://gluon-nlp.mxnet.io/master/index.html>`__.


### PR DESCRIPTION
## Description ##
Currently the Readme does not render properly on Pypi. This attempts to fix the rendering by addressing the issues raised by `python setup.py check --restructuredtext --strict`.

### Changes ###
- [X] Fix Readme formatting
- [X] Check Readme formatting on CI