### PR TITLE
Workaround missing makedirs(path, exist_ok=True)

### DIFF
--- a/scripts/word_embeddings/evaluate_pretrained.py
+++ b/scripts/word_embeddings/evaluate_pretrained.py
@@ -159,7 +159,8 @@ if __name__ == '__main__':
 
     args_ = get_args()
     ctx = utils.get_context(args_)[0]
-    os.makedirs(args_.logdir, exist_ok=True)
+    if not os.path.isdir(args_.logdir):
+        os.makedirs(args_.logdir)
 
     # Load pretrained embeddings
     if not args_.embedding_path:

--- a/scripts/word_embeddings/train_fasttext.py
+++ b/scripts/word_embeddings/train_fasttext.py
@@ -450,7 +450,8 @@ def evaluate(args, embedding, vocab, global_step, eval_analogy=False):
 
         eval_tokens = list(eval_tokens_set)
 
-    os.makedirs(args.logdir, exist_ok=True)
+    if not os.path.isdir(args.logdir):
+        os.makedirs(args.logdir)
 
     # Compute their word vectors
     context = get_context(args)


### PR DESCRIPTION
## Description ##
Workaround missing makedirs(path, exist_ok=True)

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix Python2 incompatibility for embedding scripts