### PR TITLE
Use feature detection instead of version detection

### DIFF
--- a/gluonnlp/base.py
+++ b/gluonnlp/base.py
@@ -22,9 +22,7 @@
 
 __all__ = ['_str_types']
 
-import sys
-
-if sys.version_info[0] == 3:
-    _str_types = (str, )
-else:
+try:
     _str_types = (str, unicode)
+excpet NameError:  # Python 3
+    _str_types = (str, )

--- a/gluonnlp/base.py
+++ b/gluonnlp/base.py
@@ -24,5 +24,5 @@ __all__ = ['_str_types']
 
 try:
     _str_types = (str, unicode)
-excpet NameError:  # Python 3
+except NameError:  # Python 3
     _str_types = (str, )

--- a/tests/unittest/test_datasets.py
+++ b/tests/unittest/test_datasets.py
@@ -23,7 +23,6 @@ import datetime
 import json
 import os
 import random
-import sys
 
 from flaky import flaky
 import mxnet as mx
@@ -32,10 +31,10 @@ import pytest
 
 import gluonnlp as nlp
 
-if sys.version_info[0] == 3:
-    _str_types = (str, )
-else:
+try:
     _str_types = (str, unicode)
+except NameError:  # Python 3
+    _str_types = (str, )
 
 
 ###############################################################################


### PR DESCRIPTION
Follows the Python porting best practice [use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).