### PR TITLE
Disable test_sharded_dataloader

### DIFF
--- a/scripts/tests/test_scripts.py
+++ b/scripts/tests/test_scripts.py
@@ -1,4 +1,7 @@
 import subprocess
+
+import pytest
+
 from ..nmt.dataset import TOY
 
 
@@ -32,6 +35,7 @@ def test_gnmt():
                                      '--num_hidden', '64', '--num_layers', '2'])
 
 
+@pytest.mark.skip(reason="causes deadlocks on CI. Tracked in issue #274")
 def test_transformer():
     process = subprocess.check_call(['python', './scripts/nmt/train_transformer.py',
                                      '--dataset', 'TOY', '--src_lang', 'en', '--tgt_lang', 'de',

--- a/tests/unittest/train/test_dataloader.py
+++ b/tests/unittest/train/test_dataloader.py
@@ -1,9 +1,11 @@
 import numpy as np
 import mxnet as mx
+from gluonnlp.data import FixedBucketSampler, ShardedDataLoader
 from mxnet import gluon
-from gluonnlp.data import ShardedDataLoader, FixedBucketSampler
+import pytest
 
 
+@pytest.mark.skip(reason="causes deadlocks on CI. Tracked in issue #274")
 def test_sharded_data_loader():
     X = np.random.uniform(size=(100, 20))
     Y = np.random.uniform(size=(100,))


### PR DESCRIPTION
## Description ##
Test seems to cause deadlocks. See https://github.com/dmlc/gluon-nlp/issues/274


### Changes ###
- [X] Disable test_sharded_dataloader

## Comments ##
@szhengac 