### PR TITLE
Fixes for embedding training models

### DIFF
--- a/gluonnlp/model/train/embedding.py
+++ b/gluonnlp/model/train/embedding.py
@@ -439,9 +439,11 @@ class FasttextEmbeddingModel(EmbeddingModel):
             subwords = nd.array(self.subword_function([token]), ctx=ctx)
             if subwords.shape[1]:
                 vec = self(word, subwords, wordsmask=wordmask)
+            elif token not in self.token_to_idx:
+                assert token not in self  # Assert consistency with __contains__
+                raise KeyError
             else:
-                # token is a special_token and subwords are not taken into account
-                assert token in self.token_to_idx
+                # Known tokens (eg. special token such as EOS) without subwords
                 vec = self.embedding(word)
 
             vecs.append(vec)

--- a/gluonnlp/model/train/embedding.py
+++ b/gluonnlp/model/train/embedding.py
@@ -304,7 +304,7 @@ class FasttextEmbeddingModel(EmbeddingModel):
         subword_idx_to_vec = nd.array(matrix[len(idx_to_token):])
         subword_function = create_subword_function(
             'NGramHashes', num_subwords=subword_idx_to_vec.shape[0],
-            ngrams=list(range(minn, maxn + 1)), special_tokens='</s>')
+            ngrams=list(range(minn, maxn + 1)), special_tokens={'</s>'})
 
         self = cls(token_to_idx, subword_function, embedding_size=dim,
                    **kwargs)

--- a/gluonnlp/vocab/subwords.py
+++ b/gluonnlp/vocab/subwords.py
@@ -247,6 +247,7 @@ class NGramHashes(SubwordFunction):
         self.ngrams = ngrams
         self._ngrams = np.asarray(ngrams)
 
+        assert not isinstance(special_tokens, str)
         if special_tokens is None:
             special_tokens = set()
 

--- a/scripts/word_embeddings/evaluate_pretrained.py
+++ b/scripts/word_embeddings/evaluate_pretrained.py
@@ -144,7 +144,7 @@ def load_embedding_from_path(args):
                               'for {} words.'.format(len(token_set))):
             embedding = nlp.embedding.TokenEmbedding(unknown_token=None,
                                                      allow_extend=True)
-            idx_to_tokens = list(token_set)
+            idx_to_tokens = [t for t in token_set if t in model]
             embedding[idx_to_tokens] = model[idx_to_tokens]
 
     else:


### PR DESCRIPTION
## Description ##
This improves the behavior of the fastText embedding models under edge cases. Now KeyError is raised instead of AssertionError when the model does not support imputing an embedding for an unknown word. (This may happen when the model only contains large n-grams such as 5-grams and the unknown word is too short). Further, the end of sentence token was not set correctly before due to a typo.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix specification of special_tokens={</s>} when loading fastText model from .bin
- [X] Raise KeyError instead of AssertionError if FasttextEmbeddingModel can't impute vector for OOV word.
