### PR TITLE
Session scope fixtures for WikiText2

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -18,19 +18,19 @@
 # under the License.
 """conftest.py contains configuration for pytest.
 
+Configuration file for tests in tests/ and scripts/ folders.
+
 Note that fixtures of higher-scoped fixtures (such as ``session``) are
 instantiated before lower-scoped fixtures (such as ``function``).
 
 """
 
-import functools
 import logging
 import os
 import random
 
-import gluonnlp as nlp
-import mxnet as mx
 import numpy as np
+import mxnet as mx
 import pytest
 
 
@@ -180,26 +180,3 @@ def function_scope_seed(request):
         logging.info(seed_message)
 
     np.random.set_state(post_test_state)
-
-
-###############################################################################
-# Shared test fixtures
-###############################################################################
-@pytest.fixture(params=["prefetch_process", "prefetch_thread", "none"])
-def stream_identity_wrappers(request):
-    """DataStream wrappers that don't change the content of a Stream.
-
-    All DataStreams included in Gluon-NLP should support being wrapped by one
-    of the wrappers returned by this test fixture. When writing a test to test
-    some Stream, make sure to parameterize it by stream_identity_wrappers so
-    that the stream is tested with all possible stream wrappers.
-
-    """
-    if request.param == "prefetch_process":
-        return functools.partial(nlp.data.PrefetchingStream, worker_type='process')
-    elif request.param == "prefetch_thread":
-        return functools.partial(nlp.data.PrefetchingStream, worker_type='thread')
-    elif request.param == "none":
-        return lambda x: x
-    else:
-        raise RuntimeError

--- a/tests/unittest/batchify/test_batchify_language_model.py
+++ b/tests/unittest/batchify/test_batchify_language_model.py
@@ -28,10 +28,9 @@ import mxnet as mx
 
 
 @pytest.mark.parametrize('batch_size', [7, 80])
