### PR TITLE
fix pandoc warning

### DIFF
--- a/env/doc.yml
+++ b/env/doc.yml
@@ -12,7 +12,7 @@ dependencies:
   - recommonmark
   - spacy
   - nltk
-  - pandoc=2.0.0
+  - pandoc=1.19.2
   - pip:
     - mxnet-cu80>=1.3.0b20180817
     - notedown


### PR DESCRIPTION
## Description ##
fix pandoc warning

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] use pandoc 1.19.2 to fix the warning
```
RuntimeWarning: You are using an unsupported version of pandoc (2.0.0.1).

Your version must be at least (1.12.1) but less than (2.0.0).

Refer to http://pandoc.org/installing.html.
```

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
