### PR TITLE
[FIX] Remove bias correction term in BERTAdam

### DIFF
--- a/scripts/bert/index.rst
+++ b/scripts/bert/index.rst
@@ -34,6 +34,6 @@ Use the following command to fine-tune the BERT model for classification on the 
 
 .. code-block:: console
 
-   $ GLUE_DIR=glue_data python3 finetune_classifier.py --batch_size 32 --optimizer bertadam --epochs 2 --gpu --seed 2 --lr 6e-5
+   $ GLUE_DIR=glue_data python finetune_classifier.py --batch_size 32 --optimizer bertadam --epochs 3 --gpu --seed 1 --lr 2e-5
 
-It gets validation accuracy of 87.7%, whereas the the original Tensorflow implementation give evaluation results between 84% and 88%.
+It gets validation accuracy of 87.3%, whereas the the original Tensorflow implementation give evaluation results between 84% and 88%.

--- a/src/gluonnlp/optimizer/bert_adam.py
+++ b/src/gluonnlp/optimizer/bert_adam.py
@@ -81,11 +81,6 @@ class BERTAdam(Optimizer):
         lr = self._get_lr(index)
         wd = self._get_wd(index)
 
-        t = self._index_update_count[index]
-        coef1 = 1. - self.beta1**t
-        coef2 = 1. - self.beta2**t
-        lr *= math.sqrt(coef2)/coef1
-
         kwargs = {'beta1': self.beta1, 'beta2': self.beta2, 'epsilon': self.epsilon,
                   'rescale_grad': self.rescale_grad}
         if self.clip_gradient:

--- a/src/gluonnlp/optimizer/bert_adam.py
+++ b/src/gluonnlp/optimizer/bert_adam.py
@@ -40,8 +40,9 @@ class BERTAdam(Optimizer):
 
     This is also slightly different from the AdamW optimizer described in
     *Fixing Weight Decay Regularization in Adam*, where the schedule multiplier and
-    learning rate is decoupled. The BERTAdam optimizer uses the same learning rate to
-    apply gradients w.r.t. the loss and weight decay.
+    learning rate is decoupled, and the bias-correction terms are removed.
+    The BERTAdam optimizer uses the same learning rate to apply gradients
+    w.r.t. the loss and weight decay.
 
     This optimizer accepts the following parameters in addition to those accepted
     by :class:`mxnet.optimizer.Optimizer`.

--- a/tests/unittest/test_optimizer.py
+++ b/tests/unittest/test_optimizer.py
@@ -16,8 +16,50 @@
 # under the License.
 
 import mxnet as mx
+from mxnet.test_utils import default_context, assert_almost_equal
 import numpy as np
 from gluonnlp import optimizer
+
+def compare_ndarray_tuple(t1, t2, rtol=None, atol=None):
+    """Compare ndarray tuple."""
+    if t1 is not None and t2 is not None:
+        if isinstance(t1, tuple):
+            for s1, s2 in zip(t1, t2):
+                compare_ndarray_tuple(s1, s2, rtol, atol)
+        else:
+            assert_almost_equal(t1.asnumpy(), t2.asnumpy(), rtol=rtol, atol=atol)
+
+
+def compare_optimizer(opt1, opt2, shape, dtype, w_stype='default', g_stype='default',
+                      rtol=1e-4, atol=1e-5, compare_states=True):
+    """Compare opt1 and opt2."""
+    if w_stype == 'default':
+        w2 = mx.random.uniform(shape=shape, ctx=default_context(), dtype=dtype)
+        w1 = w2.copyto(default_context())
+    elif w_stype == 'row_sparse' or w_stype == 'csr':
+        w2 = rand_ndarray(shape, w_stype, density=1, dtype=dtype)
+        w1 = w2.copyto(default_context()).tostype('default')
+    else:
+        raise Exception("type not supported yet")
+    if g_stype == 'default':
+        g2 = mx.random.uniform(shape=shape, ctx=default_context(), dtype=dtype)
+        g1 = g2.copyto(default_context())
+    elif g_stype == 'row_sparse' or g_stype == 'csr':
+        g2 = rand_ndarray(shape, g_stype, dtype=dtype)
+        g1 = g2.copyto(default_context()).tostype('default')
+    else:
+        raise Exception("type not supported yet")
+
+    state1 = opt1.create_state_multi_precision(0, w1)
+    state2 = opt2.create_state_multi_precision(0, w2)
+    if compare_states:
+        compare_ndarray_tuple(state1, state2)
+
+    opt1.update_multi_precision(0, w1, g1, state1)
+    opt2.update_multi_precision(0, w2, g2, state2)
+    if compare_states:
+        compare_ndarray_tuple(state1, state2, rtol=rtol, atol=atol)
+    assert_almost_equal(w1.asnumpy(), w2.asnumpy(), rtol=rtol, atol=atol)
 
 # BERT ADAM
 class PyBERTAdam(mx.optimizer.Optimizer):
@@ -88,5 +130,5 @@ def test_bert_adam():
                     kwarg.update(cg_option)
                     kwarg.update(rg_option)
                     kwarg.update(wd_option)
-                    mx.test_utils.compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, dtype,
-                                                    rtol=1e-4, atol=2e-5)
+                    compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, dtype,
+                                      rtol=1e-4, atol=2e-5)

--- a/tests/unittest/test_optimizer.py
+++ b/tests/unittest/test_optimizer.py
@@ -130,5 +130,9 @@ def test_bert_adam():
                     kwarg.update(cg_option)
                     kwarg.update(rg_option)
                     kwarg.update(wd_option)
-                    compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, dtype,
-                                      rtol=1e-4, atol=2e-5)
+                    try:
+                        compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, dtype,
+                                          rtol=1e-4, atol=2e-5)
+                    except ImportError:
+                        print('skipping test_bert_adam() because an old version of MXNet is found')
+                        return

--- a/tests/unittest/test_optimizer.py
+++ b/tests/unittest/test_optimizer.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import mxnet as mx
-from mxnet.test_utils import default_context, assert_almost_equal
+from mxnet.test_utils import default_context, assert_almost_equal, rand_ndarray
 import numpy as np
 from gluonnlp import optimizer
 

--- a/tests/unittest/test_optimizer.py
+++ b/tests/unittest/test_optimizer.py
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import mxnet as mx
+import numpy as np
+from gluonnlp import optimizer
+
+# BERT ADAM
+class PyBERTAdam(mx.optimizer.Optimizer):
+    """python reference implemenation of BERT style adam"""
+    def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999, epsilon=1e-8,
+                 wd=0, **kwargs):
+        super(PyBERTAdam, self).__init__(learning_rate=learning_rate, **kwargs)
+        self.beta1 = beta1
+        self.beta2 = beta2
+        self.epsilon = epsilon
+        self.wd = wd
+
+    def create_state(self, index, weight):
+        """Create additional optimizer state: mean, variance
+
+        Parameters
+        ----------
+        weight : NDArray
+        The weight data
+        """
+        return (mx.nd.zeros(weight.shape, weight.context, dtype=weight.dtype),  # mean
+                mx.nd.zeros(weight.shape, weight.context, dtype=weight.dtype))  # variance
+
+    def update(self, index, weight, grad, state):
+        """Update the parameters.
+
+        Parameters
+        ----------
+        index : int
+        An unique integer key used to index the parameters
+        weight : NDArray
+        weight ndarray
+        grad : NDArray
+        grad ndarray
+        state : NDArray or other objects returned by init_state
+        The auxiliary state used in optimization.
+        """
+        lr = self._get_lr(index)
+        wd = self._get_wd(index)
+        self._update_count(index)
+        mean, variance = state
+        grad = grad * self.rescale_grad
+        # clip gradients
+        if self.clip_gradient is not None:
+            mx.nd.clip(grad, -self.clip_gradient, self.clip_gradient, out=grad)
+        # update mean
+        mean[:] = self.beta1 * mean + (1. - self.beta1) * grad
+        # update variance
+        variance[:] = self.beta2 * variance + (1 - self.beta2) * grad.square()
+        # include weight decay
+        update = mean / (mx.nd.sqrt(variance) + self.epsilon) + wd * weight
+        # update weight
+        weight -= lr * update
+
+
+def test_bert_adam():
+    opt1 = PyBERTAdam
+    opt2 = optimizer.BERTAdam
+    shape = (3, 4, 5)
+    cg_options = [{}, {'clip_gradient': 0.4}, {'clip_gradient': 0.5}]
+    rg_options = [{}, {'rescale_grad': 0.14}, {'rescale_grad': 0.8}]
+    wd_options = [{}, {'wd': 0.03}, {'wd': 0.05}, {'wd': 0.07}]
+    for dtype in [np.float16, np.float32, np.float64]:
+        for cg_option in cg_options:
+            for rg_option in rg_options:
+                for wd_option in wd_options:
+                    kwarg = {}
+                    kwarg.update(cg_option)
+                    kwarg.update(rg_option)
+                    kwarg.update(wd_option)
+                    mx.test_utils.compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, dtype,
+                                                    rtol=1e-4, atol=2e-5)


### PR DESCRIPTION
## Description ##
The Adam optimizer in the official BERT repository does not have the bias correction term in Adam. However, this was added in the initial PR for BERTAdam. 

Now I am removing it to make the optimizer consistent with the official implementation. 

The goal is to make the reproduction of other fine-tuning tasks easier (with hyper-parameters mentioned in the BERT official repo/paper). 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
Unfortunately other ongoing BERT efforts may be affected @fierceX @haven-jeon  #493 #481