### PR TITLE
[Feature] Add TruncNorm initializer for BERT

### DIFF
--- a/src/gluonnlp/initializer/initializer.py
+++ b/src/gluonnlp/initializer/initializer.py
@@ -87,4 +87,6 @@ class TruncNorm(Initializer):
         self._frozen_rv = truncnorm(-2, 2, mean, stdev)
 
     def _init_weight(self, name, arr):
+        # pylint: disable=unused-argument
+        """Abstract method to Initialize weight."""
         arr[:] = self._frozen_rv.rvs(arr.size).reshape(arr.shape)

--- a/src/gluonnlp/initializer/initializer.py
+++ b/src/gluonnlp/initializer/initializer.py
@@ -82,9 +82,6 @@ class TruncNorm(Initializer):
         Additional parameters for base Initializer.
     """
     def __init__(self, mean=0, stdev=0.01, **kwargs):
-        """
-
-        """
         super(TruncNorm, self).__init__(**kwargs)
         from scipy.stats import truncnorm
         self._frozen_rv = truncnorm(-2, 2, mean, stdev)

--- a/src/gluonnlp/initializer/initializer.py
+++ b/src/gluonnlp/initializer/initializer.py
@@ -83,7 +83,14 @@ class TruncNorm(Initializer):
     """
     def __init__(self, mean=0, stdev=0.01, **kwargs):
         super(TruncNorm, self).__init__(**kwargs)
-        from scipy.stats import truncnorm
+        try:
+            from scipy.stats import truncnorm
+        except ImportError:
+            raise ImportError('SciPy is not installed. '
+                              'You must install SciPy >= 1.0.0 in order to use the '
+                              'TruncNorm. You can refer to the official '
+                              'installation guide in https://www.scipy.org/install.html .')
+
         self._frozen_rv = truncnorm(-2, 2, mean, stdev)
 
     def _init_weight(self, name, arr):

--- a/src/gluonnlp/initializer/initializer.py
+++ b/src/gluonnlp/initializer/initializer.py
@@ -68,8 +68,23 @@ class HighwayBias(Initializer):
 class TruncNorm(Initializer):
     r"""Initialize the weight by drawing sample from truncated normal distribution with
     provided mean and standard deviation. Values whose magnitude is more than 2 standard deviations
-    from the mean are dropped and re-picked.."""
+    from the mean are dropped and re-picked..
+
+    Parameters
+    ----------
+    mean : float, default 0
+        Mean of the underlying normal distribution
+
+    stdev : float, default 0.01
+        Standard deviation of the underlying normal distribution
+
+    **kwargs : dict
+        Additional parameters for base Initializer.
+    """
     def __init__(self, mean=0, stdev=0.01, **kwargs):
+        """
+
+        """
         super(TruncNorm, self).__init__(**kwargs)
         from scipy.stats import truncnorm
         self._frozen_rv = truncnorm(-2, 2, mean, stdev)

--- a/tests/unittest/test_initializer.py
+++ b/tests/unittest/test_initializer.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+from mxnet.gluon import nn
+from gluonnlp import initializer
+
+
+def test_truncnorm_string_alias_works():
+    try:
+        layer = nn.Dense(in_units=1, units=1, weight_initializer='truncnorm')
+        layer.initialize()
+    except RuntimeError:
+        pytest.fail('Layer couldn\'t be initialized')
+
+
+def test_truncnorm_all_values_inside_boundaries():
+    mean = 0
+    std = 0.01
+    layer = nn.Dense(in_units=1, units=1000)
+    layer.initialize(init=initializer.TruncNorm(mean, std))
+    assert ((layer.weight.data() > 2 * std).sum() +
+            (layer.weight.data() < -2 * std).sum()).sum().asscalar() == 0
+
+
+def test_truncnorm_generates_values_with_defined_mean_and_std():
+    from scipy import stats
+
+    mean = 10
+    std = 5
+    layer = nn.Dense(in_units=1, units=100000)
+    layer.initialize(init=initializer.TruncNorm(mean, std))
+    samples = layer.weight.data().reshape((-1, )).asnumpy()
+
+    p_value = stats.kstest(samples, 'truncnorm', args=(-2, 2, mean, std)).pvalue
+    assert p_value > 0.0001
+

--- a/tests/unittest/test_initializer.py
+++ b/tests/unittest/test_initializer.py
@@ -24,7 +24,7 @@ from gluonnlp import initializer
 
 def test_truncnorm_string_alias_works():
     try:
-        layer = nn.Dense(in_units=1, units=1, weight_initializer='truncnorm')
+        layer = nn.Dense(prefix="test_layer", in_units=1, units=1, weight_initializer='truncnorm')
         layer.initialize()
     except RuntimeError:
         pytest.fail('Layer couldn\'t be initialized')
@@ -33,7 +33,7 @@ def test_truncnorm_string_alias_works():
 def test_truncnorm_all_values_inside_boundaries():
     mean = 0
     std = 0.01
-    layer = nn.Dense(in_units=1, units=1000)
+    layer = nn.Dense(prefix="test_layer", in_units=1, units=1000)
     layer.initialize(init=initializer.TruncNorm(mean, std))
     assert ((layer.weight.data() > 2 * std).sum() +
             (layer.weight.data() < -2 * std).sum()).sum().asscalar() == 0
@@ -44,7 +44,7 @@ def test_truncnorm_generates_values_with_defined_mean_and_std():
 
     mean = 10
     std = 5
-    layer = nn.Dense(in_units=1, units=100000)
+    layer = nn.Dense(prefix="test_layer", in_units=1, units=100000)
     layer.initialize(init=initializer.TruncNorm(mean, std))
     samples = layer.weight.data().reshape((-1, )).asnumpy()
 


### PR DESCRIPTION
## Description ##
BERT requires TruncNorm initializer. This code uses scipy to draw samples from distribution as a quick solution. If it would be too slow for bigger sample sizes, will have to rewrite it.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented