### PR TITLE
import tarfile in language_model.py

### DIFF
--- a/gluonnlp/data/language_model.py
+++ b/gluonnlp/data/language_model.py
@@ -27,6 +27,7 @@ import zipfile
 import hashlib
 import glob
 import shutil
+import tarfile
 
 from mxnet.gluon.utils import download, check_sha1, _get_repo_file_url
 


### PR DESCRIPTION
Resolve an _undefined name_ which may cause NameError to be raised at runtime.

flake8 testing of https://github.com/dmlc/gluon-nlp on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./gluonnlp/base.py:30:24: F821 undefined name 'unicode'
    _str_types = (str, unicode)
                       ^
./gluonnlp/data/language_model.py:305:18: F821 undefined name 'tarfile'
            with tarfile.open(archive_file_path, 'r:gz') as tf:
                 ^
./gluonnlp/embedding/evaluation.py:380:67: F821 undefined name 'name'
                '{} is not a WordEmbeddingAnalogyFunction'.format(name))
                                                                  ^
./gluonnlp/embedding/evaluation.py:439:67: F821 undefined name 'name'
                '{} is not a WordEmbeddingAnalogyFunction'.format(name))
                                                                  ^
./tests/unittest/test_datasets.py:38:24: F821 undefined name 'unicode'
    _str_types = (str, unicode)
                       ^
5     F821 undefined name 'unicode'
5
```

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
