### PR TITLE
Improve imports structure

### DIFF
--- a/docs/examples/language_model/language_model.ipynb
+++ b/docs/examples/language_model/language_model.ipynb
@@ -243,7 +243,7 @@
     "We train the model using truncated [back-propagation-through-time (BPTT)](https://en.wikipedia.org/wiki/Backpropagation_through_time) . We backpropagate\n",
     "for 35 time steps using stochastic gradient descent with the learning rate.\n",
     "\n",
-    "<div style=\"width: 500px;\">![bptt](https://upload.wikimedia.org/wikipedia/commons/e/ee/Unfold_through_time.png)</div>"
+    "<img src=https://upload.wikimedia.org/wikipedia/commons/e/ee/Unfold_through_time.png width=\"500\">"
    ]
   },
   {

--- a/gluonnlp/data/__init__.py
+++ b/gluonnlp/data/__init__.py
@@ -20,38 +20,27 @@
 # pylint: disable=wildcard-import
 """This module includes common utilities such as data readers and counter."""
 
-from .utils import *
-
-from .registry import *
-
-from .transforms import *
-
-from .sampler import *
-
+from . import (batchify, candidate_sampler, conll, dataset, language_model,
+               question_answering, registry, sampler, sentiment, stream,
+               transforms, translation, utils, word_embedding_evaluation,
+               word_embedding_training)
 from .candidate_sampler import *
-
+from .conll import *
 from .dataset import *
-
-from .stream import *
-
 from .language_model import *
-
+from .question_answering import *
+from .registry import *
+from .sampler import *
 from .sentiment import *
-
+from .stream import *
+from .transforms import *
+from .translation import *
+from .utils import *
 from .word_embedding_evaluation import *
-
 from .word_embedding_training import *
 
-from .conll import *
-
-from .translation import *
-
-from . import batchify
-
-from .question_answering import *
-
-__all__ = (utils.__all__ + transforms.__all__ + sampler.__all__ +
-           dataset.__all__ + language_model.__all__ + sentiment.__all__ +
+__all__ = (['batchify'] + utils.__all__ + transforms.__all__ + sampler.__all__
+           + dataset.__all__ + language_model.__all__ + sentiment.__all__ +
            word_embedding_evaluation.__all__ + stream.__all__ +
            word_embedding_training.__all__ + conll.__all__ +
            translation.__all__ + registry.__all__ + question_answering.__all__)

--- a/gluonnlp/model/__init__.py
+++ b/gluonnlp/model/__init__.py
@@ -49,25 +49,18 @@ These models can constructed by passing ``pretrained=True``:
 .. _AWD: https://arxiv.org/abs/1404.5997
 """
 
-from .language_model import *
 
-from .beam_search import *
-
+from . import (attention_cell, beam_search, block, convolutional_encoder,
+               highway, language_model, parameter, sampled_block, train, utils)
 from .attention_cell import *
-
-from .utils import *
-
-from .parameter import *
-
+from .beam_search import *
 from .block import *
-
-from .highway import *
-
-from .sampled_block import *
-
 from .convolutional_encoder import *
-
-from . import train
+from .highway import *
+from .language_model import *
+from .parameter import *
+from .sampled_block import *
+from .utils import *
 
 __all__ = language_model.__all__ + beam_search.__all__ + attention_cell.__all__ + \
           utils.__all__ + parameter.__all__ + block.__all__ + highway.__all__ + \

--- a/gluonnlp/model/train/__init__.py
+++ b/gluonnlp/model/train/__init__.py
@@ -20,12 +20,14 @@
 # pylint: disable=wildcard-import
 """NLP training model."""
 
-import mxnet as mx
 import gluonnlp as nlp
 
-from .language_model import *
+import mxnet as mx
+
+from . import cache, embedding, language_model
 from .cache import *
 from .embedding import *
+from .language_model import *
 
 __all__ = language_model.__all__ + cache.__all__ + embedding.__all__ + \
     ['get_cache_model']

--- a/gluonnlp/model/train/language_model.py
+++ b/gluonnlp/model/train/language_model.py
@@ -22,8 +22,7 @@ __all__ = ['AWDRNN', 'StandardRNN', 'BigRNN']
 from mxnet import init, nd, autograd
 from mxnet.gluon import nn, Block, contrib, rnn
 
-from gluonnlp.model.utils import _get_rnn_layer
-from gluonnlp.model.utils import apply_weight_drop
+from ..utils import _get_rnn_layer, apply_weight_drop
 from ..sampled_block import ISLogits, SparseISLogits
 
 class AWDRNN(Block):

--- a/gluonnlp/vocab/__init__.py
+++ b/gluonnlp/vocab/__init__.py
@@ -20,7 +20,8 @@
 # pylint: disable=wildcard-import
 """Vocabulary."""
 
-from .vocab import *
+from . import subwords, vocab
 from .subwords import *
+from .vocab import *
 
 __all__ = vocab.__all__ + subwords.__all__


### PR DESCRIPTION
## Description ##
The previous import structure was prone to cyclical imports and in some cases would error out with `undefined variable X` on doing `from .X import *; __all__= (X.__all__)`. Also, sometimes package internal imports were `from gluonnlp.X import Y`, where they should have used a relative module internal path. The PR also sorts the changed imports alphabetically.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Improve internal import structure

## Comments ##
This also follows the common practice described in http://platanios.org/assets/pdf/teaching/writing_python_libraries.pdf

<img width="903" alt="image" src="https://user-images.githubusercontent.com/946903/43553902-31cfee6c-95a6-11e8-99be-384a3920b2cd.png">
