### PR TITLE
Improve error message when loading pretrained fasttext with ngrams

### DIFF
--- a/gluonnlp/embedding/token_embedding.py
+++ b/gluonnlp/embedding/token_embedding.py
@@ -925,7 +925,14 @@ class FastText(TokenEmbedding):
         self._check_source(self.source_file_hash, source)
 
         if load_ngrams:
-            self._check_source(self.source_bin_file_hash, source)
+            try:
+                self._check_source(self.source_bin_file_hash, source)
+            except KeyError:
+                raise KeyError(
+                    'No ngrams are available for {}. '
+                    'Ngram features were published for the following embeddings: {}'.
+                    format(source, ', '.join(self.source_bin_file_hash.keys())))
+
             pretrained_bin_file_path = FastText._get_file_path(self.source_bin_file_hash,
                                                                embedding_root, source)
             unknown_lookup = FasttextEmbeddingModel.load_fasttext_format(


### PR DESCRIPTION
## Description ##

For some pretrained embeddings no subword / binary / ngram models were published
and trying to load them will fail. Currently "Cannot find pre-trained source X
for token embedding fasttext" will be raised, which is wrong given that the
source exists but simply no subword features are available for that source. Now
"No ngrams are available for {}." will be raised instead.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Improve error message when loading pretrained fasttext with ngrams

## Comments ##
@eric-haibin-lin @szha we may want to do a patch release on Tuesday if we find more small usability issues like this