### PR TITLE
fix _fork attr in sharded_dataloader

### DIFF
--- a/env/doc.yml
+++ b/env/doc.yml
@@ -16,5 +16,4 @@ dependencies:
   - notedown
   - pip:
     - mxnet-cu80>=1.3.0
-    - notedown
     - sacremoses

--- a/env/doc.yml
+++ b/env/doc.yml
@@ -16,4 +16,5 @@ dependencies:
   - notedown
   - pip:
     - mxnet-cu80>=1.3.0
+    - notedown
     - sacremoses

--- a/gluonnlp/data/dataloader.py
+++ b/gluonnlp/data/dataloader.py
@@ -25,7 +25,8 @@ from mxnet.gluon.data.dataloader import DataLoader, _MultiWorkerIter, _as_in_con
 
 def worker_loop(dataset, key_queue, data_queue, batchify_fn):
     """Worker loop for multiprocessing DataLoader."""
-    dataset._fork()
+    if hasattr(dataset, '_fork') and callable(dataset._fork):
+        dataset._fork()
     while True:
         idx, samples = key_queue.get()
         if idx is None:

--- a/tests/unittest/test_datasets.py
+++ b/tests/unittest/test_datasets.py
@@ -486,3 +486,10 @@ def _test_gbw_stream():
     assert counter['.'] == 29969612
     vocab = gbw.vocab
     assert len(vocab) == 793471
+
+@pytest.mark.serial
+def test_list_dataset():
+    for num_worker in range(0, 3):
+        data = nlp.data.ShardedDataLoader([([1,2], 0), ([3, 4], 1)], batch_size=1, num_workers=num_worker)
+        for d, l in data:
+            pass


### PR DESCRIPTION
## Description ##
@zhreshold @szhengac @leezu @szha 
Fix error: 
`AttributeError: 'list' object has no attribute '_fork'`
similar to https://github.com/apache/incubator-mxnet/pull/12093/files 

So that v0.4.1 can depend on mxnet 1.3.0

## Checklist ##
### Essentials ###
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
