### PR TITLE
Add dtype support to EmbeddingCenterContextBatchify

### DIFF
--- a/docs/examples/word_embedding/word_embedding_training.md
+++ b/docs/examples/word_embedding/word_embedding_training.md
@@ -108,14 +108,14 @@ character-ngrams occuring in the string representation of the token. Thereby a
 fastText embedding model can compute meaningful embedding vectors for tokens
 that were not seen during training.
 
-For this notebook, we have prepared a
-helper function `transform_data` which builds a series of transformations of the
-`text8` `Dataset` created above, applying "tricks" mentioned before. It returns
-a `DataStream` over batches as well as a batchify_fn function that applied to a
-batch looks up and includes the fastText subwords associated with the center
-words and finally the subword function that can be used to obtain the subwords
-of a given string representation of a token. We will take a closer look at the
-subword function shortly.
+For this notebook, we have prepared a helper function `transform_data_fasttext`
+which builds a series of transformations of the `text8` `Dataset` created above,
+applying "tricks" mentioned before. It returns a `DataStream` over batches as
+well as a batchify_fn function that applied to a batch looks up and includes the
+fastText subwords associated with the center words and finally the subword
+function that can be used to obtain the subwords of a given string
+representation of a token. We will take a closer look at the subword function
+shortly.
 
 Note that the number of subwords is potentially
 different for every word. Therefore the batchify_fn represents a word with its
@@ -135,12 +135,12 @@ systems. 2013.
 Information" Transactions of the Association for Computational Linguistics 2017
 
 ```{.python .input}
-from data import transform_data
+from data import transform_data_fasttext
 
 batch_size=4096
-text8 = nlp.data.SimpleDataStream([text8])  # input is a stream of datasets, here just 1. Allows scaling to larger corpora that don't fit in memory
-data, batchify_fn, subword_function = transform_data(
-    text8, vocab, idx_to_counts, cbow=False, ngrams=[3,4,5,6], ngram_buckets=100000, batch_size=batch_size, window_size=5)
+data = nlp.data.SimpleDataStream([text8])  # input is a stream of datasets, here just 1. Allows scaling to larger corpora that don't fit in memory
+data, batchify_fn, subword_function = transform_data_fasttext(
+    data, vocab, idx_to_counts, cbow=False, ngrams=[3,4,5,6], ngram_buckets=100000, batch_size=batch_size, window_size=5)
 ```
 
 ```{.python .input}
@@ -158,7 +158,7 @@ its ngrams.
 FastText models use a hash function to map each ngram of a word to
 a number in range `[0, num_subwords)`. We include the same hash function.
 Above
-transform_data has also returned a `subword_function` object. Let's try it with
+`transform_data_fasttext` has also returned a `subword_function` object. Let's try it with
 a few words:
 
 ```{.python .input}

--- a/scripts/tests/test_scripts.py
+++ b/scripts/tests/test_scripts.py
@@ -1,7 +1,8 @@
+import os
 import subprocess
+import time
 
 import pytest
-import time
 
 from ..machine_translation.dataset import TOY
 
@@ -51,11 +52,37 @@ def test_skipgram_cbow(model, fasttext):
 
 @pytest.mark.serial
 @pytest.mark.remote_required
-def test_embedding_evaluate_pretrained():
-    subprocess.check_call([
+@pytest.mark.parametrize('fasttextloadngrams', [True, False])
+def test_embedding_evaluate_pretrained(fasttextloadngrams):
+    cmd = [
         'python', './scripts/word_embeddings/evaluate_pretrained.py',
         '--embedding-name', 'fasttext', '--embedding-source', 'wiki.simple'
-    ])
+    ]
+    if fasttextloadngrams:
+        cmd.append('--fasttext-load-ngrams')
+
+    subprocess.check_call(cmd)
+    time.sleep(5)
+
+
+@pytest.mark.serial
+@pytest.mark.remote_required
+@pytest.mark.parametrize('evaluatanalogies', [True, False])
+@pytest.mark.parametrize('maxvocabsize', [None, 16])
+def test_embedding_evaluate_from_path(evaluatanalogies, maxvocabsize):
+    path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+    path = os.path.join(
+        path, '../../tests/unittest/train/test_embedding/lorem_ipsum.bin')
+    cmd = [
+        'python', './scripts/word_embeddings/evaluate_pretrained.py',
+        '--embedding-path', path]
+    if evaluatanalogies:
+        cmd += ['--analogy-datasets', 'GoogleAnalogyTestSet']
+    else:
+        cmd += ['--analogy-datasets']
+    if maxvocabsize is not None:
+        cmd += ['--max-vocab-size', str(maxvocabsize)]
+    subprocess.check_call(cmd)
     time.sleep(5)
 
 

--- a/scripts/tests/test_scripts.py
+++ b/scripts/tests/test_scripts.py
@@ -35,7 +35,7 @@ def test_toy():
 @pytest.mark.gpu
 def test_embedding():
     process = subprocess.check_call([
-        'python', './scripts/word_embeddings/train_fasttext.py', '--gpu', '0',
+        'python', './scripts/word_embeddings/train_sg_cbow.py', '--gpu', '0',
         '--epochs', '1', '--optimizer', 'sgd', '--ngram-buckets', '100',
         '--max-vocab-size', '100', '--batch-size', '64'
     ])

--- a/scripts/tests/test_scripts.py
+++ b/scripts/tests/test_scripts.py
@@ -33,19 +33,26 @@ def test_toy():
 @pytest.mark.serial
 @pytest.mark.remote_required
 @pytest.mark.gpu
-def test_embedding():
-    process = subprocess.check_call([
+@pytest.mark.parametrize('model', ['skipgram', 'cbow'])
+@pytest.mark.parametrize('fasttext', [True, False])
+def test_skipgram_cbow(model, fasttext):
+    cmd = [
         'python', './scripts/word_embeddings/train_sg_cbow.py', '--gpu', '0',
-        '--epochs', '1', '--optimizer', 'sgd', '--ngram-buckets', '100',
-        '--max-vocab-size', '100', '--batch-size', '64'
-    ])
+        '--epochs', '2', '--optimizer', 'sgd', '--model', model,
+        '--data', 'toy', '--batch-size', '64'
+    ]
+    if fasttext:
+        cmd += ['--ngram-buckets', '1000']
+    else:
+        cmd += ['--ngram-buckets', '0']
+    subprocess.check_call(cmd)
     time.sleep(5)
 
 
 @pytest.mark.serial
 @pytest.mark.remote_required
 def test_embedding_evaluate_pretrained():