-def test_corpus_batchify(batch_size):
-    data = nlp.data.WikiText2(
-        segment='test', root=os.path.join('tests', 'data', 'wikitext-2'))
-    vocab = nlp.Vocab(nlp.data.utils.Counter(data))
+def test_corpus_batchify(batch_size, wikitext2_test_and_counter):
+    data, counter = wikitext2_test_and_counter
+    vocab = nlp.Vocab(counter)
     batchify = nlp.data.batchify.CorpusBatchify(vocab, batch_size)
     batches = batchify(data)
     assert batches[:].shape == (len(data) // batch_size, batch_size)
@@ -39,11 +38,9 @@ def test_corpus_batchify(batch_size):
 
 @pytest.mark.parametrize('batch_size', [7, 80])
 @pytest.mark.parametrize('seq_len', [7, 35])
-def test_corpus_bptt_batchify(batch_size, seq_len):
-    data = nlp.data.WikiText2(
-        segment='test',
-        root=os.path.join('tests', 'data', 'wikitext-2'))
-    vocab = nlp.Vocab(nlp.data.utils.Counter(data))
+def test_corpus_bptt_batchify(batch_size, seq_len, wikitext2_test_and_counter):
+    data, counter = wikitext2_test_and_counter
+    vocab = nlp.Vocab(counter)
 
     # unsupported last_batch
     with pytest.raises(ValueError):

--- a/tests/unittest/batchify/test_batchify_language_model.py
+++ b/tests/unittest/batchify/test_batchify_language_model.py
@@ -19,7 +19,6 @@
 
 from __future__ import print_function
 
-import itertools
 import os
 
 import pytest
@@ -97,24 +96,10 @@ def test_bptt_batchify_padding_token():
 
 @pytest.mark.parametrize('batch_size', [7, 80])
 @pytest.mark.parametrize('seq_len', [7, 35])
-def test_stream_bptt_batchify(seq_len, batch_size, stream_identity_wrappers):
-    EOS = nlp._constants.EOS_TOKEN
-    path = os.path.join('tests', 'data', 'wikitext-2')
-    token_path = os.path.join('tests', 'data', 'wikitext-2/*.tokens')
-
-    # Make sure train, val and test files exist at given path
-    train = nlp.data.WikiText2(segment='train', root=path)
-    val = nlp.data.WikiText2(segment='val', root=path)
-    test = nlp.data.WikiText2(segment='test', root=path)
-
-    stream = nlp.data.SimpleDatasetStream(
-        nlp.data.CorpusDataset,
-        token_path,
-        skip_empty=True,
-        eos=EOS)
-
-    counter = nlp.data.Counter(
-        itertools.chain.from_iterable(itertools.chain.from_iterable(stream)))
+def test_stream_bptt_batchify(
+        seq_len, batch_size, stream_identity_wrappers,
+        wikitext2_simpledatasetstream_skipempty_and_counter):
+    stream, counter = wikitext2_simpledatasetstream_skipempty_and_counter
     vocab = nlp.vocab.Vocab(counter, bos_token=None)
 
     bptt_keep = nlp.data.batchify.StreamBPTTBatchify(

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -94,3 +94,20 @@ def wikitext2_simpledatasetstream_skipempty_and_counter(
     counter = nlp.data.Counter(
         itertools.chain.from_iterable(itertools.chain.from_iterable(stream)))
     return stream, counter
+
+
+@pytest.fixture(scope="session")
+def wikitext2_simpledatasetstream_skipempty_flatten_and_counter(
+        wikitext2_train_and_counter, wikitext2_test_and_counter,
+        wikitext2_val_and_counter):
+    token_path = os.path.join('tests', 'data', 'wikitext-2/*.tokens')
+    assert len(glob.glob(token_path)) == 3
+    stream = nlp.data.SimpleDatasetStream(
+        nlp.data.CorpusDataset,
+        token_path,
+        flatten=True,
+        skip_empty=True,
+        eos=nlp._constants.EOS_TOKEN)
+    counter = nlp.data.Counter(
+        itertools.chain.from_iterable(itertools.chain.from_iterable(stream)))
+    return stream, counter

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -1,0 +1,96 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""conftest.py contains configuration for pytest."""
+
+import functools
+import glob
+import itertools
+import os
+
+import pytest
+
+import gluonnlp as nlp
+
+
+###############################################################################
+# Datasets
+###############################################################################
+@pytest.fixture(scope="session")
+def wikitext2_train_and_counter():
+    path = os.path.join('tests', 'data', 'wikitext-2')
+    data = nlp.data.WikiText2(segment='train', root=path)
+    counter = nlp.data.utils.Counter(data)
+    return data, counter
+
+
+@pytest.fixture(scope="session")
+def wikitext2_test_and_counter():
+    path = os.path.join('tests', 'data', 'wikitext-2')
+    data = nlp.data.WikiText2(segment='test', root=path)
+    counter = nlp.data.utils.Counter(data)
+    return data, counter
+
+
+@pytest.fixture(scope="session")
+def wikitext2_val_and_counter():
+    path = os.path.join('tests', 'data', 'wikitext-2')
+    data = nlp.data.WikiText2(segment='val', root=path)
+    counter = nlp.data.utils.Counter(data)
+    return data, counter
+
+
+###############################################################################
+# Stream
+###############################################################################
+@pytest.fixture(params=["prefetch_process", "prefetch_thread", "none"])
+def stream_identity_wrappers(request):
+    """DataStream wrappers that don't change the content of a Stream.
+
+    All DataStreams included in Gluon-NLP should support being wrapped by one
+    of the wrappers returned by this test fixture. When writing a test to test
+    some Stream, make sure to parameterize it by stream_identity_wrappers so
+    that the stream is tested with all possible stream wrappers.
+
+    """
+    if request.param == "prefetch_process":
+        return functools.partial(
+            nlp.data.PrefetchingStream, worker_type='process')
+    elif request.param == "prefetch_thread":
+        return functools.partial(
+            nlp.data.PrefetchingStream, worker_type='thread')
+    elif request.param == "none":
+        return lambda x: x
+    else:
+        raise RuntimeError
+
+
+@pytest.fixture(scope="session")
+def wikitext2_simpledatasetstream_skipempty_and_counter(
+        wikitext2_train_and_counter, wikitext2_test_and_counter,
+        wikitext2_val_and_counter):
+    token_path = os.path.join('tests', 'data', 'wikitext-2/*.tokens')
+    assert len(glob.glob(token_path)) == 3
+    stream = nlp.data.SimpleDatasetStream(
+        nlp.data.CorpusDataset,
+        token_path,
+        skip_empty=True,
+        eos=nlp._constants.EOS_TOKEN)
+    counter = nlp.data.Counter(
+        itertools.chain.from_iterable(itertools.chain.from_iterable(stream)))
+    return stream, counter

--- a/tests/unittest/test_models.py
+++ b/tests/unittest/test_models.py
@@ -46,10 +46,9 @@ def _test_pretrained_big_text_models():
         output, state = model(mx.nd.arange(330).reshape((33, 10)), hidden)
         output.wait_to_read()
 
-def test_big_text_models():
+def test_big_text_models(wikitext2_val_and_counter):
     # use a small vocabulary for testing
-    val = nlp.data.WikiText2(segment='val', root='tests/data/wikitext-2')
-    val_freq = nlp.data.utils.Counter(val)
+    val, val_freq = wikitext2_val_and_counter
     vocab = nlp.Vocab(val_freq)
     text_models = ['big_rnn_lm_2048_512']
 
@@ -64,9 +63,8 @@ def test_big_text_models():
         output, state = model(mx.nd.arange(330).reshape((33, 10)), hidden)
         output.wait_to_read()
 
-def test_text_models():
-    val = nlp.data.WikiText2(segment='val', root='tests/data/wikitext-2')
-    val_freq = nlp.data.utils.Counter(val)
+def test_text_models(wikitext2_val_and_counter):
+    val, val_freq = wikitext2_val_and_counter
     vocab = nlp.Vocab(val_freq)
     text_models = ['standard_lstm_lm_200', 'standard_lstm_lm_650', 'standard_lstm_lm_1500', 'awd_lstm_lm_1150', 'awd_lstm_lm_600']
     pretrained_to_test = {'standard_lstm_lm_1500': 'wikitext-2',

--- a/tests/unittest/test_stream.py
+++ b/tests/unittest/test_stream.py
@@ -27,22 +27,11 @@ import pytest
 import gluonnlp as nlp
 
 
-def test_corpus_stream(stream_identity_wrappers):
-    EOS = nlp._constants.EOS_TOKEN
-    path = os.path.join('tests', 'data', 'wikitext-2')
-    token_path = os.path.join('tests', 'data', 'wikitext-2/*.tokens')
+def test_corpus_stream(
+        stream_identity_wrappers,
+        wikitext2_simpledatasetstream_skipempty_flatten_and_counter):
+    stream, _ = wikitext2_simpledatasetstream_skipempty_flatten_and_counter
 
-    # Make sure train, val and test files exist at given path
-    train = nlp.data.WikiText2(segment='train', root=path)
-    val = nlp.data.WikiText2(segment='val', root=path)
-    test = nlp.data.WikiText2(segment='test', root=path)
-
-    stream = nlp.data.SimpleDatasetStream(
-        nlp.data.CorpusDataset,
-        token_path,
-        flatten=True,
-        skip_empty=True,
-        eos=EOS)
     stream = stream_identity_wrappers(stream)
     counter = nlp.data.Counter(itertools.chain.from_iterable(stream))
     assert len(counter) == 33278, len(counter)
@@ -60,6 +49,10 @@ def test_lazy_stream(stream_identity_wrappers):
     path = os.path.join('tests', 'data', 'wikitext-2')
     token_path = os.path.join('tests', 'data', 'wikitext-2/*test*.tokens')
     corpus = nlp.data.WikiText2(segment='test', root=path)
+
+    # We don't use wikitext2_simpledatasetstream_skipempty_flatten_and_counter
+    # here as there is no need to work on more than the 'test' segment. The
+    # fixture goes over all segments.
     stream = nlp.data.SimpleDatasetStream(
         nlp.data.CorpusDataset,
         token_path,


### PR DESCRIPTION
## Description ##
This adds session scope fixtures for the WikiText2 dataset throughout the test suite. Consequently dataset is read only once.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Use session scope fixtures for WikiText2 in test suite to avoid re-reading dataset many times
