### PR TITLE
Correct text8 file name in corpora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ docs/examples/*.zip
 docs/examples/*/*.ipynb
 
 conda
+
+# vscode
+.vscode

--- a/gluonnlp/data/corpora/large_text_compression_benchmark.py
+++ b/gluonnlp/data/corpora/large_text_compression_benchmark.py
@@ -94,7 +94,7 @@ class Text8(_LargeTextCompressionBenchmark):
 
     """
 
-    archive_file = ('text8.zip', '6c70299b93b7e1f927b42cd8f6ac1a31547c7a2e')
+    archive_file = ('text8-6c70299b.zip', '6c70299b93b7e1f927b42cd8f6ac1a31547c7a2e')
     data_file = {
         'train': ('text8', '0dc3edebc970dcc96137e7deda4d9995af9d93de')
     }


### PR DESCRIPTION
## Description ##
gluonnlp.data.Text8(segment='train') was not working when I tried to follow the tutorial. It turned out that archive name for text8 in large_text_compression_benchmark.py was wrong. Hence, I changed the archive name. 

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Change archive_file name from 'text8.zip' to 'text8-6c70299b.zip'