-    process = subprocess.check_call([
+    subprocess.check_call([
         'python', './scripts/word_embeddings/evaluate_pretrained.py',
         '--embedding-name', 'fasttext', '--embedding-source', 'wiki.simple'
     ])

--- a/scripts/word_embeddings/data.py
+++ b/scripts/word_embeddings/data.py
@@ -44,7 +44,7 @@ from gluonnlp.data import CorpusDataset, SimpleDatasetStream
 from utils import print_time
 
 
-def text8(min_freq=5, max_vocab_size=None):
+def text8(min_freq=5, max_vocab_size=None, toy=False):
     """Text8 dataset helper.
 
     Parameters
@@ -54,6 +54,8 @@ def text8(min_freq=5, max_vocab_size=None):
         and returned DataStream.
     max_vocab_size : int, optional
         Specifies a maximum size for the vocabulary.
+    toy : bool
+        Toy mode. If True, only return first 20000 words.
 
     Returns
     -------
@@ -70,6 +72,8 @@ def text8(min_freq=5, max_vocab_size=None):
     """
     with print_time('read data'):
         data = nlp.data.Text8(segment='train')
+        if toy:
+            data = mx.gluon.data.SimpleDataset(data[:2])
         counter = nlp.data.count_tokens(itertools.chain.from_iterable(data))
         vocab = nlp.Vocab(counter, unknown_token=None, padding_token=None,
                           bos_token=None, eos_token=None, min_freq=min_freq,

--- a/scripts/word_embeddings/data.py
+++ b/scripts/word_embeddings/data.py
@@ -75,6 +75,12 @@ def text8(min_freq=5, max_vocab_size=None):
                           bos_token=None, eos_token=None, min_freq=min_freq,
                           max_size=max_vocab_size)
         idx_to_counts = [counter[w] for w in vocab.idx_to_token]
+
+    def code(sentence):
+        return [vocab[token] for token in sentence if token in vocab]
+
+    with print_time('code data'):
+        data = data.transform(code, lazy=False)
     data = nlp.data.SimpleDataStream([data])
     return data, vocab, idx_to_counts
 
@@ -115,6 +121,12 @@ def wiki(wiki_root, wiki_date, wiki_language, max_vocab_size=None):
             vocab.token_to_idx.pop(token)
         vocab.idx_to_token = vocab.idx_to_token[:max_vocab_size]
     idx_to_counts = data.idx_to_counts
+
+    def code(shard):
+        return [[vocab[token] for token in sentence if token in vocab]
+                for sentence in shard]
+
+    data = data.transform(code)
     return data, vocab, idx_to_counts
 
 
@@ -179,12 +191,6 @@ def transform_data_fasttext(data, vocab, idx_to_counts, cbow, ngram_buckets,
     if ngram_buckets <= 0:
         raise ValueError('Invalid ngram_buckets. Use Word2Vec training '
                          'pipeline if not interested in ngrams.')
-
-    def code(shard):
-        return [[vocab[token] for token in sentence if token in vocab]
-                for sentence in shard]
-
-    data = data.transform(code)
 
     sum_counts = float(sum(idx_to_counts))
     idx_to_pdiscard = [
@@ -282,12 +288,6 @@ def transform_data_word2vec(data, vocab, idx_to_counts, cbow, batch_size,
     gluonnlp.data.DataStream
         Stream over batches.
     """
-
-    def code(shard):
-        return [[vocab[token] for token in sentence if token in vocab]
-                for sentence in shard]
-
-    data = data.transform(code)
 
     sum_counts = float(sum(idx_to_counts))
     idx_to_pdiscard = [

--- a/scripts/word_embeddings/data.py
+++ b/scripts/word_embeddings/data.py
@@ -21,7 +21,7 @@
 """Word embedding training datasets."""
 
 __all__ = [
-    'WikiDumpStream', 'text8', 'wiki', 'transform_data_fasttext',
+    'WikiDumpStream', 'preprocess_dataset', 'wiki', 'transform_data_fasttext',
     'transform_data_word2vec', 'skipgram_lookup', 'cbow_lookup',
     'skipgram_fasttext_batch', 'cbow_fasttext_batch', 'skipgram_batch',
     'cbow_batch']
@@ -44,18 +44,18 @@ from gluonnlp.data import CorpusDataset, SimpleDatasetStream
 from utils import print_time
 
 
-def text8(min_freq=5, max_vocab_size=None, toy=False):
-    """Text8 dataset helper.
+def preprocess_dataset(data, min_freq=5, max_vocab_size=None):
+    """Dataset preprocessing helper.
 
     Parameters
     ----------
+    data : mx.data.Dataset
+        Input Dataset. For example gluonnlp.data.Text8 or gluonnlp.data.Fil9
     min_freq : int, default 5
         Minimum token frequency for a token to be included in the vocabulary
         and returned DataStream.
     max_vocab_size : int, optional
         Specifies a maximum size for the vocabulary.
-    toy : bool
-        Toy mode. If True, only return first 20000 words.
 
     Returns
     -------
@@ -70,10 +70,7 @@ def text8(min_freq=5, max_vocab_size=None, toy=False):
         dataset.
 
     """
-    with print_time('read data'):
-        data = nlp.data.Text8(segment='train')
-        if toy:
-            data = mx.gluon.data.SimpleDataset(data[:2])
+    with print_time('count and construct vocabulary'):
         counter = nlp.data.count_tokens(itertools.chain.from_iterable(data))
         vocab = nlp.Vocab(counter, unknown_token=None, padding_token=None,
                           bos_token=None, eos_token=None, min_freq=min_freq,

--- a/scripts/word_embeddings/index.rst
+++ b/scripts/word_embeddings/index.rst
@@ -38,7 +38,7 @@ Word Embedding Training
 Besides loading pre-trained embeddings, the Gluon NLP toolkit also makes it easy
 to train embeddings.
 
-The following code block shows how to use Gluon NLP to train fastText or Word2Vec
+The following code block shows how to use Gluon NLP to train a SkipGram or CBOW
 models. The script and parts of the Gluon NLP library support just-in-time
 compilation with `numba <http://numba.pydata.org/>`_, which is enabled
 automatically when numba is installed on the system. Please `pip
@@ -47,59 +47,56 @@ by Python.
 
 .. code-block:: console
 
-   $ python train_fasttext.py
+   $ python train_sg_cbow.py --model skipgram --ngram-buckts 0  # Word2Vec
+   $ python train_sg_cbow.py --model skipgram --ngram-buckts 2000000  # fastText
+   $ python train_sg_cbow.py --model cbow --ngram-buckts 0  # Word2Vec
+   $ python train_sg_cbow.py --model cbow --ngram-buckts 2000000  # fastText
 
+Word2Vec models were introduced by Mikolov et al., "Efficient estimation of word
+representations in vector space" ICLR Workshop 2013. FastText models were
+introudced by Bojanowski et al., "Enriching word vectors with subword
+information" TACL 2017.
 
-Word2Vec models were introduced by
-
-- Tomas Mikolov, Kai Chen, Greg Corrado, and Jeffrey Dean. Efficient estimation
-  of word representations in vector space. ICLR Workshop , 2013.
-
-FastText models were introudced by
-
-- Bojanowski, P., Grave, E., Joulin, A., & Mikolov, T. (2017). Enriching word
-  vectors with subword information. TACL, 5(), 135–146.
-
-We report the results obtained by running the :code:`train_fasttext.py` script with
-default parameters. You can reproduce these results with runningand `python
-train_fasttext.py --gpu 0` respectively. For comparison we also report the
-results obtained by training FastText with the `facebookresearch/fastText
-implementation <https://github.com/facebookresearch/fastText>`_. All results are
-obtained by training 5 epochs on the `Text8
-<http://mattmahoney.net/dc/textdata.html>`_ dataset.
+We report the results obtained by running the :code:`python3
+train_sg_cbow.py --batch-size 4096 --epochs 5 --data fil9 --model skipgram`
+script.For comparison we also report the results obtained by training FastText
+with the `facebookresearch/fastText implementation
+<https://github.com/facebookresearch/fastText>`_. All results are obtained by
+training 5 epochs on the `Fil9 <http://mattmahoney.net/dc/textdata.html>`_
+dataset.
 
 ======================================  ===========================  ===================
-Similarity Dataset                        facebookresearch/fasttext    train_fasttext.py
+Similarity Dataset                        facebookresearch/fastText    train_sg_cbow.py
 ======================================  ===========================  ===================
-WordSim353-similarity                                     0.670                0.685
-WordSim353-relatedness                                    0.557                0.592
-MEN (test set)                                            0.665                0.629
-RadinskyMTurk                                             0.640                0.609
-RareWords                                                 0.400                0.429
-SimLex999                                                 0.300                0.323
-SimVerb3500                                               0.170                0.191
-SemEval17Task2 (test set)                                 0.540                0.566
-BakerVerb143                                              0.390                0.363
-YangPowersVerb130                                         0.424                0.366
+WordSim353-similarity                                     0.752                0.734
+WordSim353-relatedness                                    0.612                0.608
+MEN (test set)                                            0.736                0.700
+RadinskyMTurk                                             0.687                0.655
+RareWords                                                 0.420                0.457
+SimLex999                                                 0.320                0.346
+SimVerb3500                                               0.190                0.235
+SemEval17Task2 (test set)                                 0.541                0.542
+BakerVerb143                                              0.406                0.383
+YangPowersVerb130                                         0.489                0.466
 ======================================  ===========================  ===================
 
 ===========================================  ===========================  ===================
-Google Analogy Dataset                        facebookresearch/fasttext    train_fasttext.py
+Google Analogy Dataset                        facebookresearch/fastText    train_sg_cbow.py
 ===========================================  ===========================  ===================
-capital-common-countries                              0.581                0.470
-capital-world                                         0.176                0.148
-currency                                              0.046                0.043
-city-in-state                                         0.100                0.076
-family                                                0.375                0.342
-gram1-adjective-to-adverb                             0.695                0.663
-gram2-opposite                                        0.539                0.700
-gram3-comparative                                     0.523                0.740
-gram4-superlative                                     0.523                0.535
-gram5-present-participle                              0.480                0.399
-gram6-nationality-adjective                           0.830                0.830
-gram7-past-tense                                      0.269                0.200
-gram8-plural                                          0.703                0.860
-gram9-plural-verbs                                    0.575                0.800
+capital-common-countries                              0.796                0.581
+capital-world                                         0.442                0.334
+currency                                              0.068                0.074
+city-in-state                                         0.198                0.076
+family                                                0.498                0.593
+gram1-adjective-to-adverb                             0.377                0.688
+gram2-opposite                                        0.343                0.693
+gram3-comparative                                     0.646                0.868
+gram4-superlative                                     0.510                0.757
+gram5-present-participle                              0.445                0.792
+gram6-nationality-adjective                           0.828                0.840
+gram7-past-tense                                      0.385                0.380
+gram8-plural                                          0.706                0.810
+gram9-plural-verbs                                    0.501                0.813
 ===========================================  ===========================  ===================
 
 Loading of fastText models with subword information

--- a/scripts/word_embeddings/index.rst
+++ b/scripts/word_embeddings/index.rst
@@ -47,10 +47,10 @@ by Python.
 
 .. code-block:: console
 
-   $ python train_sg_cbow.py --model skipgram --ngram-buckts 0  # Word2Vec
-   $ python train_sg_cbow.py --model skipgram --ngram-buckts 2000000  # fastText
-   $ python train_sg_cbow.py --model cbow --ngram-buckts 0  # Word2Vec
-   $ python train_sg_cbow.py --model cbow --ngram-buckts 2000000  # fastText
+   $ python train_sg_cbow.py --model skipgram --ngram-buckts 0  # Word2Vec Skipgram
+   $ python train_sg_cbow.py --model skipgram --ngram-buckts 2000000  # fastText Skipgram
+   $ python train_sg_cbow.py --model cbow --ngram-buckts 0  # Word2Vec CBOW
+   $ python train_sg_cbow.py --model cbow --ngram-buckts 2000000  # fastText CBOW
 
 Word2Vec models were introduced by Mikolov et al., "Efficient estimation of word
 representations in vector space" ICLR Workshop 2013. FastText models were

--- a/scripts/word_embeddings/train_sg_cbow.py
+++ b/scripts/word_embeddings/train_sg_cbow.py
@@ -45,7 +45,7 @@ import gluonnlp as nlp
 import evaluation
 from utils import get_context, print_time
 from model import SG, CBOW
-from data import transform_data, text8, wiki
+from data import transform_data_word2vec, transform_data_fasttext, text8, wiki
 
 
 def parse_args():
@@ -145,10 +145,19 @@ def train(args):
         data, vocab, idx_to_counts = wiki(args.wiki_root, args.wiki_date,
                                           args.wiki_language,
                                           args.max_vocab_size)
-    data, batchify_fn, subword_function = transform_data(
-        data, vocab, idx_to_counts,
-        args.model.lower() == 'cbow', args.ngram_buckets, args.ngrams,
-        args.batch_size, args.window, args.frequent_token_subsampling)
+
+    if args.ngram_buckets > 0:
+        data, batchify_fn, subword_function = transform_data_fasttext(
+            data, vocab, idx_to_counts,
+            args.model.lower() == 'cbow', args.ngram_buckets, args.ngrams,
+            args.batch_size, args.window, args.frequent_token_subsampling)
+    else:
+        subword_function = None
+        data, batchify_fn = transform_data_word2vec(
+            data, vocab, idx_to_counts,
+            args.model.lower() == 'cbow', args.ngram_buckets, args.ngrams,
+            args.batch_size, args.window, args.frequent_token_subsampling)
+
     num_tokens = float(sum(idx_to_counts))
 
     model = CBOW if args.model.lower() == 'cbow' else SG

--- a/scripts/word_embeddings/train_sg_cbow.py
+++ b/scripts/word_embeddings/train_sg_cbow.py
@@ -18,22 +18,17 @@
 # under the License.
 
 # pylint: disable=global-variable-undefined,wrong-import-position
-"""Fasttext embedding model
-===========================
+"""SkipGram and CBOW embedding models
+=====================================
 
-This example shows how to train a FastText embedding model on Text8 with the
-Gluon NLP Toolkit.
+This example shows how to train SkipGram (SG) and Continuous Bag of Words
+(CBOW) embedding models with the Gluon NLP Toolkit. Including fastText style
+subword information is supported.
 
-The FastText embedding model was introduced by
-
-- Bojanowski, P., Grave, E., Joulin, A., & Mikolov, T. (2017). Enriching word
-  vectors with subword information. TACL, 5(), 135–146.
-
-When setting --ngram-buckets to 0, a Word2Vec embedding model is trained. The
-Word2Vec embedding model was introduced by
-
-- Tomas Mikolov, Kai Chen, Greg Corrado, and Jeffrey Dean. Efficient estimation
-  of word representations in vector space. ICLR Workshop , 2013
+The SG and CBOW models were introduced by "Mikolov et al. Efficient estimation
+of word representations in vector space. ICLR Workshop, 2013". The fastText
+model was introduced by "Bojanowski et al. Enriching word vectors with subword
+information. TACL 2017"
 
 """
 import argparse

--- a/scripts/word_embeddings/train_sg_cbow.py
+++ b/scripts/word_embeddings/train_sg_cbow.py
@@ -45,7 +45,7 @@ import gluonnlp as nlp
 import evaluation
 from utils import get_context, print_time
 from model import SG, CBOW
-from data import transform_data_word2vec, transform_data_fasttext, text8, wiki
+from data import transform_data_word2vec, transform_data_fasttext, preprocess_dataset, wiki
 
 
 def parse_args():
@@ -142,10 +142,17 @@ def train(args):
         sys.exit(1)
 
     if args.data.lower() == 'toy':
-        data, vocab, idx_to_counts = text8(max_vocab_size=args.max_vocab_size,
-                                           toy=True)
+        data = mx.gluon.data.SimpleDataset(nlp.data.Text8(segment='train')[:2])
+        data, vocab, idx_to_counts = preprocess_dataset(
+            data, max_vocab_size=args.max_vocab_size)
     elif args.data.lower() == 'text8':
-        data, vocab, idx_to_counts = text8(max_vocab_size=args.max_vocab_size)
+        data = nlp.data.Text8(segment='train')
+        data, vocab, idx_to_counts = preprocess_dataset(
+            data, max_vocab_size=args.max_vocab_size)
+    elif args.data.lower() == 'fil9':
+        data = nlp.data.Fil9(max_sentence_length=10000)
+        data, vocab, idx_to_counts = preprocess_dataset(
+            data, max_vocab_size=args.max_vocab_size)
     elif args.data.lower() == 'wiki':
         data, vocab, idx_to_counts = wiki(args.wiki_root, args.wiki_date,
                                           args.wiki_language,

--- a/scripts/word_embeddings/train_sg_cbow.py
+++ b/scripts/word_embeddings/train_sg_cbow.py
@@ -141,7 +141,10 @@ def train(args):
         logging.error('Unsupported model %s.', args.model)
         sys.exit(1)
 
-    if args.data.lower() == 'text8':
+    if args.data.lower() == 'toy':
+        data, vocab, idx_to_counts = text8(max_vocab_size=args.max_vocab_size,
+                                           toy=True)
+    elif args.data.lower() == 'text8':
         data, vocab, idx_to_counts = text8(max_vocab_size=args.max_vocab_size)
     elif args.data.lower() == 'wiki':
         data, vocab, idx_to_counts = wiki(args.wiki_root, args.wiki_date,
@@ -150,15 +153,16 @@ def train(args):
 
     if args.ngram_buckets > 0:
         data, batchify_fn, subword_function = transform_data_fasttext(
-            data, vocab, idx_to_counts,
-            args.model.lower() == 'cbow', args.ngram_buckets, args.ngrams,
-            args.batch_size, args.window, args.frequent_token_subsampling)
+            data, vocab, idx_to_counts, cbow=args.model.lower() == 'cbow',
+            ngram_buckets=args.ngram_buckets, ngrams=args.ngrams,
+            batch_size=args.batch_size, window_size=args.window,
+            frequent_token_subsampling=args.frequent_token_subsampling)
     else:
         subword_function = None
         data, batchify_fn = transform_data_word2vec(
-            data, vocab, idx_to_counts,
-            args.model.lower() == 'cbow', args.ngram_buckets, args.ngrams,
-            args.batch_size, args.window, args.frequent_token_subsampling)
+            data, vocab, idx_to_counts, cbow=args.model.lower() == 'cbow',
+            batch_size=args.batch_size, window_size=args.window,
+            frequent_token_subsampling=args.frequent_token_subsampling)
 
     num_tokens = float(sum(idx_to_counts))
 

--- a/tests/unittest/batchify/test_batchify_embedding.py
+++ b/tests/unittest/batchify/test_batchify_embedding.py
@@ -35,11 +35,9 @@ def test_center_context_batchify_stream(reduce_window_size_randomly, shuffle,
                                         cbow, stream):
     dataset = [np.arange(100).tolist()] * 3
     batchify = nlp.data.batchify.EmbeddingCenterContextBatchify(
-        batch_size=8,
-        window_size=5,
+        batch_size=8, window_size=5,
         reduce_window_size_randomly=reduce_window_size_randomly,
-        shuffle=shuffle,
-        cbow=cbow)
+        shuffle=shuffle, cbow=cbow)
     if stream:
         stream = nlp.data.SimpleDataStream([dataset, dataset])
         batches = list(
@@ -56,27 +54,32 @@ def test_center_context_batchify_stream(reduce_window_size_randomly, shuffle,
 
 
 @pytest.mark.parametrize('cbow', [True, False])
-def test_center_context_batchify(cbow):
-    dataset = [np.arange(100).tolist()]
-    batchify = nlp.data.batchify.EmbeddingCenterContextBatchify(
-        batch_size=3, window_size=1, cbow=cbow)
-    samples = batchify(dataset)
+@pytest.mark.parametrize('dtype', [np.float64, np.int64, np.dtype('O')])
+@pytest.mark.parametrize('weight_dtype', [np.float64, np.float32, np.float16])
+@pytest.mark.parametrize('index_dtype', [np.int64, np.int32])
+def test_center_context_batchify(cbow, dtype, weight_dtype, index_dtype):
+    dtype_fn = dtype if dtype is not np.dtype('O') else str
+    dataset = [[dtype_fn(i) for i in range(100)] * 2]
 
+    batchify = nlp.data.batchify.EmbeddingCenterContextBatchify(
+        batch_size=3, window_size=1, cbow=cbow, weight_dtype=weight_dtype,
+        index_dtype=index_dtype)
+    samples = batchify(dataset)
     center, context = next(iter(samples))
     (contexts_data, contexts_row, contexts_col) = context
 
-    assert center.dtype == np.int64
-    assert contexts_data.dtype == np.float32
-    assert contexts_row.dtype == np.int64
-    assert contexts_col.dtype == np.int64
+    assert center.dtype == dtype
+    assert contexts_data.dtype == weight_dtype
+    assert contexts_row.dtype == index_dtype
+    assert contexts_col.dtype == dtype
 
     if cbow:
-        assert center.asnumpy().tolist() == [0, 1, 2]
-        assert contexts_data.asnumpy().tolist() == [1, 0.5, 0.5, 0.5, 0.5]
-        assert contexts_row.asnumpy().tolist() == [0, 1, 1, 2, 2]
-        assert contexts_col.asnumpy().tolist() == [1, 0, 2, 1, 3]
+        assert center.tolist() == [dtype_fn(i) for i in [0, 1, 2]]
+        assert contexts_data.tolist() == [1, 0.5, 0.5, 0.5, 0.5]
+        assert contexts_row.tolist() == [0, 1, 1, 2, 2]
+        assert contexts_col.tolist() == [dtype_fn(i) for i in [1, 0, 2, 1, 3]]
     else:
-        assert center.asnumpy().tolist() == [0, 1, 1]
-        assert contexts_data.asnumpy().tolist() == [1, 1, 1]
-        assert contexts_row.asnumpy().tolist() == [0, 1, 2]
-        assert contexts_col.asnumpy().tolist() == [1, 0, 2]
+        assert center.tolist() == [dtype_fn(i) for i in [0, 1, 1]]
+        assert contexts_data.tolist() == [1, 1, 1]
+        assert contexts_row.tolist() == [0, 1, 2]
+        assert contexts_col.tolist() == [dtype_fn(i) for i in [1, 0, 2]]


### PR DESCRIPTION
## Description ##
This adds support for arbitrary dtype to EmbeddingCenterContextBatchify. Also some refactoring of the `data.py` in the word embedding scripts folder is done. Further `train_fasttext.py` is renamed to `train_sg_cbow.py` to better reflect it's scope.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Support arbitrary dtypes in EmbeddingCenterContextBatchify

## Comments ##
As NDArray does not support arbitrary dtype (e.g. string / python object), the returned types of EmbeddingCenterContextBatchify are changed to numpy arrays.
Todo: Update example notebook for changed `data.py`