### PR TITLE
[BUGFIX] Fix GluonNLP MXNet dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,21 +41,28 @@ Installation
 Make sure you have Python 2.7 or Python 3.6 and recent version of MXNet.
 You can install ``MXNet`` and ``GluonNLP`` using pip.
 
-In particular, if you want the ``GluonNLP`` built on most recent ``MXNet`` release:
+``GluonNLP`` is based on the most recent version of ``MXNet``.
+
+
+In particular, if you want to install the most recent ``MXNet`` release:
 
 ::
 
-    pip install --upgrade mxnet=='1.3.1'
+    pip install --upgrade mxnet>=1.3.0
 
-Else, if you want the ``GluonNLP`` built on ``MXNet`` nightly builds:
+Else, if you want to install the most recent ``MXNet`` nightly build:
 
 ::
 
     pip install --pre --upgrade mxnet
 
+Then, you can install ``GluonNLP``:
+
 ::
 
     pip install gluonnlp
+
+Please check more `installation details <https://github.com/dmlc/gluon-nlp/blob/master/docs/install.rst>`_.
 
 Docs 📖
 =======

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ You can install ``MXNet`` and ``GluonNLP`` using pip:
 
 ::
 
-    pip install --pre --upgrade mxnet
+    pip install --pre --upgrade mxnet=='1.3.1'
     pip install gluonnlp
 
 Docs 📖

--- a/README.rst
+++ b/README.rst
@@ -39,11 +39,22 @@ Installation
 ============
 
 Make sure you have Python 2.7 or Python 3.6 and recent version of MXNet.
-You can install ``MXNet`` and ``GluonNLP`` using pip:
+You can install ``MXNet`` and ``GluonNLP`` using pip.
+
+In particular, if you want the ``GluonNLP`` built on most recent ``MXNet`` release:
 
 ::
 
     pip install --pre --upgrade mxnet=='1.3.1'
+
+Else, if you want the ``GluonNLP`` built on ``MXNet`` nightly builds:
+
+::
+
+    pip install --pre --upgrade mxnet
+
+::
+
     pip install gluonnlp
 
 Docs 📖

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ In particular, if you want the ``GluonNLP`` built on most recent ``MXNet`` relea
 
 ::
 
-    pip install --pre --upgrade mxnet=='1.3.1'
+    pip install --upgrade mxnet=='1.3.1'
 
 Else, if you want the ``GluonNLP`` built on ``MXNet`` nightly builds:
 


### PR DESCRIPTION
## Description ##
This PR changes the MXNet dependency to the last stable MXNet release 1.3.1 instead of nightly builds.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- Change GluonNLP MXNet dependency

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
