### PR TITLE
Fix off by one error for ConstWidthBucket

### DIFF
--- a/gluonnlp/data/sampler.py
+++ b/gluonnlp/data/sampler.py
@@ -123,7 +123,7 @@ class ConstWidthBucket(BucketScheme):
             A list including the keys of the buckets.
         """
         if not isinstance(max_lengths, INT_TYPES):
-            bucket_width_l = [max((max_len - min_len) // num_buckets, 1)
+            bucket_width_l = [max((1 + max_len - min_len) // num_buckets, 1)
                               for max_len, min_len in
                               zip(max_lengths, min_lengths)]
             bucket_keys = \
@@ -131,7 +131,7 @@ class ConstWidthBucket(BucketScheme):
                        zip(max_lengths, min_lengths, bucket_width_l))
                  for i in range(num_buckets)]
         else:
-            bucket_width = max((max_lengths - min_lengths) // num_buckets, 1)
+            bucket_width = max((1 + max_lengths - min_lengths) // num_buckets, 1)
             bucket_keys = [max(max_lengths - i * bucket_width, min_lengths)
                            for i in range(num_buckets)]
         return bucket_keys

--- a/tests/unittest/test_sampler.py
+++ b/tests/unittest/test_sampler.py
@@ -55,6 +55,14 @@ def test_fixed_bucket_sampler():
             assert len(set(total_sampled_ids)) == len(total_sampled_ids) == N
 
 
+def test_fixed_bucket_sampler_compactness():
+    samples = list(
+        FixedBucketSampler(
+            np.arange(16, 32), 8, num_buckets=2,
+            bucket_scheme=nlp.data.ConstWidthBucket()))
+    assert len(samples) == 2
+
+
 def test_sorted_bucket_sampler():
     N = 1000
     for seq_lengths in [[np.random.randint(10, 100) for _ in range(N)],


### PR DESCRIPTION
``` python
list(nlp.data.FixedBucketSampler(
    np.arange(16, 32), 8, num_buckets=2
    bucket_scheme=nlp.data.ConstWidthBucket()))
```

Should result in exactly two batches of batch_size 8:
``` python
[[8, 9, 10, 11, 12, 13, 14, 15], [0, 1, 2, 3, 4, 5, 6, 7]]
```
Without this change, 3 batches with batch_size varying between 1, 7 and 8 are
generated.


## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix off by one error for ConstWidthBucket

## Comments ##
@szhengac please let me know if this has any negative impact on your use-case.