### PR TITLE
[feature] support for BERT fp16 inference

### DIFF
--- a/scripts/bert/finetune_squad.py
+++ b/scripts/bert/finetune_squad.py
@@ -433,8 +433,8 @@ def evaluate():
     for data in dev_dataloader:
         example_ids, inputs, token_types, valid_length, _, _ = data
 
-        out = net(inputs.astype(dtype).as_in_context(ctx),
-                  token_types.astype(dtype).as_in_context(ctx),
+        out = net(inputs.astype('float32').as_in_context(ctx),
+                  token_types.astype('float32').as_in_context(ctx),
                   valid_length.astype(dtype).as_in_context(ctx))
 
         output = nd.split(out, axis=2, num_outputs=2)

--- a/scripts/machine_translation/loss.py
+++ b/scripts/machine_translation/loss.py
@@ -121,12 +121,13 @@ class LabelSmoothing(HybridBlock):
         Created if `None`.
     """
     def __init__(self, axis=-1, epsilon=0.1, units=None,
-                 sparse_label=True, prefix=None, params=None):
+                 sparse_label=True, dtype='float32', prefix=None, params=None):
         super(LabelSmoothing, self).__init__(prefix=prefix, params=params)
         self._axis = axis
         self._epsilon = epsilon
         self._sparse_label = sparse_label
         self._units = units
+        self._dtype = dtype
 
     def hybrid_forward(self, F, inputs, units=None): # pylint: disable=arguments-differ
         """
@@ -148,7 +149,7 @@ class LabelSmoothing(HybridBlock):
                 'instance initialization when sparse_label is False'
             if units is None:
                 units = self._units
-            inputs = F.one_hot(inputs, depth=units)
+            inputs = F.one_hot(inputs, depth=units, dtype=self._dtype)
         if units is None and self._units is None:
             return F.Custom(inputs, epsilon=self._epsilon, axis=self._axis,
                             op_type='_smoothing_with_dim')

--- a/scripts/machine_translation/loss.py
+++ b/scripts/machine_translation/loss.py
@@ -121,13 +121,12 @@ class LabelSmoothing(HybridBlock):
         Created if `None`.
     """
     def __init__(self, axis=-1, epsilon=0.1, units=None,
-                 sparse_label=True, dtype='float32', prefix=None, params=None):
+                 sparse_label=True, prefix=None, params=None):
         super(LabelSmoothing, self).__init__(prefix=prefix, params=params)
         self._axis = axis
         self._epsilon = epsilon
         self._sparse_label = sparse_label
         self._units = units
-        self._dtype = dtype
 
     def hybrid_forward(self, F, inputs, units=None): # pylint: disable=arguments-differ
         """
@@ -149,7 +148,7 @@ class LabelSmoothing(HybridBlock):
                 'instance initialization when sparse_label is False'
             if units is None:
                 units = self._units
-            inputs = F.one_hot(inputs, depth=units, dtype=self._dtype)
+            inputs = F.one_hot(inputs, depth=units)
         if units is None and self._units is None:
             return F.Custom(inputs, epsilon=self._epsilon, axis=self._axis,
                             op_type='_smoothing_with_dim')

--- a/src/gluonnlp/model/attention_cell.py
+++ b/src/gluonnlp/model/attention_cell.py
@@ -53,7 +53,7 @@ def _masked_softmax(F, att_score, mask, dtype):
             neg = -10000
         else:
             raise ValueError('unexpected dtype: %s'%str(dtype))
-        att_score = F.where(mask, att_score, -1e18 * F.ones_like(att_score))
+        att_score = F.where(mask, att_score, neg * F.ones_like(att_score))
         att_weights = F.softmax(att_score, axis=-1) * mask
     else:
         att_weights = F.softmax(att_score, axis=-1)


### PR DESCRIPTION
## Description ##
I changed some transformer blocks to support fp16. Specifically:
- input token ids remains fp32
- adjust -inf mask value for softmax
- use fp32 for layernorm

Inference time on p3.2xlarge:
- fp32: 110.98 sec
- fp16: 58.61 sec

Inference accuracy with pre-trained fp32 model:
- fp32: 'exact_match': 81.21097445600756, 'f1': 88.4551346176558
- fp16:  'exact_match': 81.17313150425733, 'f1': 88.43968274854582

@zhiheng-huang

TODO:
Ideally the LayerNorm operator in MXNet should supports fp16 data with stable reduction for std calculation. 

https://github.com/apache/incubator-mxnet/issues/14073
https://github.com/apache/incubator-mxnet/issues/14072

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
