### PR TITLE
[SCRIPT] Improve BERT fine-tuning script with AdamW optimizer, bucketing and gradient accumulation

### DIFF
--- a/scripts/bert/compare_tf_gluon_model.py
+++ b/scripts/bert/compare_tf_gluon_model.py
@@ -138,6 +138,7 @@ bert, vocabulary = nlp.model.get_model(args.gluon_model,
                                        dataset_name=args.gluon_dataset,
                                        pretrained=True, use_pooler=False,
                                        use_decoder=False, use_classifier=False)
+print(bert)
 tokenizer = FullTokenizer(vocabulary, do_lower_case=do_lower_case)
 dataset = TSVDataset(input_file, field_separator=nlp.data.Splitter(' ||| '))
 

--- a/scripts/bert/compare_tf_gluon_model.py
+++ b/scripts/bert/compare_tf_gluon_model.py
@@ -160,4 +160,5 @@ for i, seq in enumerate(bert_dataloader):
     mx.test_utils.assert_almost_equal(a, b, atol=1e-4, rtol=1e-4)
     mx.test_utils.assert_almost_equal(a, b, atol=1e-5, rtol=1e-5)
     mx.test_utils.assert_almost_equal(a, b, atol=5e-6, rtol=5e-6)
+    mx.test_utils.assert_almost_equal(a, b, atol=2e-6, rtol=2e-6)
     break

--- a/scripts/bert/dataset.py
+++ b/scripts/bert/dataset.py
@@ -192,6 +192,7 @@ class BERTTransform(object):
         if self._pad:
             # Zero-pad up to the sequence length.
             padding_length = self._max_seq_length - valid_length
+            # use padding tokens for the rest
             input_ids.extend([self._tokenizer.vocab['[PAD]']] * padding_length)
             segment_ids.extend([self._tokenizer.vocab['[PAD]']] * padding_length)
 

--- a/scripts/bert/dataset.py
+++ b/scripts/bert/dataset.py
@@ -192,8 +192,8 @@ class BERTTransform(object):
         if self._pad:
             # Zero-pad up to the sequence length.
             padding_length = self._max_seq_length - valid_length
-            input_ids.extend([0] * padding_length)
-            segment_ids.extend([0] * padding_length)
+            input_ids.extend([self._tokenizer.vocab['[PAD]']] * padding_length)
+            segment_ids.extend([self._tokenizer.vocab['[PAD]']] * padding_length)
 
         return np.array(input_ids, dtype='int32'), np.array(valid_length, dtype='int32'),\
                np.array(segment_ids, dtype='int32')

