### PR TITLE
[Feature] Add split sampler for distributed training

### DIFF
--- a/src/gluonnlp/data/sampler.py
+++ b/src/gluonnlp/data/sampler.py
@@ -514,12 +514,12 @@ class SplitSampler(Sampler):
     """
     def __init__(self, length, num_parts=1, part_index=0):
         # Compute the length of each partition
-        part_len = (length + num_parts - 1) // num_parts
+        part_len = length // num_parts
         # Compute the start index for this partition
         self._start = part_len * part_index
         # Compute the end index for this partition
         self._end = self._start + part_len
-        if self._end > length:
+        if part_index == num_parts - 1:
             self._end = length
 
     def __iter__(self):

--- a/src/gluonnlp/data/sampler.py
+++ b/src/gluonnlp/data/sampler.py
@@ -20,10 +20,11 @@
 (e.g. in the order sorted by length). They can also be used to perform bucketing
 for speeding up the processing of variable-length sequences."""
 __all__ = ['ConstWidthBucket', 'LinearWidthBucket', 'ExpWidthBucket',
-           'SortedSampler', 'FixedBucketSampler', 'SortedBucketSampler']
+           'SortedSampler', 'FixedBucketSampler', 'SortedBucketSampler', 'SplitSampler']
 
 import math
 import warnings
+import random
 import numpy as np
 from mxnet.gluon.data import Sampler
 from .._constants import INT_TYPES
@@ -497,3 +498,35 @@ class SortedBucketSampler(Sampler):
 
     def __len__(self):
         return (len(self._sort_keys) + self._batch_size - 1) // self._batch_size
+
+class SplitSampler(Sampler):
+    """Split the dataset into `num_parts` parts and randomly sample from the part
+    with index `part_index`.
+
+    Parameters
+    ----------
+    length: int
+      Number of examples in the dataset
+    num_parts: int
+      Number of partitions which the data is split into
+    part_index: int
+      The index of the part to read from
+    """
+    def __init__(self, length, num_parts=1, part_index=0):
+        # Compute the length of each partition
+        part_len = (length + num_parts - 1) // num_parts
+        # Compute the start index for this partition
+        self._start = part_len * part_index
+        # Compute the end index for this partition
+        self._end = self._start + part_len
+        if self._end > length:
+            self._end = length
+
+    def __iter__(self):
+        # Extract examples between `start` and `end`, shuffle and return them.
+        indices = list(range(self._start, self._end))
+        random.shuffle(indices)
+        return iter(indices)
+
+    def __len__(self):
+        return self._end - self._start

--- a/tests/unittest/test_sampler.py
+++ b/tests/unittest/test_sampler.py
@@ -95,3 +95,17 @@ def test_sorted_bucket_sampler(seq_lengths, mult, batch_size, shuffle):
     for batch_sample_ids in sampler:
         total_sampled_ids.extend(batch_sample_ids)
     assert len(set(total_sampled_ids)) == len(total_sampled_ids) == N
+
+
+@pytest.mark.parametrize('num_samples', 30)
+@pytest.mark.parametrize('num_parts', [3, 7])
+def test_split_sampler(num_samples, num_parts):
+    total_count = 0
+    for part_idx in range(num_parts):
+        sampler = s.SplitSampler(num_samples, num_parts, part_idx)
+        count = 0
+        for i in sampler:
+            count += 1
+        total_count += count
+        assert count == len(sampler)
+    assert total_count == num_samples

--- a/tests/unittest/test_sampler.py
+++ b/tests/unittest/test_sampler.py
@@ -97,7 +97,7 @@ def test_sorted_bucket_sampler(seq_lengths, mult, batch_size, shuffle):
     assert len(set(total_sampled_ids)) == len(total_sampled_ids) == N
 
 
-@pytest.mark.parametrize('num_samples', 30)
+@pytest.mark.parametrize('num_samples', [30])
 @pytest.mark.parametrize('num_parts', [3, 7])
 def test_split_sampler(num_samples, num_parts):
     total_count = 0

--- a/tests/unittest/test_sampler.py
+++ b/tests/unittest/test_sampler.py
@@ -101,11 +101,14 @@ def test_sorted_bucket_sampler(seq_lengths, mult, batch_size, shuffle):
 @pytest.mark.parametrize('num_parts', [3, 7])
 def test_split_sampler(num_samples, num_parts):
     total_count = 0
+    indices = []
     for part_idx in range(num_parts):
         sampler = s.SplitSampler(num_samples, num_parts, part_idx)
         count = 0
         for i in sampler:
             count += 1
+            indices.append(i)
         total_count += count
         assert count == len(sampler)
     assert total_count == num_samples
+    assert sorted(indices) == list(range(num_samples))


### PR DESCRIPTION
## Description ##
Added a split sampler for distributed training with multiple nodes. Each node initializes the sampler with total number of nodes (num_parts) and its rank (part_idx) in the cluster, and samples dataset randomly from that partition. This can be used as a custom sampler with SimpleDatasetStream for a list of files, where each split is a subset of all files. 

#478 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
