### PR TITLE
Fix UnigramCandidateSampler

### DIFF
--- a/gluonnlp/data/candidate_sampler.py
+++ b/gluonnlp/data/candidate_sampler.py
@@ -100,8 +100,9 @@ class UnigramCandidateSampler(CandidateSampler):
         samples: NDArray
             The sampled candidate classes.
         """
-        idx = mx.nd.random.uniform(low=0, high=self.N + 1, shape=shape,
-                                   ctx=self._context).floor()
+        idx = mx.nd.random.uniform(low=0, high=self.N, shape=shape,
+                                   ctx=self._context,
+                                   dtype='float64').floor().astype('float32')
         prob = self.prob[idx]
         alias = self.alias[idx]
         where = mx.nd.random.uniform(shape=shape, ctx=self._context) < prob

--- a/tests/unittest/test_candidate_sampler.py
+++ b/tests/unittest/test_candidate_sampler.py
@@ -9,4 +9,4 @@ def test_unigram_candidate_sampler():
     N = 1000
     sampler = UnigramCandidateSampler(mx.nd.arange(N))
     sampled = sampler(3)
-    assert all(mx.nd.array([523, 729, 698]) == sampled)
+    assert all(mx.nd.array([729, 593, 689]) == sampled)


### PR DESCRIPTION
## Description ##
This fixes `UnigramCandidateSampler`.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix `UnigramCandidateSampler`

## Comments ##
- `dtype='float64'` seems sufficient to avoid numerical issues (meaning out of range samples) for up to [0, 9M]. With float32 for values as small as 100k numerical issues would result in frequently sampling a value that is one too high. Due to https://github.com/apache/incubator-mxnet/issues/11551 this would go unnoticed and just sometimes lead to obscure crashes depending on the memory value read at the out of bound location.
- Also high should be == N, not N+1.