### PR TITLE
Speed up ngram hashing function with numba

### DIFF
--- a/gluonnlp/base.py
+++ b/gluonnlp/base.py
@@ -20,9 +20,17 @@
 # pylint: disable=abstract-method
 """Helper functions."""
 
-__all__ = ['_str_types']
+__all__ = ['_str_types', 'numba_njit']
 
 try:
     _str_types = (str, unicode)
 except NameError:  # Python 3
     _str_types = (str, )
+
+try:
+    from numba import njit
+    numba_njit = njit(nogil=True)
+except ImportError:
+    # Define numba shims
+    def numba_njit(func):
+        return func

--- a/gluonnlp/base.py
+++ b/gluonnlp/base.py
@@ -20,7 +20,7 @@
 # pylint: disable=abstract-method
 """Helper functions."""
 
-__all__ = ['_str_types', 'numba_njit']
+__all__ = ['_str_types', 'numba_njit', 'numba_prange']
 
 try:
     _str_types = (str, unicode)
@@ -28,9 +28,12 @@ except NameError:  # Python 3
     _str_types = (str, )
 
 try:
-    from numba import njit
+    from numba import njit, prange
     numba_njit = njit(nogil=True)
+    numba_prange = prange
 except ImportError:
     # Define numba shims
     def numba_njit(func):
         return func
+
+    numba_prange = range

--- a/gluonnlp/model/train/embedding.py
+++ b/gluonnlp/model/train/embedding.py
@@ -401,8 +401,8 @@ class FasttextEmbeddingModel(EmbeddingModel):
     def __contains__(self, token):
         # supports computing vector for any str that is at least either in the
         # word level vocabulary or contains subwords
