### PR TITLE
Fix LanguageModelDataset.bptt_batchify

### DIFF
--- a/gluonnlp/data/dataset.py
+++ b/gluonnlp/data/dataset.py
@@ -24,6 +24,7 @@ __all__ = ['TextLineDataset', 'CorpusDataset', 'LanguageModelDataset']
 
 import io
 import os
+import math
 
 import mxnet as mx
 from mxnet.gluon.data import SimpleDataset
@@ -195,19 +196,24 @@ class LanguageModelDataset(CorpusDataset):
 
             - discard: The last batch is discarded if it's smaller than `(seq_len, batch_size)`.
         """
-        data = self.batchify(vocab, batch_size)
-        batches = slice_sequence(data, seq_len+1, overlap=1)
+        if last_batch not in ['keep', 'discard']:
+            raise ValueError('last_batch must be "keep" or "discard".')
+
         if last_batch == 'keep':
+            if not vocab.padding_token:
+                raise ValueError('vocab.padding_token must be specified '
+                                 'in vocab when last_batch="keep".')
+            coded = vocab[self._data[0]]
+            sample_len = math.ceil(len(coded) / batch_size)
+            padding_size = _slice_pad_length(sample_len, seq_len + 1, 1) * batch_size + \
+                sample_len * batch_size - len(coded)
+            coded.extend([vocab[vocab.padding_token]] * padding_size)
+            assert len(coded) % batch_size == 0
+            assert not _slice_pad_length(len(coded) / batch_size, seq_len + 1, 1)
+        else:
             sample_len = len(self._data[0]) // batch_size
-            has_short_batch = _slice_pad_length(sample_len*batch_size, seq_len+1, 1) > 0
-            if has_short_batch:
-                ctx = data[0].context if len(data) else None
-                last_batch = self._data[0][seq_len*batch_size*len(batches):]
-                excess_size = len(last_batch) % batch_size
-                if excess_size:
-                    assert vocab.padding_token, 'Padding token must be specified in vocab when ' \
-                                                'last_batch="keep".'
-                    padding_size = batch_size - excess_size
-                    last_batch.extend([vocab.padding_token]*padding_size)
-                batches.append(mx.nd.array(vocab[last_batch], ctx=ctx).reshape(batch_size, -1).T)
-        return SimpleDataset(batches).transform(lambda x: (x[:min(len(x)-1, seq_len), :], x[1:, :]))
+            coded = vocab[self._data[0][:sample_len * batch_size]]
+        data = mx.nd.array(coded).reshape((batch_size, -1)).T
+        batches = slice_sequence(data, seq_len + 1, overlap=1)
+
+        return SimpleDataset(batches).transform(lambda x: (x[:-1], x[1:]))

--- a/gluonnlp/data/dataset.py
+++ b/gluonnlp/data/dataset.py
@@ -204,10 +204,10 @@ class LanguageModelDataset(CorpusDataset):
                 raise ValueError('vocab.padding_token must be specified '
                                  'in vocab when last_batch="keep".')
             coded = vocab[self._data[0]]
-            sample_len = math.ceil(len(coded) / batch_size)
+            sample_len = math.ceil(float(len(coded)) / batch_size)
             padding_size = _slice_pad_length(sample_len, seq_len + 1, 1) * batch_size + \
                 sample_len * batch_size - len(coded)
-            coded.extend([vocab[vocab.padding_token]] * padding_size)
+            coded.extend([vocab[vocab.padding_token]] * int(padding_size))
             assert len(coded) % batch_size == 0
             assert not _slice_pad_length(len(coded) / batch_size, seq_len + 1, 1)
         else:

--- a/gluonnlp/data/dataset.py
+++ b/gluonnlp/data/dataset.py
@@ -197,7 +197,9 @@ class LanguageModelDataset(CorpusDataset):
             - discard: The last batch is discarded if it's smaller than `(seq_len, batch_size)`.
         """
         if last_batch not in ['keep', 'discard']:
-            raise ValueError('last_batch must be "keep" or "discard".')
+            raise ValueError(
+                'Got invalid last_batch: "{}". Must be "keep" or "discard".'.
+                format(last_batch))
 
         if last_batch == 'keep':
             if not vocab.padding_token:

--- a/tests/unittest/test_datasets.py
+++ b/tests/unittest/test_datasets.py
@@ -107,6 +107,9 @@ def test_bptt_batchify(batch_size, seq_len):
 
 
 def test_wikitext2():
+    batch_size = 80
+    seq_len = 35
+
     train = nlp.data.WikiText2(
         segment='train', root=os.path.join('tests', 'data', 'wikitext-2'))
     val = nlp.data.WikiText2(
@@ -127,16 +130,16 @@ def test_wikitext2():
     assert len(serialized_vocab) == 962190, len(serialized_vocab)
     assert json.loads(serialized_vocab)['idx_to_token'] == vocab._idx_to_token
 
-    train_data = train.bptt_batchify(vocab, 35, 80, last_batch='discard')
+    train_data = train.bptt_batchify(vocab, seq_len, batch_size, last_batch='discard')
     assert len(train_data) == 741, len(train_data)
 
     for i, (data, target) in enumerate(train_data):
         mx.test_utils.assert_almost_equal(data[1:].asnumpy(), target[:-1].asnumpy())
-        assert data.shape == target.shape == (35, 80)
+        assert data.shape == target.shape == (seq_len, batch_size)
 
-    train_data = train.bptt_batchify(vocab, 35, 80, last_batch='keep')
+    train_data = train.bptt_batchify(vocab, seq_len, batch_size, last_batch='keep')
     assert len(train_data) == 742, len(train_data)
-    assert train_data[-1][0].shape[0] < 35
+    assert train_data[-1][0].shape[0] <= seq_len
     for i, (data, target) in enumerate(train_data):
         mx.test_utils.assert_almost_equal(data[1:].asnumpy(), target[:-1].asnumpy())
         assert data.shape == target.shape
@@ -161,8 +164,8 @@ def test_wikitext2():
     assert len(test[0]) == 245569, len(test[0])
     assert len(test_freq) == 14143, len(test_freq)
     assert test_freq['English'] == 32, test_freq['English']
-    batched_data = train.batchify(vocab, 80)
-    assert batched_data.shape == (26107, 80)
+    batched_data = train.batchify(vocab, batch_size)
+    assert batched_data.shape == (26107, batch_size)
 
 
 def test_wikitext2_raw():


### PR DESCRIPTION
## Description ##
In the current `LanguageModelDataset.bptt_batchify`, elements of the "last batch" (defined as the extra words at the end of the dataset: `data[(len(data) // batch_size) * batch_size:]`) would incorrectly be split evenly among all rows in the batch dimension. However, each row in our batches should contain a independent context. The correct context for the words in the "last batch" is only the very last row. This PR fixes the logic and adds tests.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix last batch in LanguageModelDataset.bptt_batchify
