### PR TITLE
[BUGFIX] use glove.840B.300d for NLI experiments

### DIFF
--- a/scripts/natural_language_inference/index.rst
+++ b/scripts/natural_language_inference/index.rst
@@ -32,7 +32,7 @@ Test:
 	$ python3 main.py --test-file data/snli_1.0/test.txt --model-dir output/snli-basic --gpu-id 0 --mode test --output-dir output/snli-basic/test
 
 We achieve 85.0% accuracy on the SNLI test set, comparable to 86.3% reported in the
-original paper.
+original paper. `[Training log] <https://github.com/dmlc/web-data/blob/master/gluonnlp/logs/natural_language_inference/decomposable_attention_snli.log>`_
 
 Train the model with intra-sentence attention:
 
@@ -47,7 +47,7 @@ Test:
 	$ python3 main.py --test-file data/snli_1.0/test.txt --model-dir output/snli-intra --gpu-id 0 --mode test --output-dir output/snli-intra/test
 
 We achieve 85.5% accuracy on the SNLI test set, compared to 86.8% reported in the
-original paper.
+original paper. `[Training log] <https://github.com/dmlc/web-data/blob/master/gluonnlp/logs/natural_language_inference/decomposable_intra_attention_snli.log>`_
 Note that our intra-sentence attention implementation omitted the
 distance-sensitive bias term described in Equation (7) in the original paper.
 

--- a/scripts/natural_language_inference/index.rst
+++ b/scripts/natural_language_inference/index.rst
@@ -31,7 +31,7 @@ Test:
 
 	$ python3 main.py --test-file data/snli_1.0/test.txt --model-dir output/snli-basic --gpu-id 0 --mode test --output-dir output/snli-basic/test
 
-We achieve 84.6% accuracy on the SNLI test set, comparable to 86.3% reported in the
+We achieve 85.0% accuracy on the SNLI test set, comparable to 86.3% reported in the
 original paper.
 
 Train the model with intra-sentence attention:
@@ -46,7 +46,7 @@ Test:
 
 	$ python3 main.py --test-file data/snli_1.0/test.txt --model-dir output/snli-intra --gpu-id 0 --mode test --output-dir output/snli-intra/test
 
-We achieve 84.4% accuracy on the SNLI test set, compared to 86.8% reported in the
+We achieve 85.5% accuracy on the SNLI test set, compared to 86.8% reported in the
 original paper.
 Note that our intra-sentence attention implementation omitted the
 distance-sensitive bias term described in Equation (7) in the original paper.

--- a/scripts/natural_language_inference/index.rst
+++ b/scripts/natural_language_inference/index.rst
@@ -32,7 +32,7 @@ Test:
 	$ python3 main.py --test-file data/snli_1.0/test.txt --model-dir output/snli-basic --gpu-id 0 --mode test --output-dir output/snli-basic/test
 
 We achieve 85.0% accuracy on the SNLI test set, comparable to 86.3% reported in the
-original paper. `[Training log] <https://github.com/dmlc/web-data/blob/master/gluonnlp/logs/natural_language_inference/decomposable_attention_snli.log>`_
+original paper. `[Training log] <https://github.com/dmlc/web-data/blob/master/gluonnlp/logs/natural_language_inference/decomposable_attention_snli.log>`__
 
 Train the model with intra-sentence attention:
 
@@ -47,7 +47,7 @@ Test:
 	$ python3 main.py --test-file data/snli_1.0/test.txt --model-dir output/snli-intra --gpu-id 0 --mode test --output-dir output/snli-intra/test
 
 We achieve 85.5% accuracy on the SNLI test set, compared to 86.8% reported in the
-original paper. `[Training log] <https://github.com/dmlc/web-data/blob/master/gluonnlp/logs/natural_language_inference/decomposable_intra_attention_snli.log>`_
+original paper. `[Training log] <https://github.com/dmlc/web-data/blob/master/gluonnlp/logs/natural_language_inference/decomposable_intra_attention_snli.log>`__
 Note that our intra-sentence attention implementation omitted the
 distance-sensitive bias term described in Equation (7) in the original paper.
 

--- a/scripts/natural_language_inference/main.py
+++ b/scripts/natural_language_inference/main.py
@@ -75,7 +75,7 @@ def parse_args():
                         help='maximum number of epochs to train')
     parser.add_argument('--embedding', default='glove',
                         help='word embedding type')
-    parser.add_argument('--embedding-source', default='glove.6B.300d',
+    parser.add_argument('--embedding-source', default='glove.840B.300d',
                         help='embedding file source')
     parser.add_argument('--embedding-size', type=int, default=300,
                         help='size of pretrained word embedding')


### PR DESCRIPTION
## Description ##
Use glove.840B.300d instead of glove.6B.300d. Updated accuracy numbers.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] default embedding is glove.840B.300d

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here