### PR TITLE
Refactor DataStream

### DIFF
--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -210,3 +210,4 @@ API Reference
 .. automodule:: gluonnlp.data
    :members:
    :imported-members:
+   :special-members: __iter__

--- a/gluonnlp/data/stream.py
+++ b/gluonnlp/data/stream.py
@@ -56,6 +56,17 @@ class DataStream(object):
     """
 
     def __iter__(self):
+        """Return an iterator over all elements of the DataStream.
+
+        This method returns a new iterator object that can iterate over
+        all the objects in the DataStream.
+
+        Returns
+        -------
+        iterator
+            An object implementing the Python *iterator protocol*.
+
+        """
         raise NotImplementedError
 
     def transform(self, fn):

--- a/gluonnlp/data/stream.py
+++ b/gluonnlp/data/stream.py
@@ -24,18 +24,18 @@ ready for training and evaluation."""
 __all__ = ['DataStream', 'CorpusStream', 'LanguageModelStream', 'SimpleDataStream',
            'PrefetchingStream']
 
-import os
 import glob
 import itertools
-import threading
-import numpy as np
+import multiprocessing
 import os
 import random
-import multiprocessing
 import threading
+
+import numpy as np
 
 import mxnet as mx
 from mxnet.gluon.data import RandomSampler, SequentialSampler
+
 from .dataset import CorpusDataset
 
 try:

--- a/gluonnlp/data/stream.py
+++ b/gluonnlp/data/stream.py
@@ -485,7 +485,7 @@ class _ThreadPrefetcher(_Prefetcher, threading.Thread):
         self.start()
 
 
-class PrefetchingStream(object):
+class PrefetchingStream(DataStream):
     """Prefetch a DataStream in a separate Thread or Process.
 
     This iterator will create another thread or process to perform

--- a/gluonnlp/data/stream.py
+++ b/gluonnlp/data/stream.py
@@ -415,7 +415,7 @@ class _LanguageModelBPTTStream(DataStream):
 
 
 class _Prefetcher(object):
-    """Interal shared prefetcher logic."""
+    """Internal shared prefetcher logic."""
     data_queue = None
     control_queue = None
 
@@ -464,7 +464,7 @@ class _Prefetcher(object):
 
 
 class _ProcessPrefetcher(_Prefetcher, multiprocessing.Process):
-    """Interal multi-processing prefetcher."""
+    """Internal multi-processing prefetcher."""
 
     def __init__(self, *args, **kwargs):
         super(_ProcessPrefetcher, self).__init__(*args, **kwargs)
@@ -475,7 +475,7 @@ class _ProcessPrefetcher(_Prefetcher, multiprocessing.Process):
 
 
 class _ThreadPrefetcher(_Prefetcher, threading.Thread):
-    """Interal threaded prefetcher."""
+    """Internal threaded prefetcher."""
 
     def __init__(self, *args, **kwargs):
         super(_ThreadPrefetcher, self).__init__(*args, **kwargs)

--- a/gluonnlp/data/stream.py
+++ b/gluonnlp/data/stream.py
@@ -37,6 +37,7 @@ import mxnet as mx
 from mxnet.gluon.data import RandomSampler, SequentialSampler
 
 from .dataset import CorpusDataset
+from .utils import line_splitter, whitespace_splitter
 
 try:
     import Queue as queue
@@ -172,7 +173,7 @@ class CorpusStream(DatasetStream):
         - 'random': RandomSampler
     """
     def __init__(self, file_pattern, encoding='utf8', flatten=False, skip_empty=True,
-                 sample_splitter=lambda s: s.splitlines(), tokenizer=lambda s: s.split(),
+                 sample_splitter=line_splitter, tokenizer=whitespace_splitter,
                  bos=None, eos=None, file_sampler='random'):
         assert sample_splitter, 'sample_splitter must be specified.'
         if not isinstance(file_pattern, str):
