### PR TITLE
Use unicode instead of string for writing files

### DIFF
--- a/scripts/machine_translation/dataprocessor.py
+++ b/scripts/machine_translation/dataprocessor.py
@@ -264,5 +264,5 @@ def write_sentences(sentences, file_path):
         for sent in sentences:
             if isinstance(sent, (list, tuple)):
                 of.write(u' '.join(sent) + u'\n')
-            else:
+            else: 
                 of.write(u''.join(sent) + u'\n')

--- a/scripts/machine_translation/dataprocessor.py
+++ b/scripts/machine_translation/dataprocessor.py
@@ -265,4 +265,4 @@ def write_sentences(sentences, file_path):
             if isinstance(sent, (list, tuple)):
                 of.write(u' '.join(sent) + u'\n')
             else: 
-                of.write(u''.join(sent) + u'\n')
+                of.write(u' '.join(sent) + u'\n')

--- a/scripts/machine_translation/dataprocessor.py
+++ b/scripts/machine_translation/dataprocessor.py
@@ -264,5 +264,5 @@ def write_sentences(sentences, file_path):
         for sent in sentences:
             if isinstance(sent, (list, tuple)):
                 of.write(u' '.join(sent) + u'\n')
-            else: 
+            else:
                 of.write(u' '.join(sent) + u'\n')

--- a/scripts/machine_translation/dataprocessor.py
+++ b/scripts/machine_translation/dataprocessor.py
@@ -265,4 +265,4 @@ def write_sentences(sentences, file_path):
             if isinstance(sent, (list, tuple)):
                 of.write(u' '.join(sent) + u'\n')
             else:
-                of.write(u' '.join(sent) + u'\n')
+                of.write(sent + u'\n')

--- a/scripts/machine_translation/dataprocessor.py
+++ b/scripts/machine_translation/dataprocessor.py
@@ -263,6 +263,6 @@ def write_sentences(sentences, file_path):
     with io.open(file_path, 'w', encoding='utf-8') as of:
         for sent in sentences:
             if isinstance(sent, (list, tuple)):
-                of.write(unicode(' '.join(sent) + '\n'))
+                of.write(u' '.join(sent) + u'\n')
             else:
-                of.write(unicode(sent + '\n'))
+                of.write(u''.join(sent) + u'\n')

--- a/scripts/machine_translation/dataprocessor.py
+++ b/scripts/machine_translation/dataprocessor.py
@@ -263,6 +263,6 @@ def write_sentences(sentences, file_path):
     with io.open(file_path, 'w', encoding='utf-8') as of:
         for sent in sentences:
             if isinstance(sent, (list, tuple)):
-                of.write(' '.join(sent) + '\n')
+                of.write(unicode(' '.join(sent) + '\n'))
             else:
-                of.write(sent + '\n')
+                of.write(unicode(sent + '\n'))


### PR DESCRIPTION

## Description ##
Fix the following error: 

```
File "~/machine_translation/dataprocessor.py", line 268, in write_sentences
    of.write(sent + '\n')
TypeError: must be unicode, not str
```


