### PR TITLE
 Fix API discrepancy between upstream Dataset.transform() and GluonNLP DataStream.transform()

### DIFF
--- a/gluonnlp/data/stream.py
+++ b/gluonnlp/data/stream.py
@@ -162,8 +162,20 @@ class _LazyTransformDataStream(DataStream):
         self._fn = fn
 
     def __iter__(self):
-        for item in iter(self._stream):
+        stream_iter = iter(self._stream)
+        try:
+            item = next(stream_iter)
+        except StopIteration:
+            return
+        istuple = isinstance(item, tuple)
+        if istuple:
+            yield self._fn(*item)
+            for item in stream_iter:
+                yield self._fn(*item)
+        else:
             yield self._fn(item)
+            for item in stream_iter:
+                yield self._fn(item)
 
 class CorpusStream(DataStream):
     """Common text data stream that streams a corpus consisting of multiple text files

--- a/scripts/language_model/large_word_language_model.py
+++ b/scripts/language_model/large_word_language_model.py
@@ -135,8 +135,7 @@ def _load(xs):
             ret.append(x.as_in_context(ctx))
     return ret
 
-def _split_and_sample(data):
-    x, y, m = data
+def _split_and_sample(x, y, m):
     num_ctx = len(context)
     if num_ctx > 1:
         xs = gluon.utils.split_data(x, num_ctx, batch_axis=1, even_split=True)


### PR DESCRIPTION
## Description ##
This makes DataStream.transform() conform to the behavior of upstream DataSet.transform().

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix API discrepancy between upstream Dataset.transform() and GluonNLP DataStream.transform()

## Comments ##
- @eric-haibin-lin