### PR TITLE
Add flake8 without RecursionError

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,19 @@
 
 ROOTDIR = $(CURDIR)
 
+flake8:
+	flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+
 pylint:
 	pylint --rcfile=$(ROOTDIR)/.pylintrc gluonnlp scripts/*/*.py
+
+restruc:
+	python setup.py check --restructuredtext --strict
+
+lint:
+	make flake8
+	make pylint
+	make restruc
 
 docs: release
 	make -C docs html SPHINXOPTS=-W

--- a/env/pylint.yml
+++ b/env/pylint.yml
@@ -5,5 +5,6 @@ dependencies:
   - python=3.6
   - pylint=1.9.2
   - sphinx=1.7.5
+  - flake8
   - pip:
     - pylint-quotes

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
             'jieba',
         ],
         'dev': [
+            'flake8',
             'pytest',
             'recommonmark',
             'sphinx-gallery',


### PR DESCRIPTION
## Description ##
Another approach to @leezu #219 that is based on some of the ideas in the review of #213 that were lost when that PR was simplified.  Our goal is to add flake8 tests while avoiding a RecursionError.  We do this by creating three different steps in Makefile that can be run separately or together via a unified __make lint__ command.  This allows contributors to run these tests separately or together.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes ~have~ _are_ test coverage
- [x] Code is well-documented

### Changes ###
- [x] Add __make flake8__, __make restruc__, and __make lint__ to Makefile

## Comments ##
