### PR TITLE
[FIX] Fix divergence of the training of transformer

### DIFF
--- a/src/gluonnlp/model/transformer.py
+++ b/src/gluonnlp/model/transformer.py
@@ -314,7 +314,7 @@ class BaseTransformerEncoder(HybridBlock, Seq2SeqEncoder):
                  use_residual=True, output_attention=False,
                  weight_initializer=None, bias_initializer='zeros',
                  positional_weight='sinusoidal', use_bert_encoder=False,
-                 use_layer_norm_before_dropout=True, scale_embed=True,
+                 use_layer_norm_before_dropout=False, scale_embed=True,
                  prefix=None, params=None):
         super(BaseTransformerEncoder, self).__init__(prefix=prefix, params=params)
         assert units % num_heads == 0,\
@@ -660,7 +660,7 @@ class TransformerEncoder(BaseTransformerEncoder):
                                                  # extra configurations for transformer
                                                  positional_weight='sinusoidal',
                                                  use_bert_encoder=False,
-                                                 use_layer_norm_before_dropout=True,
+                                                 use_layer_norm_before_dropout=False,
                                                  scale_embed=True)
 
 ###############################################################################


### PR DESCRIPTION
## Description ##
Change the default value of flag use_layer_norm_before_dropout to false. Otherwise, the training of transformer model will diverge with the default cmd.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Feature1, tests, (and when applicable, API doc)
- [x] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
