### PR TITLE
[DOC] MEN dataset documentation enhancement

### DIFF
--- a/src/gluonnlp/data/word_embedding_evaluation.py
+++ b/src/gluonnlp/data/word_embedding_evaluation.py
@@ -219,6 +219,7 @@ class MEN(WordSimilarityEvaluationDataset):
     Examples
     --------
     >>> men_dataset = nlp.data.MEN('test', root='./datasets/men')
+    -etc-
     >>> len(men)
     1000
     >>> men[0]

--- a/src/gluonnlp/data/word_embedding_evaluation.py
+++ b/src/gluonnlp/data/word_embedding_evaluation.py
@@ -223,7 +223,7 @@ class MEN(WordSimilarityEvaluationDataset):
     >>> len(men_dataset)
     1000
     >>> men_dataset[0]
-    [u'display', u'pond', 10.0]
+    ['display', 'pond', 10.0]
     """
     _url = 'https://staff.fnwi.uva.nl/e.bruni/resources/MEN.tar.gz'
     _namespace = 'gluon/dataset/men'

--- a/src/gluonnlp/data/word_embedding_evaluation.py
+++ b/src/gluonnlp/data/word_embedding_evaluation.py
@@ -216,6 +216,13 @@ class MEN(WordSimilarityEvaluationDataset):
     segment : str, default 'train'
         Dataset segment. Options are 'train', 'dev', 'test'.
 
+    Examples
+    --------
+    >>> men_dataset = nlp.data.MEN('test', root='./datasets/men')
+    >>> len(men)
+    1000
+    >>> men[0]
+    [u'display', u'pond', 10.0]
     """
     _url = 'https://staff.fnwi.uva.nl/e.bruni/resources/MEN.tar.gz'
     _namespace = 'gluon/dataset/men'

--- a/src/gluonnlp/data/word_embedding_evaluation.py
+++ b/src/gluonnlp/data/word_embedding_evaluation.py
@@ -220,9 +220,9 @@ class MEN(WordSimilarityEvaluationDataset):
     --------
     >>> men_dataset = gluonnlp.data.MEN('test', root='./datasets/men')
     -etc-
-    >>> len(men)
+    >>> len(men_dataset)
     1000
-    >>> men[0]
+    >>> men_dataset[0]
     [u'display', u'pond', 10.0]
     """
     _url = 'https://staff.fnwi.uva.nl/e.bruni/resources/MEN.tar.gz'

--- a/src/gluonnlp/data/word_embedding_evaluation.py
+++ b/src/gluonnlp/data/word_embedding_evaluation.py
@@ -218,7 +218,7 @@ class MEN(WordSimilarityEvaluationDataset):
 
     Examples
     --------
-    >>> men_dataset = nlp.data.MEN('test', root='./datasets/men')
+    >>> men_dataset = gluonnlp.data.MEN('test', root='./datasets/men')
     -etc-
     >>> len(men)
     1000


### PR DESCRIPTION
## Description ##
As described in https://github.com/dmlc/gluon-nlp/issues/405 many auto-downloaded datasets doesn't provide any data sample. It is not clear what samples look like and if any pre-processing is done. This PR adds an example to the MEN data by showing the number of samples in the test set and the first sample in the dataset. I suggest we follow this style and enhance the remaining datasets. 

Note that I deliberately specified `root=xxx` to make sure the data is downloaded each time doctest runs on CI, and `-etc-` makes any string message (including msg for downloading dataset) is acceptable. 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
