### PR TITLE
Make NCELogits easier to use, and rename XXLogits to XXDense

### DIFF
--- a/docs/api/model.rst
+++ b/docs/api/model.rst
@@ -68,10 +68,10 @@ Other Modeling Utilities
     WeightDropParameter
     apply_weight_drop
     L2Normalization
-    ISLogits
-    NCELogits
-    SparseISLogits
-    SparseNCELogits
+    ISDense
+    NCEDense
+    SparseISDense
+    SparseNCEDense
 
 API Reference
 -------------

--- a/gluonnlp/model/sampled_block.py
+++ b/gluonnlp/model/sampled_block.py
@@ -18,13 +18,13 @@
 # under the License.
 
 """Blocks for sampled losses."""
-__all__ = ['ISLogits', 'NCELogits', 'SparseISLogits', 'SparseNCELogits']
+__all__ = ['ISDense', 'NCEDense', 'SparseISDense', 'SparseNCEDense']
 
 from mxnet import nd
 from mxnet.gluon import Block, HybridBlock
 
-class _SampledLogitsHelper(HybridBlock):
-    """A helper Block for calculating sampled logits.
+class _SampledDenseHelper(HybridBlock):
+    """A helper Block for calculating sampled pred.
 
     Parameters
     ----------
@@ -42,7 +42,7 @@ class _SampledLogitsHelper(HybridBlock):
     """
     def __init__(self, num_classes, num_sampled, in_unit, remove_accidental_hits,
                  sparse_label, prefix=None, params=None):
-        super(_SampledLogitsHelper, self).__init__(prefix=prefix, params=params)
+        super(_SampledDenseHelper, self).__init__(prefix=prefix, params=params)
         self._num_classes = num_classes
         self._num_sampled = num_sampled
         self._in_unit = in_unit
@@ -57,42 +57,42 @@ class _SampledLogitsHelper(HybridBlock):
         w_true = w_all.slice(begin=(self._num_sampled, 0), end=(None, None))
         b_sampled = b_all.slice(begin=(0,), end=(self._num_sampled,))
         b_true = b_all.slice(begin=(self._num_sampled,), end=(None,))
-        # true logits
+        # true pred
         # (batch_size, 1)
         x = x.reshape((-1, self._in_unit))
-        logits_true = (w_true * x).sum(axis=1) + b_true
-        # samples logits
+        pred_true = (w_true * x).sum(axis=1) + b_true
+        # samples pred
         # (batch_size, num_sampled)
         b_sampled = F.reshape(b_sampled, (-1,))
-        logits_sampled = F.FullyConnected(x, weight=w_sampled, bias=b_sampled,
-                                          num_hidden=self._num_sampled)
+        pred_sampled = F.FullyConnected(x, weight=w_sampled, bias=b_sampled,
+                                        num_hidden=self._num_sampled)
 
         # remove accidental hits
         if self._remove_accidental_hits:
             label_vec = F.reshape(label, (-1, 1))
             sample_vec = F.reshape(sampled_candidates, (1, -1))
             mask = F.broadcast_equal(label_vec, sample_vec) * -1e37
-            logits_sampled = logits_sampled + mask
+            pred_sampled = pred_sampled + mask
 
         # subtract log(q)
         expected_count_sampled = F.reshape(expected_count_sampled,
                                            shape=(1, self._num_sampled))
         expected_count_true = expected_count_true.reshape((-1,))
-        logits_true = logits_true - F.log(expected_count_true)
-        logits_true = logits_true.reshape((-1, 1))
-        logits_sampled = F.broadcast_sub(logits_sampled, F.log(expected_count_sampled))
+        pred_true = pred_true - F.log(expected_count_true)
+        pred_true = pred_true.reshape((-1, 1))
+        pred_sampled = F.broadcast_sub(pred_sampled, F.log(expected_count_sampled))
 
-        # logits and new_labels
+        # pred and new_labels
         # (batch_size, 1+num_sampled)
-        logits = F.concat(logits_true, logits_sampled, dim=1)
+        pred = F.concat(pred_true, pred_sampled, dim=1)
         if self._sparse_label:
             new_label = F.zeros_like(label)
         else:
             label_vec = F.reshape(label, (-1, 1))
-            new_label_sampled = F.zeros_like(logits_sampled)
+            new_label_sampled = F.zeros_like(pred_sampled)
             new_label_true = F.ones_like(label_vec)
             new_label = F.Concat(new_label_sampled, new_label_true, dim=1)
-        return logits, new_label
+        return pred, new_label
 
     def __repr__(self):
         s = '{name}({mapping})'
@@ -102,8 +102,8 @@ class _SampledLogitsHelper(HybridBlock):
                         mapping=mapping,
                         **self.__dict__)
 
-class _SampledLogits(HybridBlock):
-    """Block that computes sampled output training logits and labels suitable for
+class _SampledDense(HybridBlock):
+    """Block that computes sampled output training pred and labels suitable for
     sampled softmax loss or noise contrastive estimation loss.
 
     Please use `loss.SoftmaxCrossEntropyLoss` for sampled softmax loss, and
@@ -150,7 +150,7 @@ class _SampledLogits(HybridBlock):
     def __init__(self, num_classes, num_sampled, in_unit, remove_accidental_hits,
                  sparse_label, dtype='float32', weight_initializer=None,
                  bias_initializer='zeros', sparse_grad=True, prefix=None, params=None):
-        super(_SampledLogits, self).__init__(prefix=prefix, params=params)
+        super(_SampledDense, self).__init__(prefix=prefix, params=params)
         with self.name_scope():
             grad_stype = 'row_sparse' if sparse_grad else 'default'
             self.weight = self.params.get('weight', shape=(num_classes, in_unit),
@@ -158,8 +158,8 @@ class _SampledLogits(HybridBlock):
                                           dtype=dtype, grad_stype=grad_stype)
             self.bias = self.params.get('bias', shape=(num_classes,), init=bias_initializer,
                                         dtype=dtype)
-        self._logits = _SampledLogitsHelper(num_classes, num_sampled, in_unit,
-                                            remove_accidental_hits, sparse_label)
+        self._dense = _SampledDenseHelper(num_classes, num_sampled, in_unit,
+                                          remove_accidental_hits, sparse_label)
         self._num_classes = num_classes
         self._num_sampled = num_sampled
         self._in_unit = in_unit
@@ -180,7 +180,7 @@ class _SampledLogits(HybridBlock):
                             sparse_grad=self._sparse_grad)
         # (num_sampled+batch_size, 1)
         b_all = F.take(bias, indices=ids)
-        return self._logits(x, sampled_values, label, w_all, b_all)
+        return self._dense(x, sampled_values, label, w_all, b_all)
 
     def __repr__(self):
         s = '{name}({mapping})'
@@ -190,9 +190,9 @@ class _SampledLogits(HybridBlock):
                         mapping=mapping,
                         **self.__dict__)
 
-class NCELogits(_SampledLogits):
-    """Block that computes sampled output training logits and labels suitable for
-    noise contrastive estimation loss.
+class NCEDense(_SampledDense):
+    """Noise contrastive estimated Dense block, which computes sampled pred
+    output and labels for noise contrastive estimation loss during training.
 
     Please use `loss.SigmoidBinaryCrossEntropyLoss` for noise contrastive estimation loss
     during training.
@@ -211,15 +211,15 @@ class NCELogits(_SampledLogits):
 
         # network with sampling for training
         encoder = Encoder(..)
-        decoder = NCELogits(..)
+        decoder = NCEDense(..)
         train_net.add(encoder)
         train_net.add(decoder)
         loss_train = SigmoidBinaryCrossEntropyLoss()
 
         # training
         for x, y, sampled_values in train_batches:
-            logits, new_targets = train_net(x, sampled_values, y)
-            l = loss_train(logits, new_targets)
+            pred, new_targets = train_net(x, sampled_values, y)
+            l = loss_train(pred, new_targets)
 
         # network for testing
         test_net.add(encoder)
@@ -228,8 +228,8 @@ class NCELogits(_SampledLogits):
 
         # testing
         for x, y in test_batches:
-            logits = test_net(x)
-            l = loss_test(logits, y)
+            pred = test_net(x)
+            l = loss_test(pred, y)
 
     Parameters
     ----------
@@ -270,14 +270,14 @@ class NCELogits(_SampledLogits):
     def __init__(self, num_classes, num_sampled, in_unit, remove_accidental_hits=False,
                  dtype='float32', weight_initializer=None, bias_initializer='zeros',
                  sparse_grad=True, prefix=None, params=None):
-        super(NCELogits, self).__init__(num_classes, num_sampled, in_unit, remove_accidental_hits,
-                                        False, dtype=dtype, weight_initializer=weight_initializer,
-                                        bias_initializer=bias_initializer, sparse_grad=sparse_grad,
-                                        prefix=prefix, params=params)
+        super(NCEDense, self).__init__(num_classes, num_sampled, in_unit, remove_accidental_hits,
+                                       False, dtype=dtype, weight_initializer=weight_initializer,
+                                       bias_initializer=bias_initializer, sparse_grad=sparse_grad,
+                                       prefix=prefix, params=params)
 
-class ISLogits(_SampledLogits):
-    """Block that computes sampled output training logits and labels suitable for
-    importance sampled softmax loss.
+class ISDense(_SampledDense):
+    """Importance sampled Dense block, which computes sampled pred output and labels
+    for importance sampled softmax loss during training.
 
     Please use `loss.SoftmaxCrossEntropyLoss` for sampled softmax loss.
 
@@ -288,22 +288,22 @@ class ISLogits(_SampledLogits):
         sparse gradients, including SGD, AdaGrad and Adam.
         By default `lazy_update` is turned on for these optimizers,
         which may perform differently from standard updates.
-        For more details, please check the Optimization API at:
+        For more details, please check the Optimization API at
         https://mxnet.incubator.apache.org/api/python/optimization/optimization.html
 
     Example::
 
         # network with importance sampling for training
         encoder = Encoder(..)
-        decoder = ISLogits(..)
+        decoder = ISDense(..)
         train_net.add(encoder)
         train_net.add(decoder)
         loss = SoftmaxCrossEntropyLoss()
 
         # training
         for x, y, sampled_values in train_batches:
-            logits, new_targets = train_net(x, sampled_values, y)
-            l = loss(logits, new_targets)
+            pred, new_targets = train_net(x, sampled_values, y)
+            l = loss(pred, new_targets)
 
         # network for testing
         test_net.add(encoder)
@@ -311,8 +311,8 @@ class ISLogits(_SampledLogits):
 
         # testing
         for x, y in test_batches:
-            logits = test_net(x)
-            l = loss(logits, y)
+            pred = test_net(x)
+            l = loss(pred, y)
 
     Parameters
     ----------
@@ -353,13 +353,13 @@ class ISLogits(_SampledLogits):
     def __init__(self, num_classes, num_sampled, in_unit, remove_accidental_hits=True,
                  dtype='float32', weight_initializer=None, bias_initializer='zeros',
                  sparse_grad=True, prefix=None, params=None):
-        super(ISLogits, self).__init__(num_classes, num_sampled, in_unit, remove_accidental_hits,
-                                       True, dtype=dtype, weight_initializer=weight_initializer,
-                                       bias_initializer=bias_initializer, sparse_grad=sparse_grad,
-                                       prefix=prefix, params=params)
+        super(ISDense, self).__init__(num_classes, num_sampled, in_unit, remove_accidental_hits,
+                                      True, dtype=dtype, weight_initializer=weight_initializer,
+                                      bias_initializer=bias_initializer, sparse_grad=sparse_grad,
+                                      prefix=prefix, params=params)
 
-class _SparseSampledLogits(Block):
-    """Block that computes sampled output training logits and labels suitable for
+class _SparseSampledDense(Block):
+    """Block that computes sampled output training pred and labels suitable for
     sampled softmax loss or noise contrastive estimation loss.
 
     Please use `loss.SoftmaxCrossEntropyLoss` for sampled softmax loss, and
@@ -369,7 +369,7 @@ class _SparseSampledLogits(Block):
     number of classes to reduce communication overhead and memory consumption.
     Both weight and gradient w.r.t. weight are `RowSparseNDArray`.
 
-    Different from SampledLogits block, the parameters have to be saved before they
+    Different from SampledDense block, the parameters have to be saved before they
     are used for testing.
 
     Example::
@@ -377,13 +377,13 @@ class _SparseSampledLogits(Block):
         # network with sampled_softmax_loss for training
         encoder = Encoder(..)
         train_net.add(encoder)
-        train_net.add(SampledLogits(.., prefix='decoder')))
+        train_net.add(SampledDense(.., prefix='decoder')))
         loss = SoftmaxCrossEntropyLoss()
 
         # training
         for x, y, sampled_values in train_batches:
-            logits, new_targets = train_net(x, sampled_values, y)
-            l = loss(logits, new_targets)
+            pred, new_targets = train_net(x, sampled_values, y)
+            l = loss(pred, new_targets)
 
         # save params
         train_net.save_parameters('net.params')
@@ -397,8 +397,8 @@ class _SparseSampledLogits(Block):
 
         # testing
         for x, y in test_batches:
-            logits = test_net(x)
-            l = loss(logits, y)
+            pred = test_net(x)
+            l = loss(pred, y)
 
     Parameters
     ----------
@@ -441,15 +441,15 @@ class _SparseSampledLogits(Block):
     def __init__(self, num_classes, num_sampled, in_unit, remove_accidental_hits,
                  sparse_label, dtype='float32', weight_initializer=None,
                  bias_initializer='zeros', prefix=None, params=None):
-        super(_SparseSampledLogits, self).__init__(prefix=prefix, params=params)
+        super(_SparseSampledDense, self).__init__(prefix=prefix, params=params)
         with self.name_scope():
             self.weight = self.params.get('weight', shape=(num_classes, in_unit),
                                           init=weight_initializer, dtype=dtype,
                                           grad_stype='row_sparse', stype='row_sparse')
             self.bias = self.params.get('bias', shape=(num_classes,), init=bias_initializer,
                                         dtype=dtype)
-            self._logits = _SampledLogitsHelper(num_classes, num_sampled, in_unit,
-                                                remove_accidental_hits, sparse_label)
+            self._dense = _SampledDenseHelper(num_classes, num_sampled, in_unit,
+                                              remove_accidental_hits, sparse_label)
         self._num_classes = num_classes
         self._num_sampled = num_sampled
         self._in_unit = in_unit
@@ -471,7 +471,7 @@ class _SparseSampledLogits(Block):
         w_all = nd.Embedding(data=ids, weight=weight, **self._kwargs)
         # (num_sampled+batch_size,)
         b_all = nd.take(bias, indices=ids)
-        out, new_targets = self._logits(x, sampled_values, label, w_all, b_all)
+        out, new_targets = self._dense(x, sampled_values, label, w_all, b_all)
         return out, new_targets
 
     def __repr__(self):
@@ -482,9 +482,9 @@ class _SparseSampledLogits(Block):
         return s.format(name=self.__class__.__name__,
                         mapping=mapping, **self.__dict__)
 
-class SparseISLogits(_SparseSampledLogits):
-    """Block that computes sampled output training logits and labels suitable for
-    importance sampled softmax loss.
+class SparseISDense(_SparseSampledDense):
+    """Importance sampled Dense block with sparse weights, which computes sampled pred output
+    and labels for importance sampled softmax loss during training.
 
     Please use `loss.SoftmaxCrossEntropyLoss` for sampled softmax loss.
 
@@ -494,7 +494,7 @@ class SparseISLogits(_SparseSampledLogits):
 
     .. note::
 
-        Different from `ISLogits` block, the weight parameter is stored in
+        Different from `ISDense` block, the weight parameter is stored in
         row_sparse format, which helps reduce memory consumption and
         communication overhead during multi-GPU training. However,
         sparse parameters cannot be shared with other blocks, nor could we hybridize
@@ -506,13 +506,13 @@ class SparseISLogits(_SparseSampledLogits):
         # network with importance sampled softmax for training
         encoder = Encoder(..)
         train_net.add(encoder)
-        train_net.add(SparseISLogits(.., prefix='decoder')))
+        train_net.add(SparseISDense(.., prefix='decoder')))
         loss = SoftmaxCrossEntropyLoss()
 
         # training
         for x, y, sampled_values in train_batches:
-            logits, new_targets = train_net(x, sampled_values, y)
-            l = loss(logits, new_targets)
+            pred, new_targets = train_net(x, sampled_values, y)
+            l = loss(pred, new_targets)
 
         # save params
         train_net.save_parameters('net.params')
@@ -526,8 +526,8 @@ class SparseISLogits(_SparseSampledLogits):
 
         # testing
         for x, y in test_batches:
-            logits = test_net(x)
-            l = loss(logits, y)
+            pred = test_net(x)
+            l = loss(pred, y)
 
     Parameters
     ----------
@@ -567,14 +567,14 @@ class SparseISLogits(_SparseSampledLogits):
     def __init__(self, num_classes, num_sampled, in_unit, remove_accidental_hits=True,
                  dtype='float32', weight_initializer=None, bias_initializer='zeros',
                  prefix=None, params=None):
-        super(SparseISLogits, self).__init__(num_classes, num_sampled, in_unit,
-                                             remove_accidental_hits, True, dtype,
-                                             weight_initializer, bias_initializer,
-                                             prefix=prefix, params=params)
+        super(SparseISDense, self).__init__(num_classes, num_sampled, in_unit,
+                                            remove_accidental_hits, True, dtype,
+                                            weight_initializer, bias_initializer,
+                                            prefix=prefix, params=params)
 
-class SparseNCELogits(_SparseSampledLogits):
-    """Block that computes sampled output training logits and labels suitable for
-    noise contrastive estimation loss.
+class SparseNCEDense(_SparseSampledDense):
+    """Noise contrastive estimated Dense block with sparse weights, which computes sampled
+    pred output and labels for noise contrastive estimation loss during training.
 
     Please use `loss.SigmoidBinaryCrossEntropyLoss` for noise contrastive estimation loss
     during training.
@@ -585,7 +585,7 @@ class SparseNCELogits(_SparseSampledLogits):
 
     .. note::
 
-        Different from `NCELogits` block, the weight parameter is stored
+        Different from `NCEDense` block, the weight parameter is stored
         in row_sparse format, which helps reduce memory consumption and
         communication overhead during multi-GPU training. However,
         sparse parameters cannot be shared with other blocks, nor could we
@@ -597,13 +597,13 @@ class SparseNCELogits(_SparseSampledLogits):
         # network with importance sampled softmax for training
         encoder = Encoder(..)
         train_net.add(encoder)
-        train_net.add(SparseNCELogits(.., prefix='decoder')))
+        train_net.add(SparseNCEDense(.., prefix='decoder')))
         train_loss = SigmoidBinaryCrossEntropyLoss()
 
         # training
         for x, y, sampled_values in train_batches:
-            logits, new_targets = train_net(x, sampled_values, y)
-            l = train_loss(logits, new_targets)
+            pred, new_targets = train_net(x, sampled_values, y)
+            l = train_loss(pred, new_targets)
 
         # save params
         train_net.save_parameters('net.params')
@@ -618,8 +618,8 @@ class SparseNCELogits(_SparseSampledLogits):
 
         # testing
         for x, y in test_batches:
-            logits = test_net(x)
-            l = test_loss(logits, y)
+            pred = test_net(x)
+            l = test_loss(pred, y)
 
     Parameters
     ----------
@@ -659,7 +659,7 @@ class SparseNCELogits(_SparseSampledLogits):
     def __init__(self, num_classes, num_sampled, in_unit, remove_accidental_hits=True,
                  dtype='float32', weight_initializer=None, bias_initializer='zeros',
                  prefix=None, params=None):
-        super(SparseNCELogits, self).__init__(num_classes, num_sampled, in_unit,
-                                              remove_accidental_hits, dtype, weight_initializer,
-                                              bias_initializer, False, prefix=prefix,
-                                              params=params)
+        super(SparseNCEDense, self).__init__(num_classes, num_sampled, in_unit,
+                                             remove_accidental_hits, dtype, weight_initializer,
+                                             bias_initializer, False, prefix=prefix,
+                                             params=params)

--- a/gluonnlp/model/sampled_block.py
+++ b/gluonnlp/model/sampled_block.py
@@ -246,13 +246,16 @@ class NCELogits(_SampledLogits):
         - **new_targets**: A tensor of shape `(batch_size,)`.
           The new target classes.
 
-    .. note: If `sparse_grad` is set to True, the gradient w.r.t input and output
+    .. note::
+
+             If `sparse_grad` is set to True, the gradient w.r.t input and output
              embeddings will be sparse. Only a subset of optimizers support
              sparse gradients, including SGD, AdaGrad and Adam.
              By default `lazy_update` is turned on for these optimizers,
              which may perform differently from standard updates.
              For more details, please check the Optimization API at:
              https://mxnet.incubator.apache.org/api/python/optimization/optimization.html
+
     """
     def __init__(self, num_classes, num_sampled, in_unit, remove_accidental_hits=False,
                  dtype='float32', weight_initializer=None, bias_initializer='zeros',
@@ -327,7 +330,9 @@ class ISLogits(_SampledLogits):
         - **new_targets**: A tensor of shape `(batch_size,)`.
           The new target classes.
 
-    .. note: If `sparse_grad` is set to True, the gradient w.r.t input and output
+    .. note::
+
+             If `sparse_grad` is set to True, the gradient w.r.t input and output
              embeddings will be sparse. Only a subset of optimizers support
              sparse gradients, including SGD, AdaGrad and Adam.
              By default `lazy_update` is turned on for these optimizers,
@@ -475,7 +480,9 @@ class SparseISLogits(_SparseSampledLogits):
     number of classes to reduce communication overhead and memory consumption.
     Both weight and gradient w.r.t. weight are `RowSparseNDArray`.
 
-    .. note: Different from `ISLogits` block, the weight parameter is stored in
+    .. note::
+
+             Different from `ISLogits` block, the weight parameter is stored in
              row_sparse format, which helps reduce memory consumption and
              communication overhead during multi-GPU training. However,
              sparse parameters cannot be shared with other blocks, nor could we hybridize
@@ -563,7 +570,9 @@ class SparseNCELogits(_SparseSampledLogits):
     number of classes to reduce communication overhead and memory consumption.
     Both weight and gradient w.r.t. weight are `RowSparseNDArray`.
 
-    .. note: Different from `NCELogits` block, the weight parameter is stored
+    .. note::
+
+             Different from `NCELogits` block, the weight parameter is stored
              in row_sparse format, which helps reduce memory consumption and
              communication overhead during multi-GPU training. However,
              sparse parameters cannot be shared with other blocks, nor could we

--- a/gluonnlp/model/sampled_block.py
+++ b/gluonnlp/model/sampled_block.py
@@ -186,6 +186,16 @@ class NCELogits(_SampledLogits):
     Please use `loss.SigmoidBinaryCrossEntropyLoss` for noise contrastive estimation loss
     during training.
 
+    .. note::
+
+        If `sparse_grad` is set to True, the gradient w.r.t input and output
+        embeddings will be sparse. Only a subset of optimizers support
+        sparse gradients, including SGD, AdaGrad and Adam.
+        By default `lazy_update` is turned on for these optimizers,
+        which may perform differently from standard updates.
+        For more details, please check the Optimization API at:
+        https://mxnet.incubator.apache.org/api/python/optimization/optimization.html
+
     Example::
 
         # network with sampling for training
@@ -248,13 +258,13 @@ class NCELogits(_SampledLogits):
 
     .. note::
 
-             If `sparse_grad` is set to True, the gradient w.r.t input and output
-             embeddings will be sparse. Only a subset of optimizers support
-             sparse gradients, including SGD, AdaGrad and Adam.
-             By default `lazy_update` is turned on for these optimizers,
-             which may perform differently from standard updates.
-             For more details, please check the Optimization API at:
-             https://mxnet.incubator.apache.org/api/python/optimization/optimization.html
+        If `sparse_grad` is set to True, the gradient w.r.t input and output
+        embeddings will be sparse. Only a subset of optimizers support
+        sparse gradients, including SGD, AdaGrad and Adam.
+        By default `lazy_update` is turned on for these optimizers,
+        which may perform differently from standard updates.
+        For more details, please check the Optimization API at:
+        https://mxnet.incubator.apache.org/api/python/optimization/optimization.html
 
     """
     def __init__(self, num_classes, num_sampled, in_unit, remove_accidental_hits=False,
@@ -270,6 +280,16 @@ class ISLogits(_SampledLogits):
     importance sampled softmax loss.
 
     Please use `loss.SoftmaxCrossEntropyLoss` for sampled softmax loss.
+
+    .. note::
+
+        If `sparse_grad` is set to True, the gradient w.r.t input and output
+        embeddings will be sparse. Only a subset of optimizers support
+        sparse gradients, including SGD, AdaGrad and Adam.
+        By default `lazy_update` is turned on for these optimizers,
+        which may perform differently from standard updates.
+        For more details, please check the Optimization API at:
+        https://mxnet.incubator.apache.org/api/python/optimization/optimization.html
 
     Example::
 
@@ -329,17 +349,6 @@ class ISLogits(_SampledLogits):
           The output probability for the true class and sampled classes
         - **new_targets**: A tensor of shape `(batch_size,)`.
           The new target classes.
-
-    .. note::
-
-             If `sparse_grad` is set to True, the gradient w.r.t input and output
-             embeddings will be sparse. Only a subset of optimizers support
-             sparse gradients, including SGD, AdaGrad and Adam.
-             By default `lazy_update` is turned on for these optimizers,
-             which may perform differently from standard updates.
-             For more details, please check the Optimization API at:
-             https://mxnet.incubator.apache.org/api/python/optimization/optimization.html
-
     """
     def __init__(self, num_classes, num_sampled, in_unit, remove_accidental_hits=True,
                  dtype='float32', weight_initializer=None, bias_initializer='zeros',
@@ -482,12 +491,12 @@ class SparseISLogits(_SparseSampledLogits):
 
     .. note::
 
-             Different from `ISLogits` block, the weight parameter is stored in
-             row_sparse format, which helps reduce memory consumption and
-             communication overhead during multi-GPU training. However,
-             sparse parameters cannot be shared with other blocks, nor could we hybridize
-             a block containinng sparse parameters. Therefore, the parameters have
-             to be saved before they are used for testing.
+        Different from `ISLogits` block, the weight parameter is stored in
+        row_sparse format, which helps reduce memory consumption and
+        communication overhead during multi-GPU training. However,
+        sparse parameters cannot be shared with other blocks, nor could we hybridize
+        a block containinng sparse parameters. Therefore, the parameters have
+        to be saved before they are used for testing.
 
     Example::
 
@@ -572,12 +581,12 @@ class SparseNCELogits(_SparseSampledLogits):
 
     .. note::
 
-             Different from `NCELogits` block, the weight parameter is stored
-             in row_sparse format, which helps reduce memory consumption and
-             communication overhead during multi-GPU training. However,
-             sparse parameters cannot be shared with other blocks, nor could we
-             hybridize a block containinng sparse parameters. Therefore, the
-             parameters have to be saved before they are used for testing.
+        Different from `NCELogits` block, the weight parameter is stored
+        in row_sparse format, which helps reduce memory consumption and
+        communication overhead during multi-GPU training. However,
+        sparse parameters cannot be shared with other blocks, nor could we
+        hybridize a block containinng sparse parameters. Therefore, the
+        parameters have to be saved before they are used for testing.
 
     Example::
 

--- a/gluonnlp/model/sampled_block.py
+++ b/gluonnlp/model/sampled_block.py
@@ -265,7 +265,6 @@ class NCELogits(_SampledLogits):
         which may perform differently from standard updates.
         For more details, please check the Optimization API at:
         https://mxnet.incubator.apache.org/api/python/optimization/optimization.html
-
     """
     def __init__(self, num_classes, num_sampled, in_unit, remove_accidental_hits=False,
                  dtype='float32', weight_initializer=None, bias_initializer='zeros',

--- a/gluonnlp/model/sampled_block.py
+++ b/gluonnlp/model/sampled_block.py
@@ -660,6 +660,6 @@ class SparseNCEDense(_SparseSampledDense):
                  dtype='float32', weight_initializer=None, bias_initializer='zeros',
                  prefix=None, params=None):
         super(SparseNCEDense, self).__init__(num_classes, num_sampled, in_unit,
-                                             remove_accidental_hits, dtype, weight_initializer,
-                                             bias_initializer, False, prefix=prefix,
-                                             params=params)
+                                             remove_accidental_hits, False,
+                                             dtype, weight_initializer, bias_initializer,
+                                             prefix=prefix, params=params)

--- a/gluonnlp/model/sampled_block.py
+++ b/gluonnlp/model/sampled_block.py
@@ -255,16 +255,6 @@ class NCELogits(_SampledLogits):
           The output probability for the true class and sampled classes
         - **new_targets**: A tensor of shape `(batch_size,)`.
           The new target classes.
-
-    .. note::
-
-        If `sparse_grad` is set to True, the gradient w.r.t input and output
-        embeddings will be sparse. Only a subset of optimizers support
-        sparse gradients, including SGD, AdaGrad and Adam.
-        By default `lazy_update` is turned on for these optimizers,
-        which may perform differently from standard updates.
-        For more details, please check the Optimization API at:
-        https://mxnet.incubator.apache.org/api/python/optimization/optimization.html
     """
     def __init__(self, num_classes, num_sampled, in_unit, remove_accidental_hits=False,
                  dtype='float32', weight_initializer=None, bias_initializer='zeros',

--- a/gluonnlp/model/train/language_model.py
+++ b/gluonnlp/model/train/language_model.py
@@ -23,7 +23,7 @@ from mxnet import init, nd, autograd
 from mxnet.gluon import nn, Block, contrib, rnn
 
 from ..utils import _get_rnn_layer, apply_weight_drop
-from ..sampled_block import ISLogits, SparseISLogits
+from ..sampled_block import ISDense, SparseISDense
 
 class AWDRNN(Block):
     """AWD language model by salesforce.
@@ -373,14 +373,14 @@ class BigRNN(Block):
     def _get_decoder(self):
         prefix = 'decoder0_'
         if self._sparse_weight:
-            # sparse IS logits has both sparse weight and sparse grad
-            block = SparseISLogits(self._vocab_size, self._num_sampled,
-                                   self._projection_size, remove_accidental_hits=True,
-                                   prefix=prefix)
+            # sparse IS Dense has both sparse weight and sparse grad
+            block = SparseISDense(self._vocab_size, self._num_sampled,
+                                  self._projection_size, remove_accidental_hits=True,
+                                  prefix=prefix)
         else:
-            block = ISLogits(self._vocab_size, self._num_sampled,
-                             self._projection_size, remove_accidental_hits=True,
-                             prefix=prefix, sparse_grad=self._sparse_grad)
+            block = ISDense(self._vocab_size, self._num_sampled,
+                            self._projection_size, remove_accidental_hits=True,
+                            prefix=prefix, sparse_grad=self._sparse_grad)
         return block
 
     def begin_state(self, **kwargs):

--- a/tests/unittest/test_models.py
+++ b/tests/unittest/test_models.py
@@ -181,12 +181,12 @@ def test_save_load_big_rnn_models():
     hidden = model.begin_state(batch_size=batch_size, func=mx.nd.zeros, ctx=ctx)
     # test forward
     with mx.autograd.record():
-        logits, hidden, new_y = model(x, y, hidden, samples)
-        assert logits.shape == (seq_len, batch_size, 1+num_sampled)
+        pred, hidden, new_y = model(x, y, hidden, samples)
+        assert pred.shape == (seq_len, batch_size, 1+num_sampled)
         assert new_y.shape == (seq_len, batch_size)
-        logits = logits.reshape((-3, -1))
+        pred = pred.reshape((-3, -1))
         new_y = new_y.reshape((-1,))
-        l = loss(logits, new_y)
+        l = loss(pred, new_y)
     l.backward()
     mx.nd.waitall()
     path = 'tests/data/model/test_save_load_big_rnn_models.params'
@@ -216,12 +216,12 @@ def test_big_rnn_model_share_params():
     samples = (sampled_cls, sampled_cls_cnt, true_cls_cnt)
     hidden = model.begin_state(batch_size=batch_size, func=mx.nd.zeros, ctx=ctx)
     with mx.autograd.record():
-        logits, hidden, new_y = model(x, y, hidden, samples)
-        assert logits.shape == (seq_len, batch_size, 1+num_sampled)
+        pred, hidden, new_y = model(x, y, hidden, samples)
+        assert pred.shape == (seq_len, batch_size, 1+num_sampled)
         assert new_y.shape == (seq_len, batch_size)
-        logits = logits.reshape((-3, -1))
+        pred = pred.reshape((-3, -1))
         new_y = new_y.reshape((-1,))
-        l = loss(logits, new_y)
+        l = loss(pred, new_y)
     l.backward()
     assert model.decoder.weight._grad_stype == 'default'
     mx.nd.waitall()
@@ -229,8 +229,8 @@ def test_big_rnn_model_share_params():
                                                  params=model.collect_params())
     eval_model.hybridize()
     eval_model.initialize(mx.init.Xavier(), ctx=ctx)
-    logits, hidden = eval_model(x, hidden)
-    assert logits.shape == (seq_len, batch_size, vocab_size)
+    pred, hidden = eval_model(x, hidden)
+    assert pred.shape == (seq_len, batch_size, vocab_size)
     mx.nd.waitall()
 
 def test_weight_drop():

--- a/tests/unittest/test_sampled_logits.py
+++ b/tests/unittest/test_sampled_logits.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import print_function
+
+import sys
+
+import mxnet as mx
+from mxnet import gluon
+import gluonnlp as nlp
+
+def test_nce_loss():
+    ctx = mx.cpu()
+    batch_size = 2
+    num_sampled = 3
+    vocab_size = 10
+    num_hidden = 5
+    model = nlp.model.NCELogits(vocab_size, num_sampled, num_hidden)
+    loss = gluon.loss.SigmoidBCELoss()
+    model.hybridize()
+    model.initialize(mx.init.Xavier(), ctx=ctx)
+    trainer = mx.gluon.Trainer(model.collect_params(), 'sgd')
+    x = mx.nd.ones((batch_size, num_hidden))
+    y = mx.nd.ones((batch_size,))
+    sampled_cls = mx.nd.ones((num_sampled,))
+    sampled_cls_cnt = mx.nd.ones((num_sampled,))
+    true_cls_cnt = mx.nd.ones((batch_size,))
+    samples = (sampled_cls, sampled_cls_cnt, true_cls_cnt)
+    with mx.autograd.record():
+        logits, new_y = model(x, samples, y)
+        assert logits.shape == (batch_size, 1+num_sampled)
+        assert new_y.shape == (batch_size, 1+num_sampled)
+        l = loss(logits, new_y)
+    l.backward()
+    mx.nd.waitall()
+
+def test_is_softmax_loss():
+    ctx = mx.cpu()
+    batch_size = 2
+    num_sampled = 3
+    vocab_size = 10
+    num_hidden = 5
+    model = nlp.model.ISLogits(vocab_size, num_sampled, num_hidden)
+    loss = gluon.loss.SoftmaxCrossEntropyLoss()
+    model.hybridize()
+    model.initialize(mx.init.Xavier(), ctx=ctx)
+    trainer = mx.gluon.Trainer(model.collect_params(), 'sgd')
+    x = mx.nd.ones((batch_size, num_hidden))
+    y = mx.nd.ones((batch_size,))
+    sampled_cls = mx.nd.ones((num_sampled,))
+    sampled_cls_cnt = mx.nd.ones((num_sampled,))
+    true_cls_cnt = mx.nd.ones((batch_size,))
+    samples = (sampled_cls, sampled_cls_cnt, true_cls_cnt)
+    with mx.autograd.record():
+        logits, new_y = model(x, samples, y)
+        assert logits.shape == (batch_size, 1+num_sampled)
+        assert new_y.shape == (batch_size,)
+        l = loss(logits, new_y)
+    l.backward()
+    mx.nd.waitall()

--- a/tests/unittest/test_sampled_logits.py
+++ b/tests/unittest/test_sampled_logits.py
@@ -31,7 +31,7 @@ def test_nce_loss():
     num_sampled = 3
     vocab_size = 10
     num_hidden = 5
-    model = nlp.model.NCELogits(vocab_size, num_sampled, num_hidden)
+    model = nlp.model.NCEDense(vocab_size, num_sampled, num_hidden)
     loss = gluon.loss.SigmoidBCELoss()
     model.hybridize()
     model.initialize(mx.init.Xavier(), ctx=ctx)
@@ -43,10 +43,10 @@ def test_nce_loss():
     true_cls_cnt = mx.nd.ones((batch_size,))
     samples = (sampled_cls, sampled_cls_cnt, true_cls_cnt)
     with mx.autograd.record():
-        logits, new_y = model(x, samples, y)
-        assert logits.shape == (batch_size, 1+num_sampled)
+        pred, new_y = model(x, samples, y)
+        assert pred.shape == (batch_size, 1+num_sampled)
         assert new_y.shape == (batch_size, 1+num_sampled)
-        l = loss(logits, new_y)
+        l = loss(pred, new_y)
     l.backward()
     mx.nd.waitall()
 
@@ -56,7 +56,7 @@ def test_is_softmax_loss():
     num_sampled = 3
     vocab_size = 10
     num_hidden = 5
-    model = nlp.model.ISLogits(vocab_size, num_sampled, num_hidden)
+    model = nlp.model.ISDense(vocab_size, num_sampled, num_hidden)
     loss = gluon.loss.SoftmaxCrossEntropyLoss()
     model.hybridize()
     model.initialize(mx.init.Xavier(), ctx=ctx)
@@ -68,9 +68,9 @@ def test_is_softmax_loss():
     true_cls_cnt = mx.nd.ones((batch_size,))
     samples = (sampled_cls, sampled_cls_cnt, true_cls_cnt)
     with mx.autograd.record():
-        logits, new_y = model(x, samples, y)
-        assert logits.shape == (batch_size, 1+num_sampled)
+        pred, new_y = model(x, samples, y)
+        assert pred.shape == (batch_size, 1+num_sampled)
         assert new_y.shape == (batch_size,)
-        l = loss(logits, new_y)
+        l = loss(pred, new_y)
     l.backward()
     mx.nd.waitall()


### PR DESCRIPTION
## Description ##
- NCELogits is usually used together with SigmoidBCELoss. This PR update the output of NCELogits to be probably distribution ([1, 0, 0, .... 0]) instead of target class. This way the output can be fed into the loss directly. 
- Rename NCELogits/ISLogits to NCEDense/ISDense, since the output of these blocks are unnormalized predictions rather than log probabilities. Otherwise it's misleading to users

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
