### PR TITLE
[FIX] Update default value of BERTAdam epsilon to 1e-6

### DIFF
--- a/src/gluonnlp/optimizer/bert_adam.py
+++ b/src/gluonnlp/optimizer/bert_adam.py
@@ -48,14 +48,14 @@ class BERTAdam(Optimizer):
 
     Parameters
     ----------
-    beta1 : float, optional
+    beta1 : float, optional, default is 0.9
         Exponential decay rate for the first moment estimates.
-    beta2 : float, optional
+    beta2 : float, optional, default is 0.999
         Exponential decay rate for the second moment estimates.
-    epsilon : float, optional
+    epsilon : float, optional, default is 1e-6
         Small value to avoid division by 0.
     """
-    def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999, epsilon=1e-8,
+    def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999, epsilon=1e-6,
                  **kwargs):
         super(BERTAdam, self).__init__(learning_rate=learning_rate, **kwargs)
         self.beta1 = beta1


### PR DESCRIPTION
## Description ##
This PR updates the default value for eps in the BERTAdam optimizer, so that it is consistent with the official bert repo. Note that a few other fine-tuning scripts are also using this optimizer. The epsilon values in these scripts are all explicitly provided in these scripts and will not be affected. #571 by @kenjewu  #493 by @fierceX  and https://github.com/dmlc/gluon-nlp/blob/master/scripts/bert/finetune_classifier.py by @haven-jeon. @bikestra your ongoing BERT+NER work might be affected. 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
