### PR TITLE
[BUGFIX] Fix Weight Drop and Test

### DIFF
--- a/src/gluonnlp/model/parameter.py
+++ b/src/gluonnlp/model/parameter.py
@@ -40,6 +40,7 @@ class WeightDropParameter(gluon.Parameter):
     """
     def __init__(self, parameter, rate=0.0, mode='training', axes=()):
         p = parameter
+        self._deferred_init = p._deferred_init
         super(WeightDropParameter, self).__init__(
             name=p.name, grad_req=p.grad_req, shape=p._shape, dtype=p.dtype,
             lr_mult=p.lr_mult, wd_mult=p.wd_mult, init=p.init,
@@ -48,6 +49,12 @@ class WeightDropParameter(gluon.Parameter):
         self._rate = rate
         self._mode = mode
         self._axes = axes
+        self._var = p._var
+        self._data = p._data
+        self._grad = p._grad
+        self._ctx_list = p._ctx_list
+        self._ctx_map = p._ctx_map
+        self._trainer = p._trainer
 
     def data(self, ctx=None):
         """Returns a copy of this parameter on one context. Must have been

--- a/tests/unittest/test_models.py
+++ b/tests/unittest/test_models.py
@@ -98,7 +98,7 @@ def test_pretrained_bert_models():
                   'bert_24_1024_16': ['book_corpus_wiki_en_uncased','book_corpus_wiki_en_cased']}
     vocab_size = {'book_corpus_wiki_en_cased': 28996,
                   'book_corpus_wiki_en_uncased': 30522,
-                  'wiki_multilingual_cased': 119547, 
+                  'wiki_multilingual_cased': 119547,
                   'wiki_cn': 21128,
                   'wiki_multilingual': 105879}
     special_tokens = ['[UNK]', '[PAD]', '[SEP]', '[CLS]', '[MASK]']
@@ -382,12 +382,12 @@ def test_weight_drop():
     shared_net3 = gluon.nn.HybridSequential(params=net3.collect_params())
     shared_net3.add(gluon.rnn.LSTM(10, params=net3[0].collect_params()))
 
-    x = mx.nd.ones((3, 4, 5))
+    x = mx.random.uniform(shape=(3, 4, 5))
     nets = [(net1, shared_net1),
             (net2, shared_net2),
             (net3, shared_net3)]
     for net, shared_net in nets:
-        net.initialize('ones')
+        net.initialize('uniform')
         mx.test_utils.assert_almost_equal(net(x).asnumpy(),
                                           shared_net(x).asnumpy())
         with mx.autograd.train_mode():
@@ -408,7 +408,7 @@ def test_weight_drop():
 
         drop_rate = 0.5
         nlp.model.utils.apply_weight_drop(net, '.*h2h_weight', drop_rate)
-        net.initialize('ones')
+        net.initialize('uniform')
 
         mx.test_utils.assert_almost_equal(net(x).asnumpy(),
                                           shared_net(x).asnumpy())

--- a/tests/unittest/test_models.py
+++ b/tests/unittest/test_models.py
@@ -408,10 +408,10 @@ def test_weight_drop():
 
         drop_rate = 0.5
         nlp.model.utils.apply_weight_drop(net, '.*h2h_weight', drop_rate)
-        net.initialize('uniform')
 
-        mx.test_utils.assert_almost_equal(net(x).asnumpy(),
-                                          shared_net(x).asnumpy())
+        with mx.autograd.predict_mode():
+            mx.test_utils.assert_almost_equal(net(x).asnumpy(),
+                                              shared_net(x).asnumpy())
         with mx.autograd.train_mode():
             assert not mx.test_utils.almost_equal(net(x).asnumpy(),
                                                   shared_net(x).asnumpy())


### PR DESCRIPTION
## Description ##
Fix the problem where the weight dropped parameter didn't copy data/grad from original parameter. Fix flaky test. Previously WeightDropParameter has only been used for fresh training and didn't test the case where existing parameter needs to be copied.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Fix weight drop to reuse data/grad from input parameter
- [x] Add randomness to the weight drop tests. Fixes #463 

## Comments ##
- It doesn't change the behavior of weight drop for previous use case, which always starts a fresh copy.