### PR TITLE
[BUGFIX] fix parameter clip

### DIFF
--- a/src/gluonnlp/utils/parameter.py
+++ b/src/gluonnlp/utils/parameter.py
@@ -69,7 +69,7 @@ def clip_grad_global_norm(parameters, max_norm, check_isfinite=True):
             return nd.dot(x, x)
         return array.norm().square()
 
-    arrays = [p.grad() for p in parameters if p.grad_req != 'null']
+    arrays = [p.list_grad()[0] for p in parameters if p.grad_req != 'null']
     assert len(arrays) > 0, 'No parameter found available for gradient norm clipping.'
     ctx, dtype = arrays[0].context, arrays[0].dtype
     total_norm = nd.add_n(*[_norm(arr).as_in_context(ctx) for arr in arrays])

--- a/tests/unittest/test_utils.py
+++ b/tests/unittest/test_utils.py
@@ -81,8 +81,9 @@ def test_clip_grad_norm(max_norm, check_isfinite):
             out = net(mx.nd.ones((1, 1), ctx=ctx))
         out.backward()
     trainer.allreduce_grads()
-    norm = nlp.utils.clip_grad_global_norm(net.collect_params().values(),
-                                           max_norm, check_isfinite)
+    with mx.cpu(2):
+        norm = nlp.utils.clip_grad_global_norm(net.collect_params().values(),
+                                               max_norm, check_isfinite)
     if isinstance(norm, mx.nd.NDArray):
         norm = norm.asnumpy()
     mx.test_utils.assert_almost_equal(norm, np.sqrt(8), atol=1e-5)


### PR DESCRIPTION
## Description ##
fix parameter clip where it causes error such as
> Parameter 'gnmt_enc_rnn0_l_i2h_weight' was not initialized on context cpu(0). It was only initialized on [gpu(0), gpu(1), gpu(2), gpu(3)]

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] fix parameter clip
