### PR TITLE
Auto-download required nltk data for transformer

### DIFF
--- a/gluonnlp/data/transforms.py
+++ b/gluonnlp/data/transforms.py
@@ -475,6 +475,12 @@ class SacreMosesDetokenizer(object):
                               'To install sacremoses, use pip install -U sacremoses'
                               ' Now try NLTKMosesDetokenizer using NLTK ...')
             try:
+                from nltk.data import find
+                from nltk import download
+                try:
+                    find('perluniprops')
+                except LookupError:
+                    download('perluniprops')
                 from nltk.tokenize.moses import MosesDetokenizer
                 self._detokenizer = MosesDetokenizer()
             except ImportError:


### PR DESCRIPTION
## Description ##
Even if NLTK is installed via pip, I still need to manually run nltk.download('perluniprops') when setting up a machine to train transformer. Add a check there to make this happen automatically. 


## Checklist ##
### Essentials ###
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
