### PR TITLE
Re-initialize the unknown token vector for npz distributed on S3 by default

### DIFF
--- a/gluonnlp/embedding/token_embedding.py
+++ b/gluonnlp/embedding/token_embedding.py
@@ -341,19 +341,13 @@ class TokenEmbedding(object):
             # is the same now as it was when the .npz was generated. Under this
             # assumption we can safely overwrite the respective token and
             # vector from the npz.
-            if deserialized_embedding.unknown_token == self.unknown_token:
-                # If the unknown_token is the same, we will find it below and a
-                # new unknown token wont be inserted.
-                idx_to_token = deserialized_embedding.idx_to_token
-                idx_to_vec = deserialized_embedding.idx_to_vec
-            elif self.unknown_token:
-                # If they are different, we need to manually replace it so that
-                # it is found below and no new unknown token would be inserted.
+            if deserialized_embedding.unknown_token:
                 idx_to_token = deserialized_embedding.idx_to_token
                 idx_to_vec = deserialized_embedding.idx_to_vec
                 idx_to_token[C.UNK_IDX] = self.unknown_token
-                vec_len = idx_to_vec.shape[1]
-                idx_to_vec[C.UNK_IDX] = self._init_unknown_vec(shape=vec_len)
+                if self._init_unknown_vec:
+                    vec_len = idx_to_vec.shape[1]
+                    idx_to_vec[C.UNK_IDX] = self._init_unknown_vec(shape=vec_len)
             else:
                 # If the TokenEmbedding shall not have an unknown token, we
                 # just delete the one in the npz.


### PR DESCRIPTION
## Description ##
We currently distribute some pre-trained embeddings on with pre-initialized unknown token. This is known and a workaround has been implemented. Currently the workaround treats the unknown token and vector loaded from the npz file as correct, even if the user specifies a special initialization function, instead of re-initializing it.

The reasoning was, that for some embeddings the unknown token vector in the npz file may actually be valuable and shouldn't be overwritten. However, this was not a good default behavior. With this PR, the unknown vector from the npz will only be preserved if `init_unknown_vec=None`.
Note this only affects embeddings distributed by us on S3.

Thanks @garima3292 for reporting this issue.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix `init_unknown_vec` ignored for some pretrained embeddings.