--- a/scripts/bert/finetune_classifier.py
+++ b/scripts/bert/finetune_classifier.py
@@ -110,6 +110,7 @@ train_trans = ClassificationTransform(tokenizer, MRPCDataset.get_labels(),
 dev_trans = ClassificationTransform(tokenizer, MRPCDataset.get_labels(), args.max_len)
 
 data_train = MRPCDataset('train').transform(train_trans, lazy=False)
+data_dev = MRPCDataset('dev').transform(dev_trans, lazy=False)
 data_train_len = data_train.transform(lambda input_id, length, segment_id, label_id: length)
 
 batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(axis=0),

--- a/scripts/bert/finetune_classifier.py
+++ b/scripts/bert/finetune_classifier.py
@@ -229,4 +229,9 @@ def train():
         tic = toc
 
 if __name__ == '__main__':
+    pool_type = os.environ.get('MXNET_GPU_MEM_POOL_TYPE', '')
+    if pool_type.lower() == 'round':
+        logging.info('Setting MXNET_GPU_MEM_POOL_TYPE="Round" may lead to higher memory '
+                     'usage and faster speed. If you encounter OOM errors, please unset '
+                     'this environment variable.')
     train()

--- a/scripts/bert/finetune_classifier.py
+++ b/scripts/bert/finetune_classifier.py
@@ -229,9 +229,4 @@ def train():
         tic = toc
 
 if __name__ == '__main__':
-    pool_type = os.environ.get('MXNET_GPU_MEM_POOL_TYPE', '')
-    if pool_type.lower() == 'round':
-        logging.info('Setting MXNET_GPU_MEM_POOL_TYPE="Round" may lead to higher memory '
-                     'usage and faster speed. If you encounter OOM errors, please unset '
-                     'this environment variable.')
     train()

--- a/scripts/bert/finetune_classifier.py
+++ b/scripts/bert/finetune_classifier.py
@@ -35,8 +35,6 @@ sentence pair classification, with Gluon NLP Toolkit.
 # pylint:disable=redefined-outer-name,logging-format-interpolation
 
 import os
-os.environ['MXNET_GPU_MEM_POOL_TYPE'] = 'Round'
-
 import time
 import argparse
 import random
@@ -224,4 +222,9 @@ def train():
         tic = toc
 
 if __name__ == '__main__':
+    pool_type = os.environ.get('MXNET_GPU_MEM_POOL_TYPE', '')
+    if pool_type.lower() == 'round':
+        logging.info('Setting MXNET_GPU_MEM_POOL_TYPE="Round" may lead to higher memory '
+                     'usage and faster speed. If you encounter OOM errors, please unset '
+                     'this environment variable.')
     train()

--- a/scripts/bert/index.rst
+++ b/scripts/bert/index.rst
@@ -34,6 +34,6 @@ Use the following command to fine-tune the BERT model for classification on the 
 
 .. code-block:: console
 
-   $ GLUE_DIR=glue_data python3 finetune_classifier.py --batch_size 32 --optimizer adamw --epochs 2 --gpu --seed 2 --lr 6e-5
+   $ MXNET_GPU_MEM_POOL_TYPE=Round GLUE_DIR=glue_data python3 finetune_classifier.py --batch_size 32 --optimizer adamw --epochs 2 --gpu --seed 2 --lr 6e-5
 
 It gets validation accuracy of 88.0%, whereas the the original Tensorflow implementation give evaluation results between 84% and 88%.

--- a/scripts/bert/index.rst
+++ b/scripts/bert/index.rst
@@ -34,6 +34,6 @@ Use the following command to fine-tune the BERT model for classification on the 
 
 .. code-block:: console
 
-   $ GLUE_DIR=glue_data python3 finetune_classifier.py --batch_size 32 --optimizer bertadam --epochs 2 --gpu --seed 2 --lr 6e-5
+   $ MXNET_GPU_MEM_POOL_TYPE=Round GLUE_DIR=glue_data python3 finetune_classifier.py --batch_size 32 --optimizer bertadam --epochs 2 --gpu --seed 2 --lr 6e-5
 
 It gets validation accuracy of 87.7%, whereas the the original Tensorflow implementation give evaluation results between 84% and 88%.

--- a/scripts/bert/index.rst
+++ b/scripts/bert/index.rst
@@ -34,6 +34,6 @@ Use the following command to fine-tune the BERT model for classification on the 
 
 .. code-block:: console
 
-   $ MXNET_GPU_MEM_POOL_TYPE=Round GLUE_DIR=glue_data python3 finetune_classifier.py --batch_size 32 --optimizer adamw --epochs 2 --gpu --seed 2 --lr 6e-5
+   $ MXNET_GPU_MEM_POOL_TYPE=Round GLUE_DIR=glue_data python3 finetune_classifier.py --batch_size 32 --optimizer bertadam --epochs 2 --gpu --seed 2 --lr 6e-5
 
-It gets validation accuracy of 88.0%, whereas the the original Tensorflow implementation give evaluation results between 84% and 88%.
+It gets validation accuracy of 87.7%, whereas the the original Tensorflow implementation give evaluation results between 84% and 88%.

--- a/scripts/bert/index.rst
+++ b/scripts/bert/index.rst
@@ -34,6 +34,6 @@ Use the following command to fine-tune the BERT model for classification on the 
 
 .. code-block:: console
 
-   $ GLUE_DIR=glue_data MXNET_GPU_MEM_POOL_TYPE=Round python3 finetune_classifier.py --batch_size 32 --optimizer adam --epochs 3 --gpu
+   $ GLUE_DIR=glue_data python3 finetune_classifier.py --batch_size 32 --optimizer adamw --epochs 2 --gpu --seed 2 --lr 6e-5
 
-It gets validation accuracy of 87.0%, whereas the the original Tensorflow implementation give evaluation results between 84% and 88%.
+It gets validation accuracy of 88.0%, whereas the the original Tensorflow implementation give evaluation results between 84% and 88%.

--- a/scripts/bert/index.rst
+++ b/scripts/bert/index.rst
@@ -34,6 +34,6 @@ Use the following command to fine-tune the BERT model for classification on the 
 
 .. code-block:: console
 
-   $ MXNET_GPU_MEM_POOL_TYPE=Round GLUE_DIR=glue_data python3 finetune_classifier.py --batch_size 32 --optimizer bertadam --epochs 2 --gpu --seed 2 --lr 6e-5
+   $ GLUE_DIR=glue_data python3 finetune_classifier.py --batch_size 32 --optimizer bertadam --epochs 2 --gpu --seed 2 --lr 6e-5
 
 It gets validation accuracy of 87.7%, whereas the the original Tensorflow implementation give evaluation results between 84% and 88%.

--- a/src/gluonnlp/model/bert.py
+++ b/src/gluonnlp/model/bert.py
@@ -46,6 +46,7 @@ class BERTLayerNorm(nn.LayerNorm):
         super(BERTLayerNorm, self).__init__(epsilon=epsilon, in_channels=in_channels,
                                             prefix=prefix, params=params)
 
+
 class BERTPositionwiseFFN(BasePositionwiseFFN):
     """Structure of the Positionwise Feed-Forward Neural Network for
     BERT.
@@ -232,206 +233,6 @@ class BERTEncoderCell(BaseTransformerEncoderCell):
 ###############################################################################
 #                                FULL MODEL                                   #
 ###############################################################################
-
-class BERTForPreTraining(Block):
-    """Generic Model for BERT (Bidirectional Encoder Representations from Transformers).
-    Parameters
-    ----------
-    encoder : BERTEncoder
-        Bidirectional encoder that encodes the input sentence.
-    vocab_size : int or None, default None
-        The size of the vocabulary.
-    token_type_vocab_size : int or None, default None
-        The vocabulary size of token types.
-    units : int or None, default None
-        Number of units for the final pooler layer.
-    embed_size : int or None, default None
-        Size of the embedding vectors. It is used to generate the word and token type
-        embeddings if word_embed and token_type_embed are None.
-    embed_dropout : float, default 0.0
-        Dropout rate of the embedding weights. It is used to generate the source and target
-        embeddings if word_embed and token_type_embed are None.
-    embed_initializer : Initializer, default None
-        Initializer of the embedding weights. It is used to generate the source and target
-        embeddings if word_embed and token_type_embed are None.
-    word_embed : Block or None, default None
-        The word embedding. If set to None, word_embed will be constructed using embed_size and
-        embed_dropout.
-    token_type_embed : Block or None, default None
-        The token type embedding. If set to None and the token_type_embed will be constructed using
-        embed_size and embed_dropout.
-    use_pooler : bool, default True
-        Whether to include the pooler which converts the encoded sequence tensor of shape
-        (batch_size, seq_length, units) to a tensor of shape (batch_size, units)
-        for segment level classification task.
-    use_decoder : bool, default True
-        Whether to include the decoder for masked language model prediction.
-    use_classifier : bool, default True
-        Whether to include the classifier for next sentence classification.
-    prefix : str or None
-        See document of `mx.gluon.Block`.
-    params : ParameterDict or None
-        See document of `mx.gluon.Block`.
-    Inputs:
-        - **inputs**: input sequence tensor of shape (batch_size, seq_length)
-        - **token_types**: input token type tensor of shape (batch_size, seq_length).
-            If the inputs contain two sequences, then the token type of the first
-            sequence differs from that of the second one.
-        - **valid_length**: tensor for valid length of shape (batch_size)
-    Outputs:
-        - **sequence_outputs**: output tensor of sequence encodings.
-            Shape (batch_size, seq_length, units).
-        - **pooled_output**: output tensor of pooled representation of the first tokens.
-            Returned only if use_pooler is True. Shape (batch_size, units)
-        - **classifier_output**: output tensor of next sentence classification prediction.
-            Returned only if use_classifier is True. Shape (batch_size, 2)
-        - **decode_output**: output tensor of sequence decoding for masked language model
-            prediction. Returned only if use_decoder True.
-            Shape (batch_size, max_num_positions, vocab_size), where max_num_positions denotes
-            the maximum number of positions for decoding.
-    """
-    def __init__(self, encoder, vocab_size=None, token_type_vocab_size=None, units=None,
-                 embed_size=None, embed_dropout=0.0, embed_initializer=None,
-                 word_embed=None, token_type_embed=None, use_pooler=True, use_decoder=True,
-                 use_classifier=True, prefix=None, params=None, static=False):
-        super(BERTForPreTraining, self).__init__(prefix=prefix, params=params)
-        self._use_decoder = use_decoder
-        self._use_classifier = use_classifier
-        self._use_pooler = use_pooler
-        self.encoder = encoder
-        self._static = static
-        # Construct word embedding
-        self.word_embed = self._get_embed(word_embed, vocab_size, embed_size,
-                                          embed_initializer, embed_dropout, 'word_embed_')
-        # Construct token type embedding
-        self.token_type_embed = self._get_embed(token_type_embed, token_type_vocab_size,
-                                                embed_size, embed_initializer, embed_dropout,
-                                                'token_type_embed_')
-        if self._use_pooler:
-            # Construct pooler
-            self.pooler = self._get_pooler(units, 'pooler_')
-            if self._use_classifier:
-                # Construct classifier for next sentence predicition
-                self.classifier = self._get_classifier('cls_')
-        else:
-            assert not use_classifier, 'Cannot use classifier if use_pooler is False'
-        if self._use_decoder:
-            # Construct decoder for masked language model
-            self.decoder = self._get_decoder(units, vocab_size, self.word_embed, 'decoder_')
-
-    def _get_classifier(self, prefix):
-        """ Construct a decoder for the masked language model task """
-        with self.name_scope():
-            classifier = nn.Dense(2, prefix=prefix)
-        return classifier
-
-    def _get_decoder(self, units, vocab_size, embed, prefix):
-        """ Construct a decoder for the masked language model task """
-        with self.name_scope():
-            decoder = nn.HybridSequential(prefix=prefix)
-            decoder.add(nn.Dense(units))
-            decoder.add(GELU())
-            decoder.add(BERTLayerNorm(in_channels=units))
-            decoder.add(nn.Dense(vocab_size, params=embed.params))
-        return decoder
-
-    def _get_embed(self, embed, vocab_size, embed_size, initializer, dropout, prefix):
-        """ Construct an embedding block. """
-        if embed is None:
-            assert embed_size is not None, '"embed_size" cannot be None if "word_embed" or ' \
-                                           'token_type_embed is not given.'
-            with self.name_scope():
-                embed = nn.HybridSequential(prefix=prefix)
-                with embed.name_scope():
-                    embed.add(nn.Embedding(input_dim=vocab_size, output_dim=embed_size,
-                                           weight_initializer=initializer))
-                    if dropout:
-                        embed.add(nn.Dropout(rate=dropout))
-        assert isinstance(embed, Block)
-        return embed
-
-    def _get_pooler(self, units, prefix):
-        """ Construct pooler.
-        The pooler slices and projects the hidden output of first token
-        in the sequence for segment level classification.
-        """
-        with self.name_scope():
-            pooler = nn.Dense(units=units, flatten=False, activation='tanh',
-                              prefix=prefix)
-        return pooler
-
-    def __call__(self, inputs, token_types, valid_length=None, positions=None):
-        """Encode the input sequence.
-        """
-        return self.forward(inputs, token_types, valid_length=valid_length, positions=positions)
-
-    def forward(self, inputs, token_types, valid_length=None, positions=None): #pylint: disable=arguments-differ
-        """Generate the representation given the inputs.
-        This is used in training or fine-tuning a BERT model.
-        """
-        outputs = []
-        seq_out, _ = self._encode_sequence(inputs, token_types, valid_length)
-        #outputs.append(seq_out)
-        if self._use_pooler:
-            pooled_out = self._apply_pooling(seq_out)
-            #outputs.append(pooled_out)
-            if self._use_classifier:
-                classifier_out = self.classifier(pooled_out)
-                outputs.append(classifier_out)
-        if self._use_decoder:
-            decoder_out = self._decode(seq_out, positions)
-            outputs.append(decoder_out)
-        return tuple(outputs) if len(outputs) > 1 else outputs[0]
-
-
-    def _encode_sequence(self, inputs, token_types, valid_length=None):
-        """Generate the representation given the input sequences.
-        This is used for pre-training or fine-tuning a BERT model.
-        """
-        # embedding
-        word_embedding = self.word_embed(inputs)
-        type_embedding = self.token_type_embed(token_types)
-        embedding = word_embedding + type_embedding
-        # encoding
-        if not self._static:
-            outputs, additional_outputs = self.encoder(embedding, None, valid_length)
-        else:
-            outputs, additional_outputs = self.encoder(embedding, valid_length)
-        return outputs, additional_outputs
-
-    def _apply_pooling(self, sequence):
-        """Generate the representation given the inputs.
-        This is used for pre-training or fine-tuning a BERT model.
-        """
-        outputs = sequence[:, 0, :]
-        return self.pooler(outputs)
-
-    def _decode(self, sequence, positions):
-        """Generate unormalized prediction for the masked language model task.
-        This is only used for pre-training the BERT model.
-        Inputs:
-            - **sequence**: input tensor of sequence encodings.
-              Shape (batch_size, seq_length, units).
-            - **position**: input tensor of position of tokens for decoding.
-              Shape (batch_size, max_num_positions)
-            - **position_mask**: input tensor of position masks of tokens for decoding.
-              This is used when the number of positions of a samples is less than max_num_positions.
-              Shape (batch_size, max_num_positions)
-        Outputs:
-            - **decode_outputs**: output tensor of sequence encodings.
-                Shape (batch_size, max_num_positions, vocab_size).
-        """
-        batch_size = sequence.shape[0]
-        max_num_positions = positions.shape[1]
-        ctx = positions.context
-        dtype = positions.dtype
-        # [0,0,0,1,1,1,2,2,2...]
-        batch_idx = mx.nd.arange(0, batch_size, repeat=max_num_positions, dtype=dtype, ctx=ctx).reshape((1, -1))
-        # [1,2,4,0,3,4,2,3,5...]
-        positions = positions.reshape((1, -1))
-        position_idx = mx.nd.Concat(batch_idx, positions, dim=0)
-        encoded = mx.nd.gather_nd(sequence, position_idx)
-        return self.decoder(encoded)
 
 class BERTModel(Block):
     """Model for BERT (Bidirectional Encoder Representations from Transformers).
@@ -752,7 +553,7 @@ def bert_24_1024_16(dataset_name=None, vocab=None, pretrained=True, ctx=mx.cpu()
                        **kwargs)
 
 def _bert_model(model_name=None, dataset_name=None, vocab=None, pretrained=True, ctx=mx.cpu(),
-                use_pooler=True, use_decoder=True, use_classifier=True, for_pretrain=False,
+                use_pooler=True, use_decoder=True, use_classifier=True,
                 root=os.path.join('~', '.mxnet', 'models'), **kwargs):
     """BERT pretrained model.
 
@@ -779,8 +580,7 @@ def _bert_model(model_name=None, dataset_name=None, vocab=None, pretrained=True,
     # vocab
     vocab = _load_vocab(dataset_name, vocab, root)
     # BERT
-    m = BERTForPreTraining if for_pretrain else BERTModel
-    net = m(encoder, len(vocab),
+    net = BERTModel(encoder, len(vocab),
                     token_type_vocab_size=predefined_args['token_type_vocab_size'],
                     units=predefined_args['units'],
                     embed_size=predefined_args['embed_size'],
@@ -788,7 +588,6 @@ def _bert_model(model_name=None, dataset_name=None, vocab=None, pretrained=True,
                     word_embed=predefined_args['word_embed'],
                     use_pooler=use_pooler, use_decoder=use_decoder,
                     use_classifier=use_classifier)
-
     if pretrained:
         ignore_extra = not (use_pooler and use_decoder and use_classifier)
         _load_pretrained_params(net, model_name, dataset_name, root, ctx,

--- a/src/gluonnlp/optimizer/__init__.py
+++ b/src/gluonnlp/optimizer/__init__.py
@@ -18,26 +18,8 @@
 # under the License.
 
 # pylint: disable=wildcard-import
-"""NLP toolkit."""
+"""NLP optimizer."""
 
-from . import loss
-from . import data
-from . import embedding
-from . import model
-from . import utils
-from . import vocab
-from . import optimizer
-from . import initializer
-from .vocab import Vocab
+from .bert_adam import *
 
-__version__ = '0.5.1'
-
-__all__ = ['data',
-           'model',
-           'embedding',
-           'Vocab',
-           'vocab',
-           'loss',
-           'initializer',
-           'optimizer',
-           'utils']
+__all__ = bert_adam.__all__

--- a/src/gluonnlp/optimizer/bert_adam.py
+++ b/src/gluonnlp/optimizer/bert_adam.py
@@ -1,0 +1,88 @@
+# coding: utf-8
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Weight updating functions."""
+import math
+from mxnet.optimizer import Optimizer, register
+from mxnet.ndarray import zeros, NDArray
+from mxnet.ndarray.contrib import adamw_update
+
+__all__ = ['BERTAdam']
+
+@register
+class BERTAdam(Optimizer):
+    """The Adam optimizer with weight decay regularization for BERT.
+
+    Updates are applied by::
+
+        rescaled_grad = clip(grad * rescale_grad, clip_gradient)
+        m = beta1 * m + (1 - beta1) * rescaled_grad
+        v = beta2 * v + (1 - beta2) * (rescaled_grad**2)
+        w = w - learning_rate * (m / (sqrt(v) + epsilon) + wd * w)
+
+    Note that this is different from `mxnet.optimizer.Adam`, where L2 loss is added and
+    accumulated in m and v. In BERTAdam, the weight decay term decoupled from gradient
+    based update.
+
+    This is also slightly different from the AdamW optimizer described in
+    *Fixing Weight Decay Regularization in Adam*, where the schedule multiplier and
+    learning rate is decoupled. The BERTAdam optimizer uses the same learning rate to
+    apply gradients w.r.t. the loss and weight decay.
+
+    This optimizer accepts the following parameters in addition to those accepted
+    by :class:`mxnet.optimizer.Optimizer`.
+
+    Parameters
+    ----------
+    beta1 : float, optional
+        Exponential decay rate for the first moment estimates.
+    beta2 : float, optional
+        Exponential decay rate for the second moment estimates.
+    epsilon : float, optional
+        Small value to avoid division by 0.
+    """
+    def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999, epsilon=1e-8,
+                 **kwargs):
+        super(BERTAdam, self).__init__(learning_rate=learning_rate, **kwargs)
+        self.beta1 = beta1
+        self.beta2 = beta2
+        self.epsilon = epsilon
+
+    def create_state(self, index, weight):
+        return (zeros(weight.shape, weight.context, dtype=weight.dtype), #mean
+                zeros(weight.shape, weight.context, dtype=weight.dtype)) #variance
+
+    def update(self, index, weight, grad, state):
+        assert(isinstance(weight, NDArray))
+        assert(isinstance(grad, NDArray))
+        self._update_count(index)
+        lr = self._get_lr(index)
+        wd = self._get_wd(index)
+
+        t = self._index_update_count[index]
+        coef1 = 1. - self.beta1**t
+        coef2 = 1. - self.beta2**t
+        lr *= math.sqrt(coef2)/coef1
+
+        kwargs = {'beta1': self.beta1, 'beta2': self.beta2, 'epsilon': self.epsilon,
+                  'rescale_grad': self.rescale_grad}
+        if self.clip_gradient:
+            kwargs['clip_gradient'] = self.clip_gradient
+
+        mean, var = state
+        adamw_update(weight, grad, mean, var, out=weight, lr=1, wd=wd, eta=lr, **kwargs)