-        return (token in self.idx_to_token
-                or self.subword_function([token])[0].shape[0])
+        return (token in self.token_to_idx
+                or self.subword_function([token])[0])
 
     def __getitem__(self, tokens):
         """Looks up embedding vectors of text tokens.

--- a/gluonnlp/model/train/embedding.py
+++ b/gluonnlp/model/train/embedding.py
@@ -436,8 +436,7 @@ class FasttextEmbeddingModel(EmbeddingModel):
             else:
                 word = nd.array([0], ctx=ctx)
                 wordmask = nd.zeros_like(word)
-            subwords = self.subword_function([token])[0].expand_dims(0)
-            subwords = subwords.as_in_context(ctx)
+            subwords = nd.array(self.subword_function([token]), ctx=ctx)
             if subwords.shape[1]:
                 vec = self(word, subwords, wordsmask=wordmask)
             else:

--- a/scripts/word_embeddings/evaluate_pretrained.py
+++ b/scripts/word_embeddings/evaluate_pretrained.py
@@ -162,9 +162,9 @@ if __name__ == '__main__':
     os.makedirs(args_.logdir, exist_ok=True)
 
     # Load pretrained embeddings
-    print('Loading embedding ', args_.embedding_name, ' from ',
-          args_.embedding_source)
     if not args_.embedding_path:
+        print('Loading embedding ', args_.embedding_name, ' from ',
+              args_.embedding_source)
         token_embedding = nlp.embedding.create(args_.embedding_name,
                                                source=args_.embedding_source)
         name = '-' + args_.embedding_name + '-' + args_.embedding_source

--- a/scripts/word_embeddings/train_fasttext.py
+++ b/scripts/word_embeddings/train_fasttext.py
@@ -53,10 +53,10 @@ import warnings
 
 import mxnet as mx
 import numpy as np
+import gluonnlp as nlp
+from gluonnlp.base import numba_njit, numba_prange
 
 import evaluation
-import gluonnlp as nlp
-import numba
 from candidate_sampler import remove_accidental_hits
 from utils import get_context, print_time, prune_sentences
 
@@ -201,13 +201,13 @@ def get_subwords_masks_factory(idx_to_subwordidxs):
     return get_subwords_masks
 
 
-@numba.njit()
+@numba_njit
 def _get_subwords_masks(subwords):
     lengths = np.array([len(s) for s in subwords])
     length = np.max(lengths)
     subwords_arr = np.zeros((len(subwords), length))
     mask = np.zeros((len(subwords), length))
-    for i in numba.prange(len(subwords)):
+    for i in numba_prange(len(subwords)):
         s = subwords[i]
         subwords_arr[i, :len(s)] = s
         mask[i, :len(s)] = 1

--- a/scripts/word_embeddings/train_fasttext.py
+++ b/scripts/word_embeddings/train_fasttext.py
@@ -49,14 +49,16 @@ import random
 import sys
 import tempfile
 import time
+import warnings
 
 import mxnet as mx
 import numpy as np
 
 import evaluation
 import gluonnlp as nlp
-from utils import get_context, print_time, prune_sentences
+import numba
 from candidate_sampler import remove_accidental_hits
+from utils import get_context, print_time, prune_sentences
 
 
 ###############################################################################
@@ -169,26 +171,47 @@ def get_train_data(args):
                 'NGramHashes', ngrams=args.ngrams,
                 num_subwords=args.ngram_buckets)
 
-            # Precompute a idx to subwordidxs mapping to support fast lookup
+            # Store subword indices for all words in vocabulary
             idx_to_subwordidxs = list(subword_function(vocab.idx_to_token))
+            get_subwords_masks = get_subwords_masks_factory(idx_to_subwordidxs)
             max_subwordidxs_len = max(len(s) for s in idx_to_subwordidxs)
+            if max_subwordidxs_len > 500:
+                warnings.warn(
+                    'The word with largest number of subwords '
+                    'has {} subwords, suggesting there are '
+                    'some noisy words in your vocabulary. '
+                    'You should filter out very long words '
+                    'to avoid memory issues.'.format(max_subwordidxs_len))
 
-            # Padded max_subwordidxs_len + 1 so each row contains at least one -1
-            # element which can be found by np.argmax below.
-            idx_to_subwordidxs = np.stack(
-                np.pad(b.asnumpy(), (0, max_subwordidxs_len - len(b) + 1), \
-                       constant_values=-1, mode='constant')
-                for b in idx_to_subwordidxs).astype(np.float32)
-            idx_to_subwordidxs = mx.nd.array(idx_to_subwordidxs)
-
-            logging.info('Using %s to obtain subwords. '
-                         'The word with largest number of subwords '
-                         'has %s subwords.', subword_function,
-                         max_subwordidxs_len)
         return (coded_dataset, negatives_sampler, vocab, subword_function,
-                idx_to_subwordidxs)
+                get_subwords_masks)
     else:
         return coded_dataset, negatives_sampler, vocab
+
+
+def get_subwords_masks_factory(idx_to_subwordidxs):
+    idx_to_subwordidxs = [
+        np.array(i, dtype=np.int_) for i in idx_to_subwordidxs
+    ]
+
+    def get_subwords_masks(indices):
+        subwords = [idx_to_subwordidxs[i] for i in indices]
+        return _get_subwords_masks(subwords)
+
+    return get_subwords_masks
+
+
+@numba.njit()
+def _get_subwords_masks(subwords):
+    lengths = np.array([len(s) for s in subwords])
+    length = np.max(lengths)
+    subwords_arr = np.zeros((len(subwords), length))
+    mask = np.zeros((len(subwords), length))
+    for i in numba.prange(len(subwords)):
+        s = subwords[i]
+        subwords_arr[i, :len(s)] = s
+        mask[i, :len(s)] = 1
+    return subwords_arr, mask
 
 
 def save_params(args, embedding, embedding_out):
@@ -202,37 +225,6 @@ def save_params(args, embedding, embedding_out):
     os.replace(path, os.path.join(args.logdir, 'embedding_out.params'))
 
 
-def indices_to_subwordindices_mask(indices, idx_to_subwordidxs):
-    """Return array of subwordindices for indices.
-
-    A padded numpy array and a mask is returned. The mask is used as
-    indices map to varying length subwords.
-
-    Parameters
-    ----------
-    indices : list of int, numpy array or mxnet NDArray
-        Token indices that should be mapped to subword indices.
-
-    Returns
-    -------
-    Array of subword indices.
-
-    """
-    if not isinstance(indices, mx.nd.NDArray):
-        indices = mx.nd.array(indices)
-    subwords = idx_to_subwordidxs[indices]
-    mask = mx.nd.zeros_like(subwords)
-    mask += subwords != -1
-    lengths = mx.nd.argmax(subwords == -1, axis=1)
-    subwords += subwords == -1
-
-    new_length = int(max(mx.nd.max(lengths).asscalar(), 1))
-    subwords = subwords[:, :new_length]
-    mask = mask[:, :new_length]
-
-    return subwords, mask
-
-
 ###############################################################################
 # Training code
 ###############################################################################
@@ -240,7 +232,7 @@ def train(args):
     """Training helper."""
     if args.ngram_buckets:  # Fasttext model
         coded_dataset, negatives_sampler, vocab, subword_function, \
-            idx_to_subwordidxs = get_train_data(args)
+            get_subwords_masks = get_train_data(args)
         embedding = nlp.model.train.FasttextEmbeddingModel(
             token_to_idx=vocab.token_to_idx,
             subword_function=subword_function,
@@ -310,19 +302,21 @@ def train(args):
                 if args.model.lower() == 'skipgram':
                     unique, inverse_unique_indices = np.unique(
                         center.asnumpy(), return_inverse=True)
-                    unique = mx.nd.array(unique)
                     inverse_unique_indices = mx.nd.array(
                         inverse_unique_indices, ctx=context[0])
-                    subwords, subwords_mask = \
-                        indices_to_subwordindices_mask(unique, idx_to_subwordidxs)
+                    subwords, subwords_mask = get_subwords_masks(
+                        unique.astype(int))
+                    subwords = mx.nd.array(subwords, ctx=context[0])
+                    subwords_mask = mx.nd.array(subwords_mask, ctx=context[0])
                 elif args.model.lower() == 'cbow':
                     unique, inverse_unique_indices = np.unique(
                         word_context.asnumpy(), return_inverse=True)
-                    unique = mx.nd.array(unique)
                     inverse_unique_indices = mx.nd.array(
                         inverse_unique_indices, ctx=context[0])
-                    subwords, subwords_mask = \
-                        indices_to_subwordindices_mask(unique, idx_to_subwordidxs)
+                    subwords, subwords_mask = get_subwords_masks(
+                        unique.astype(int))
+                    subwords = mx.nd.array(subwords, ctx=context[0])
+                    subwords_mask = mx.nd.array(subwords_mask, ctx=context[0])
                 else:
                     logging.error('Unsupported model %s.', args.model)
                     sys.exit(1)
@@ -331,10 +325,6 @@ def train(args):
 
             # To GPU
             center = center.as_in_context(context[0])
-            if args.ngram_buckets:  # Fasttext model
-                subwords = subwords.as_in_context(context[0])
-                subwords_mask = subwords_mask.astype(np.float32).as_in_context(
-                    context[0])
             word_context = word_context.as_in_context(context[0])
             word_context_mask = word_context_mask.as_in_context(context[0])
             negatives = negatives.as_in_context(context[0])
@@ -416,9 +406,9 @@ def train(args):
             log_wc += loss.shape[0]
             log_avg_loss += loss.mean()
             if (i + 1) % args.log_interval == 0:
-                wps = log_wc / (time.time() - log_start_time)
                 # Forces waiting for computation by computing loss value
                 log_avg_loss = log_avg_loss.asscalar() / args.log_interval
+                wps = log_wc / (time.time() - log_start_time)
                 logging.info('[Epoch {} Batch {}/{}] loss={:.4f}, '
                              'throughput={:.2f}K wps, wc={:.2f}K'.format(
                                  epoch, i + 1, num_batches, log_avg_loss,

--- a/scripts/word_embeddings/word_embeddings.rst
+++ b/scripts/word_embeddings/word_embeddings.rst
@@ -38,10 +38,12 @@ Word Embedding Training
 Besides loading pretrained embeddings, the Gluon NLP toolkit also makes it easy
 to train embeddings.
 
-`train_word2vec.py` shows how to facilitate the embeddings related functionality
-in the Gluon NLP toolkit to train Word2Vec word embedding models. Similarly
-`train_fasttext.py` shows how to train an embedding model that facilitates
-subword information.
+`train_fasttext.py` shows how to use Gluon NLP to train fastText or Word2Vec
+models. The script and parts of the Gluon NLP library support just-in-time
+compilation with `numba <http://numba.pydata.org/>`_, which is enabled
+automatically when numba is installed on the system. Please `pip
+install --upgrade numba` to make sure training speed is not needlessly throttled
+by Python.
 
 Word2Vec models were introduced by
 

--- a/tests/unittest/test_vocab_embed.py
+++ b/tests/unittest/test_vocab_embed.py
@@ -1019,16 +1019,13 @@ def test_word_embedding_analogy_evaluation_models(analogy_function):
 def test_subword_function_bytes():
     sf = nlp.vocab.create_subword_function('ByteSubwords')
 
-    assert [116, 101, 115, 116] == sf([u'test'])[0].asnumpy().tolist()
-    assert [207, 132, 206, 181, 207, 131, 207, 132] == \
-        sf([u'τεστ'])[0].asnumpy().tolist()
+    assert [[116, 101, 115, 116]] == sf([u'test'])
+    assert [[207, 132, 206, 181, 207, 131, 207, 132]] == sf([u'τεστ'])
 
 
 def test_subword_function_ngramhashes():
     sf = nlp.vocab.create_subword_function('NGramHashes', ngrams=[3, 4, 5, 6],
                                            num_subwords=1000)
 
-    assert [8.0, 195.0, 271.0, 500.0, 201.0, 445.0, 379.0, 831.0, 617.0, 851.0] == \
-        sf([u'test'])[0].asnumpy().tolist()
-    assert [429.0, 793.0, 101.0, 334.0, 295.0, 474.0, 145.0, 524.0, 388.0, 790.0] == \
-        sf([u'τεστ'])[0].asnumpy().tolist()
+    assert set([8, 195, 271, 500, 201, 445, 379, 831, 617, 851]) == set(sf([u'test'])[0])
+    assert set([429, 793, 101, 334, 295, 474, 145, 524, 388, 790]) == set(sf([u'τεστ'])[0])

--- a/tests/unittest/train/test_embedding.py
+++ b/tests/unittest/train/test_embedding.py
@@ -99,3 +99,4 @@ def test_fasttext_embedding_load_binary_compare_vec():
     assert np.all(
         np.isclose(a=token_embedding_vec.idx_to_vec.asnumpy(),
                    b=idx_to_vec.asnumpy(), atol=0.001))
+    assert all(token in model for token in token_embedding_vec.idx_to_token)


### PR DESCRIPTION
## Description ##
This PR switches the internal implementation of `NGramHashes` to make use of just in time compiling if numba is available. The speed-up is around 30x in case of the `scripts/word_embeddings/train_fasttext.py` example (during the startup/preprocessing phase). If numba the speed of the new implementation is more or less equivalent.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Use numba just-in-time compilation for `NGramHashes` when available.

## Comments ##
- This breaks the API of NGramHashes in that now lists instead of NDArrays are returned. This is necessary as in mxnet empty NDArrays are disallowed / discouraged, but NGramHashes has previously returned empty NDArrays..
- This breaks the API of NGramHashes by removing the option to cache results, which is not helpful anymore.
- Since numba 0.39 (which was released a week ago), now lists of refcounted objects can be passed to numba optimized functions. This allows to do away with pre-padding all subword arrays to maximum length in the `scripts/word_embeddings/train_fasttext.py` example and instead use a JIT compiled function to pad the subwords needed for the current batch to an array.