@@ -245,7 +246,7 @@ class LanguageModelStream(CorpusStream):
         - 'random': RandomSampler
     """
     def __init__(self, file_pattern, encoding='utf8', skip_empty=True,
-                 sample_splitter=lambda s: s.splitlines(), tokenizer=lambda s: s.split(),
+                 sample_splitter=line_splitter, tokenizer=whitespace_splitter,
                  bos=None, eos=None, sampler='random', file_sampler='random'):
         super(LanguageModelStream, self).__init__(file_pattern, flatten=True,
                                                   encoding=encoding,

--- a/gluonnlp/data/stream.py
+++ b/gluonnlp/data/stream.py
@@ -510,6 +510,8 @@ class PrefetchingStream(object):
     def __init__(self, stream, num_prefetch=1, worker_type='thread'):
         self._stream = stream
         self._num_prefetch = num_prefetch
+        if num_prefetch < 1:
+            raise ValueError('num_prefetch must be greater 0.')
         assert worker_type.lower() in ['thread', 'process']
         self._multiprocessing = worker_type.lower() == 'process'
 

--- a/gluonnlp/data/stream.py
+++ b/gluonnlp/data/stream.py
@@ -335,7 +335,7 @@ class _LanguageModelBPTTStream(DataStream):
         The length of each of the samples for truncated back-propagation-through-time (TBPTT).
     batch_size : int
         The number of samples in each batch.
-     sampler : mx.gluon.data.Sampler
+    sampler : mx.gluon.data.Sampler
         The sampler used to sample texts within a file.
     last_batch : {'keep', 'discard'}
         How to handle the last batch if the remaining length is less than `seq_len`.

--- a/gluonnlp/data/utils.py
+++ b/gluonnlp/data/utils.py
@@ -21,7 +21,10 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-__all__ = ['Counter', 'count_tokens', 'concat_sequence', 'slice_sequence', 'train_valid_split']
+__all__ = [
+    'Counter', 'count_tokens', 'concat_sequence', 'slice_sequence', 'train_valid_split',
+    'line_splitter', 'whitespace_splitter'
+]
 
 import os
 import collections
@@ -329,3 +332,35 @@ def _extract_archive(file, target_dir):
         raise Exception('Unrecognized file type: ' + file)
     archive.extractall(path=target_dir)
     archive.close()
+
+
+def line_splitter(s):
+    """Split a string at newlines.
+
+    Parameters
+    ----------
+    s : str
+        The string to be split
+
+    Returns
+    --------
+    List[str]
+        List of strings. Obtained by calling s.splitlines().
+
+    """
+    return s.splitlines()
+
+def whitespace_splitter(s):
+    """Split a string at whitespace.
+
+    Parameters
+    ----------
+    s : str
+        The string to be split
+
+    Returns
+    --------
+    List[str]
+        List of strings. Obtained by calling s.split().
+    """
+    return s.split()

--- a/tests/unittest/test_datasets.py
+++ b/tests/unittest/test_datasets.py
@@ -422,7 +422,7 @@ def test_conll2002_esp(segment, length):
         assert all(isinstance(n, _str_types) for n in ner), ner
 
 
-@pytest.mark.skipif(datetime.date.today() < datetime.date(2018, 7, 7),
+@pytest.mark.skipif(datetime.date.today() < datetime.date(2018, 8, 2),
                     reason='Disabled for 1 weeks due to server downtime.')
 @flaky(max_runs=2, min_passes=1)
 @pytest.mark.parametrize('segment,length', [


### PR DESCRIPTION
## Description ##
See Changes below. This was part of https://github.com/dmlc/gluon-nlp/pull/218. I split up the PR to make it easier to review / discuss.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Remove DataStream.transform() and encourage the use of Python generator expressions instead
- [X] Remove SimpleDataStream (without .transform(), any Python iterable implements the DataStream interface. Consequently there is no need for SimpleDataStream. Let's keep the class hierarchy simple.)
- [X] Refactor PrefetchingStream
  - Remove option to iterate over a list of Streams. This allows keeping the implementation simple. A list of streams can be transformed into a single stream using `zip`.
  - Add option to use multi-processing (with a single worker process)
- [X] Introduce DatasetStream to clarify when we expect a Stream over Datasets vs over individual samples
- [X] Refactor CorpusStream to iterate over CorpusDataset instead of single sentences
  - An iterator over single sentences can still be obtained via `itertools.chain.from_iterable(corpus_stream)`. However, it can be useful to iterate over bigger chunks in the stream to speed up other steps in the data pipeline.
  - Remove the `sampler` argument. It is not needed anymore. (Note that it still kept for LanguageModelStream, which internally now uses `itertools.chain.from_iterable(corpus_stream)`)
- [X] Fix random stability of PrefetchingStream
  - Set the python, numpy and mxnet seeds in the started thread / process deterministically based on the python random number generator state in the calling thread.

## Comments ##
- We may want to re-consider introducing `DatasetStream`. The only difference to `DataStream` is the docstring. It may or may not be a good idea to complicate the class hierarchy for this.