### PR TITLE
make CI more debug-friendly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ stage("Unit Test") {
         python -m spacy download en
         python -m nltk.downloader all
         make clean
-        python setup.py install
+        python setup.py install --force
         py.test -v --capture=no --durations=0 tests/unittest scripts
         """
       }
@@ -46,7 +46,7 @@ stage("Unit Test") {
           python -m spacy download en
           python -m nltk.downloader all
           make clean
-          python setup.py install
+          python setup.py install --force
           py.test -v --capture=no --durations=0 --cov=./ tests/unittest scripts
           EXIT_STATUS=\$?
           bash ./codecov.sh
@@ -72,7 +72,7 @@ stage("Deploy") {
         conda list
         python -m spacy download en
         python -m nltk.downloader all
-        python setup.py install
+        python setup.py install --force
         export LD_LIBRARY_PATH=/usr/local/cuda/lib64
         make clean
         make docs

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ compile_notebooks:
 	done;
 
 dist_scripts:
-	find scripts/* -type d -prune | grep -v 'tests\|__pycache__' | xargs -n 1 -I{} zip -r {}.zip {}
+	find scripts/* -type d -prune | grep -v 'tests\|__pycache__' | xargs -t -n 1 -I{} zip -r {}.zip {}
 
 dist_notebooks: compile_notebooks
-	find docs/examples/* -type d -prune | grep -v 'tests\|__pycache__' | xargs -n 1 -I{} zip -r {}.zip {} -x "*.md"
+	find docs/examples/* -type d -prune | grep -v 'tests\|__pycache__' | xargs -t -n 1 -I{} zip -r {}.zip {} -x "*.md"
 
 test:
 	py.test -v --capture=no --durations=0  tests/unittest scripts

--- a/env/doc.yml
+++ b/env/doc.yml
@@ -5,14 +5,14 @@ dependencies:
   - python=3.6
   - ipython
   - ipykernel
-  - sphinx=1.7.5
+  - sphinx=1.7.7
   - sphinx-gallery
   - sphinx_rtd_theme
-  - nbsphinx>=0.3.3
+  - nbsphinx>=0.3.4
   - recommonmark
   - spacy
   - nltk
-  - pandoc==2.2.1
+  - pandoc=2.0.0
   - pip:
     - mxnet-cu80>=1.3.0b20180817
     - notedown

--- a/env/py2.yml
+++ b/env/py2.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=2.7
   - perl
-  - sphinx=1.7.5
+  - sphinx=1.7.7
   - spacy
   - nltk
   - pytest

--- a/env/py3.yml
+++ b/env/py3.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.6
   - perl
-  - sphinx=1.7.5
+  - sphinx=1.7.7
   - spacy
   - nltk
   - pytest

--- a/env/pylint.yml
+++ b/env/pylint.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.6
   - pylint=1.9.2
-  - sphinx=1.7.5
+  - sphinx=1.7.7
   - flake8
   - pip:
     - pylint-quotes

--- a/examples
+++ b/examples
@@ -1,0 +1,1 @@
+docs/examples


### PR DESCRIPTION
## Description ##
- force install in CI
- print xargs commands
- fix pandoc version, since the utils.pandoc in nbconvert (dep of nbsphinx) has max version of 2.0.0 https://github.com/jupyter/nbconvert/blob/master/nbconvert/utils/pandoc.py#L18