### PR TITLE
Remove timid = True from .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,6 @@
 # .coveragerc to control coverage.py
 [run]
 branch = True
-timid = True
 omit =
     tests/*
     conda/*


### PR DESCRIPTION
## Description ##
With `timid = True`, coverage is computed using a more accurate but slower method. Unfortunately the slowdown is too significant and doubles the CI runtime.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented
