### PR TITLE
[FIX] Fix weight dying in BERTModel.decoder for BERT pre-training

### DIFF
--- a/scripts/bert/convert_tf_model.py
+++ b/scripts/bert/convert_tf_model.py
@@ -29,12 +29,16 @@ from utils import convert_vocab, get_hash, read_tf_checkpoint
 
 parser = argparse.ArgumentParser(description='Conversion script for Tensorflow BERT model')
 parser.add_argument('--model', type=str, default='bert_12_768_12',
-                    help='BERT model name. options are bert_12_768_12 and bert_24_1024_16')
-parser.add_argument('--tf_checkpoint_dir', type=str, required=True,
+                    help='BERT model name. options are bert_12_768_12 and bert_24_1024_16.'
+                         'Default is bert_12_768_12')
+parser.add_argument('--tf_checkpoint_dir', type=str,
+                    default='/home/ubuntu/cased_L-12_H-768_A-12/',
                     help='Path to Tensorflow checkpoint folder. '
-                         'e.g. /home/ubuntu/cased_L-12_H-768_A-12/')
-parser.add_argument('--out_dir', type=str, required=True,
-                    help='Path to output folder. The folder must exist. e.g. /home/ubuntu/output/')
+                         'Default is /home/ubuntu/cased_L-12_H-768_A-12/')
+parser.add_argument('--out_dir', type=str,
+                    default='/home/ubuntu/output/',
+                    help='Path to output folder. The folder must exist. '
+                         'Default is /home/ubuntu/output/')
 parser.add_argument('--debug', action='store_true', help='debugging mode')
 args = parser.parse_args()
 logging.getLogger().setLevel(logging.DEBUG if args.debug else logging.INFO)
@@ -159,10 +163,10 @@ for name in params:
     # pylint: disable=broad-except
     except Exception:
         if name not in mx_tensors:
-            logging.info('cannot initialize %s from tf checkpoint', name)
+            raise RuntimeError('cannot initialize %s from tf checkpoint'%name)
         else:
-            logging.info('cannot initialize %s. Expect shape = %s, but found %s',
-                         name, params[name].shape, arr.shape)
+            raise RuntimeError('cannot initialize %s. Expect shape = %s, but found %s'%\
+                               name, params[name].shape, arr.shape)
 
 logging.info('num loaded params = %d, total num params = %d',
              len(loaded_params), len(mx_tensors))

--- a/src/gluonnlp/model/bert.py
+++ b/src/gluonnlp/model/bert.py
@@ -335,6 +335,8 @@ class BERTModel(Block):
             decoder.add(GELU())
             decoder.add(BERTLayerNorm(in_channels=units))
             decoder.add(nn.Dense(vocab_size, params=embed.collect_params()))
+        assert decoder[3].weight == list(embed.collect_params().values())[0], \
+          'The weights of word embedding are not tied with those of decoder'
         return decoder
 
     def _get_embed(self, embed, vocab_size, embed_size, initializer, dropout, prefix):

--- a/src/gluonnlp/model/bert.py
+++ b/src/gluonnlp/model/bert.py
@@ -319,7 +319,7 @@ class BERTModel(Block):
             assert not use_classifier, 'Cannot use classifier if use_pooler is False'
         if self._use_decoder:
             # Construct decoder for masked language model
-            self.decoder = self._get_decoder(units, vocab_size, self.word_embed, 'decoder_')
+            self.decoder = self._get_decoder(units, vocab_size, self.word_embed[0], 'decoder_')
 
     def _get_classifier(self, prefix):
         """ Construct a decoder for the masked language model task """
@@ -334,7 +334,7 @@ class BERTModel(Block):
             decoder.add(nn.Dense(units))
             decoder.add(GELU())
             decoder.add(BERTLayerNorm(in_channels=units))
-            decoder.add(nn.Dense(vocab_size, params=embed.params))
+            decoder.add(nn.Dense(vocab_size, params=embed.collect_params()))
         return decoder
 
     def _get_embed(self, embed, vocab_size, embed_size, initializer, dropout, prefix):


### PR DESCRIPTION
## Description ##
The decoder for masked language model task in BERTModel is not correctly tied with the word embedding similar to https://github.com/dmlc/gluon-nlp/pull/413 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- Does this affect other downstream fine-tuning tasks? No, it affects the decoder which is only relevant to the masked language model task during pre-training. 
- Does this affect the pre-trained models? No, the converted BERT model from TF can still be loaded correctly. 