### PR TITLE
Include output of nlp.embedding.list_sources() in API docs

### DIFF
--- a/docs/api/modules/embedding.rst
+++ b/docs/api/modules/embedding.rst
@@ -24,6 +24,7 @@ Pre-trained Embeddings
     TokenEmbedding
     GloVe
     FastText
+    Word2Vec
 
 
 Intrinsic evaluation

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,7 @@ extensions = [
     'nbsphinx',
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
+    'sphinx_autorun',
 ]
 
 doctest_global_setup = '''

--- a/env/doc.yml
+++ b/env/doc.yml
@@ -23,3 +23,4 @@ dependencies:
     - seaborn
     - sentencepiece
     - jieba
+    - sphinx-autorun

--- a/src/gluonnlp/embedding/evaluation.py
+++ b/src/gluonnlp/embedding/evaluation.py
@@ -26,9 +26,8 @@ from mxnet.gluon import HybridBlock
 __all__ = [
     'register', 'create', 'list_evaluation_functions',
     'WordEmbeddingSimilarityFunction', 'WordEmbeddingAnalogyFunction',
-    'CosineSimilarity', 'ThreeCosMul', 'WordEmbeddingSimilarity',
-    'WordEmbeddingAnalogy'
-]
+    'CosineSimilarity', 'ThreeCosMul', 'ThreeCosAdd',
+    'WordEmbeddingSimilarity', 'WordEmbeddingAnalogy']
 
 
 class _WordEmbeddingEvaluationFunction(HybridBlock):  # pylint: disable=abstract-method
@@ -113,8 +112,9 @@ def create(kind, name, **kwargs):
 
     Parameters
     ----------
-    kind : ['similarity', 'analogy', None]
-        Return only valid names for similarity, analogy or both kinds of functions.
+    kind : ['similarity', 'analogy']
+        Return only valid names for similarity, analogy or both kinds of
+        functions.
     name : str
         The evaluation function name (case-insensitive).
 
@@ -128,10 +128,11 @@ def create(kind, name, **kwargs):
         An instance of the specified evaluation function.
 
     """
-    if not kind in _REGSITRY_KIND_CLASS_MAP.keys():
-        raise KeyError('Cannot find `kind` {}. Use '
-                       '`list_sources(kind=None).keys()` to get all the valid'
-                       'kinds of evaluation functions.'.format(kind))
+    if kind not in _REGSITRY_KIND_CLASS_MAP.keys():
+        raise KeyError(
+            'Cannot find `kind` {}. Use '
+            '`list_evaluation_functions(kind=None).keys()` to get'
+            'all the valid kinds of evaluation functions.'.format(kind))
 
     create_ = registry.get_create_func(
         _REGSITRY_KIND_CLASS_MAP[kind],
@@ -165,8 +166,8 @@ def list_evaluation_functions(kind=None):
         if kind not in _REGSITRY_KIND_CLASS_MAP.keys():
             raise KeyError(
                 'Cannot find `kind` {}. Use '
-                '`list_sources(kind=None).keys()` to get all the valid'
-                'kinds of evaluation functions.'.format(kind))
+                '`list_evaluation_functions(kind=None).keys()` to get all the'
+                'valid kinds of evaluation functions.'.format(kind))
 
         reg = registry.get_registry(_REGSITRY_KIND_CLASS_MAP[kind])
         return list(reg.keys())
@@ -313,6 +314,7 @@ class ThreeCosAdd(WordEmbeddingAnalogyFunction):
         \\arg\\max_{b^* ∈ V}[\\cos(b^∗, b - a + a^*)]
 
     See the following paper for more details:
+
     - Levy, O., & Goldberg, Y. (2014). Linguistic regularities in sparse and
       explicit word representations. In R. Morante, & W. Yih, Proceedings of the
       Eighteenth Conference on Computational Natural Language Learning, CoNLL 2014,

--- a/src/gluonnlp/embedding/token_embedding.py
+++ b/src/gluonnlp/embedding/token_embedding.py
@@ -799,16 +799,20 @@ class GloVe(TokenEmbedding):
     Jeffrey Pennington, Richard Socher, and Christopher D. Manning.
     https://nlp.stanford.edu/pubs/glove.pdf
 
-    Website:
-
-    https://nlp.stanford.edu/projects/glove/
+    Website: https://nlp.stanford.edu/projects/glove/
 
     To get the updated URLs to the externally hosted pre-trained token embedding
     files, visit https://nlp.stanford.edu/projects/glove/
 
-    License for pre-trained embedding:
+    License for pre-trained embedding: https://opendatacommons.org/licenses/pddl/
 
-    https://opendatacommons.org/licenses/pddl/
+    Available sources
+
+    .. runblock:: pycon
+
+        >>> import warnings; warnings.filterwarnings('ignore');
+        >>> import gluonnlp as nlp
+        >>> nlp.embedding.list_sources('GloVe')
 
     Parameters
     ----------
@@ -873,16 +877,21 @@ class FastText(TokenEmbedding):
     Alexis Conneau, Guillaume Lample, Marc'Aurelio Ranzato, Ludovic Denoyer, and Herve Jegou.
     https://arxiv.org/abs/1710.04087
 
-    Website:
-
-    https://fasttext.cc/
+    Website: https://fasttext.cc/
 
     To get the updated URLs to the externally hosted pre-trained token embedding files, visit
     https://github.com/facebookresearch/fastText/blob/master/pretrained-vectors.md
 
-    License for pre-trained embedding:
+    License for pre-trained embedding: https://creativecommons.org/licenses/by-sa/3.0/
 
-    https://creativecommons.org/licenses/by-sa/3.0/
+    Available sources
+
+    .. runblock:: pycon
+
+        >>> import warnings; warnings.filterwarnings('ignore');
+        >>> import gluonnlp as nlp
+        >>> nlp.embedding.list_sources('FastText')
+
 
     Parameters
     ----------
@@ -971,13 +980,17 @@ class Word2Vec(TokenEmbedding):
     in Continuous Space Word Representations. In Proceedings of NAACL HLT,
     2013.
 
-    Website:
+    Website: https://code.google.com/archive/p/word2vec/
 
-    https://code.google.com/archive/p/word2vec/
+    License for pre-trained embedding: Unspecified
 
-    License for pre-trained embedding:
+    Available sources
 
-    Unspecified
+    .. runblock:: pycon
+
+        >>> import warnings; warnings.filterwarnings('ignore');
+        >>> import gluonnlp as nlp
+        >>> nlp.embedding.list_sources('Word2Vec')
 
     Parameters
     ----------

--- a/src/gluonnlp/embedding/token_embedding.py
+++ b/src/gluonnlp/embedding/token_embedding.py
@@ -126,7 +126,8 @@ def list_sources(embedding_name=None):
 
     text_embedding_reg = registry.get_registry(TokenEmbedding)
 
-    if embedding_name:
+    if embedding_name is not None:
+        embedding_name = embedding_name.lower()
         if embedding_name not in text_embedding_reg:
             raise KeyError('Cannot find `embedding_name` {}. Use '
                            '`list_sources(embedding_name=None).keys()` to get all the valid'


### PR DESCRIPTION
## Description ##
Previously the API docs only explain how to obtain the list of supported sources. Users must run this themselves. Instead, with this PR, include output of nlp.embedding.list_sources() in API docs.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Include output of nlp.embedding.list_sources() in API docs

## Comments ##
Fixes https://github.com/dmlc/gluon-nlp/issues/396