### PR TITLE
[BUGFIX] Remove unused argument in fasttext_word_ngram.py

### DIFF
--- a/scripts/text_classification/fasttext_word_ngram.py
+++ b/scripts/text_classification/fasttext_word_ngram.py
@@ -165,8 +165,6 @@ def parse_args():
         '--output', type=str, help='Location to save trained model')
     group.add_argument(
         '--ngrams', type=int, default=1, help='NGrams used for training')
-    group.add_argument(
-        '--batch-size', type=int, default=16, help='Batch size for training.')
     group.add_argument('--epochs', type=int, default=10, help='Epoch limit')
     group.add_argument(
         '--gpu',


### PR DESCRIPTION
## Description ##
Small update to remove unused argument

In fasttext_word_ngram.py batch_size is used but batch-size is never used