--- a/src/gluonnlp/optimizer/bert_adam.py
+++ b/src/gluonnlp/optimizer/bert_adam.py
@@ -62,11 +62,13 @@ class BERTAdam(Optimizer):
         self.beta2 = beta2
         self.epsilon = epsilon
 
-    def create_state(self, index, weight):
+    def create_state(self, index, weight): # pylint-disable=unused-argument
+        """Initialization for mean and var."""
         return (zeros(weight.shape, weight.context, dtype=weight.dtype), #mean
                 zeros(weight.shape, weight.context, dtype=weight.dtype)) #variance
 
     def update(self, index, weight, grad, state):
+        """Update method."""
         try:
             from mxnet.ndarray.contrib import adamw_update
         except ImportError:

--- a/src/gluonnlp/optimizer/bert_adam.py
+++ b/src/gluonnlp/optimizer/bert_adam.py
@@ -20,7 +20,6 @@
 import math
 from mxnet.optimizer import Optimizer, register
 from mxnet.ndarray import zeros, NDArray
-from mxnet.ndarray.contrib import adamw_update
 
 __all__ = ['BERTAdam']
 
@@ -68,6 +67,12 @@ class BERTAdam(Optimizer):
                 zeros(weight.shape, weight.context, dtype=weight.dtype)) #variance
 
     def update(self, index, weight, grad, state):
+        try:
+            from mxnet.ndarray.contrib import adamw_update
+        except ImportError:
+            raise ImportError("Failed to import nd.contrib.adamw_update from MXNet. "
+                              "BERTAdam optimizer requires mxnet>=1.5.0b20181228. "
+                              "Please upgrade your MXNet version.")
         assert(isinstance(weight, NDArray))
         assert(isinstance(grad, NDArray))
         self._update_count(index)


### PR DESCRIPTION
## Description ##
- update command with adamw optimizer, which applies weight decay instead of l2 loss with Adam, as is used in the original TF bert repo.  (requires https://github.com/apache/incubator-mxnet/pull/13728)
- update training script with option for gradient accumulation for bert_large model
- update training script to use bucket sampler, which speeds up training by 2x
Other ongoing BERT efforts may also benefit from this PR @fierceX @kenjewu @haven-jeon 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
