### PR TITLE
Remove pytest-datadir

### DIFF
--- a/env/py2.yml
+++ b/env/py2.yml
@@ -10,6 +10,5 @@ dependencies:
   - pytest
   - flaky
   - pytest-cov
-  - pytest-datadir
   - pip:
     - mxnet-cu80>=1.3.0b20180629

--- a/env/py3.yml
+++ b/env/py3.yml
@@ -10,6 +10,5 @@ dependencies:
   - pytest
   - flaky
   - pytest-cov
-  - pytest-datadir
   - pip:
     - mxnet-cu80>=1.3.0b20180629

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
         ],
         'dev': [
             'pytest',
-            'pytest-datadir',
             'recommonmark',
             'sphinx-gallery',
             'sphinx_rtd_theme',

--- a/tests/unittest/train/test_embedding.py
+++ b/tests/unittest/train/test_embedding.py
@@ -87,12 +87,14 @@ def test_fasttext_embedding(sparse_grad, hybridize, wordsmask, subwordsmask):
     loss.asnumpy()
 
 
-def test_fasttext_embedding_load_binary_compare_vec(datadir):
+def test_fasttext_embedding_load_binary_compare_vec():
+    test_dir = os.path.dirname(os.path.realpath(__file__))
     token_embedding_vec = nlp.embedding.TokenEmbedding.from_file(
-        os.path.join(str(datadir), 'lorem_ipsum.vec'), unknown_token=None)
+        os.path.join(str(test_dir), 'test_embedding', 'lorem_ipsum.vec'),
+        unknown_token=None)
 
     model = nlp.model.train.FasttextEmbeddingModel.load_fasttext_format(
-        os.path.join(str(datadir), 'lorem_ipsum.bin'))
+        os.path.join(str(test_dir), 'test_embedding', 'lorem_ipsum.bin'))
     idx_to_vec = model[token_embedding_vec.idx_to_token]
     assert np.all(
         np.isclose(a=token_embedding_vec.idx_to_vec.asnumpy(),


### PR DESCRIPTION
## Description ##
After pytest-datadir was upgraded, Py2 CI starts failing as it does not find the addon anymore. This removes the addon and replaces it by some `os.path.realpath(__file__)` logic.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- Fix CI
