### PR TITLE
[BUGFIX][FEATURE] Fixes for BERT embedding, pretraining scripts

### DIFF
--- a/scripts/bert/embedding.py
+++ b/scripts/bert/embedding.py
@@ -3,11 +3,12 @@ import argparse
 import io
 import logging
 
-import gluonnlp
 import numpy as np
 import mxnet as mx
 
 from mxnet.gluon.data import DataLoader
+
+import gluonnlp
 from gluonnlp.data import BERTTokenizer, BERTSentenceTransform
 
 try:
@@ -55,7 +56,7 @@ class BertEmbedding(object):
         batch size
     """
 
-    def __init__(self, ctx=mx.cpu(), dtype="float32", model='bert_12_768_12',
+    def __init__(self, ctx=mx.cpu(), dtype='float32', model='bert_12_768_12',
                  dataset_name='book_corpus_wiki_en_uncased',
                  params_path=None, max_seq_length=25, batch_size=256):
         """
@@ -92,7 +93,7 @@ class BertEmbedding(object):
         self.bert.cast(self.dtype)
 
         if params_path:
-            logger.info("Loading params from {}".format(params_path))
+            logger.info('Loading params from {}' % params_path)
             self.bert.load_parameters(params_path, ctx=ctx, ignore_extra=True)
 
     def __call__(self, sentences, oov_way='avg'):
@@ -129,10 +130,8 @@ class BertEmbedding(object):
         return self.oov(batches, oov_way)
 
     def data_loader(self, sentences, shuffle=False):
-        if "uncased" in self.dataset_name:
-            lower = True
-        else:
-            lower = False
+        """Load, tokenize and prepare the input sentences."""
+        lower = 'uncased' in self.dataset_name
         tokenizer = BERTTokenizer(self.vocab, lower=lower)
         transform = BERTSentenceTransform(tokenizer=tokenizer,
                                           max_seq_length=self.max_seq_length,

--- a/scripts/bert/embedding.py
+++ b/scripts/bert/embedding.py
@@ -84,9 +84,15 @@ class BertEmbedding(object):
         self.max_seq_length = max_seq_length
         self.batch_size = batch_size
         self.dataset_name = dataset_name
+        if params_path is not None:
+            # Don't download the pretrained models if we have a parameter path
+            pretrained = False
+        else:
+            pretrained = True
         self.bert, self.vocab = gluonnlp.model.get_model(model,
                                                          dataset_name=self.dataset_name,
-                                                         pretrained=True, ctx=self.ctx,
+                                                         pretrained=pretrained,
+                                                         ctx=self.ctx,
                                                          use_pooler=False,
                                                          use_decoder=False,
                                                          use_classifier=False)

--- a/scripts/bert/embedding.py
+++ b/scripts/bert/embedding.py
@@ -1,11 +1,13 @@
 """BERT embedding."""
 import argparse
 import io
+import logging
 
+import gluonnlp
 import numpy as np
 import mxnet as mx
+
 from mxnet.gluon.data import DataLoader
-import gluonnlp
 from gluonnlp.data import BERTTokenizer, BERTSentenceTransform
 
 try:
@@ -28,6 +30,9 @@ def to_unicode(s):
 __all__ = ['BertEmbedding']
 
 
+logger = logging.getLogger(__name__)
+
+
 class BertEmbedding(object):
     """
     Encoding from BERT model.
@@ -36,19 +41,23 @@ class BertEmbedding(object):
     ----------
     ctx : Context.
         running BertEmbedding on which gpu device id.
+    dtype: str
+        data type to use for the model.
     model : str, default bert_12_768_12.
         pre-trained BERT model
     dataset_name : str, default book_corpus_wiki_en_uncased.
         pre-trained model dataset
+    params_path: str, default None
+        path to a parameters file to load instead of the pretrained model.
     max_seq_length : int, default 25
         max length of each sequence
     batch_size : int, default 256
         batch size
     """
 
-    def __init__(self, ctx=mx.cpu(), model='bert_12_768_12',
+    def __init__(self, ctx=mx.cpu(), dtype="float32", model='bert_12_768_12',
                  dataset_name='book_corpus_wiki_en_uncased',
-                 max_seq_length=25, batch_size=256):
+                 params_path=None, max_seq_length=25, batch_size=256):
         """
         Encoding from BERT model.
 
@@ -56,24 +65,35 @@ class BertEmbedding(object):
         ----------
         ctx : Context.
             running BertEmbedding on which gpu device id.
+        dtype: str
+            data type to use for the model.
         model : str, default bert_12_768_12.
             pre-trained BERT model
         dataset_name : str, default book_corpus_wiki_en_uncased.
             pre-trained model dataset
+        params_path: str, default None
+            path to a parameters file to load instead of the pretrained model.
         max_seq_length : int, default 25
             max length of each sequence
         batch_size : int, default 256
             batch size
         """
         self.ctx = ctx
+        self.dtype = dtype
         self.max_seq_length = max_seq_length
         self.batch_size = batch_size
+        self.dataset_name = dataset_name
         self.bert, self.vocab = gluonnlp.model.get_model(model,
-                                                         dataset_name=dataset_name,
+                                                         dataset_name=self.dataset_name,
                                                          pretrained=True, ctx=self.ctx,
                                                          use_pooler=False,
                                                          use_decoder=False,
                                                          use_classifier=False)
+        self.bert.cast(self.dtype)
+
+        if params_path:
+            logger.info("Loading params from {}".format(params_path))
+            self.bert.load_parameters(params_path, ctx=ctx, ignore_extra=True)
 
     def __call__(self, sentences, oov_way='avg'):
         return self.embedding(sentences, oov_way='avg')
@@ -102,14 +122,18 @@ class BertEmbedding(object):
             valid_length = valid_length.as_in_context(self.ctx)
             token_types = token_types.as_in_context(self.ctx)
             sequence_outputs = self.bert(token_ids, token_types,
-                                         valid_length.astype('float32'))
+                                         valid_length.astype(self.dtype))
             for token_id, sequence_output in zip(token_ids.asnumpy(),
                                                  sequence_outputs.asnumpy()):
                 batches.append((token_id, sequence_output))
         return self.oov(batches, oov_way)
 
     def data_loader(self, sentences, shuffle=False):
-        tokenizer = BERTTokenizer(self.vocab)
+        if "uncased" in self.dataset_name:
+            lower = True
+        else:
+            lower = False
+        tokenizer = BERTTokenizer(self.vocab, lower=lower)
         transform = BERTSentenceTransform(tokenizer=tokenizer,
                                           max_seq_length=self.max_seq_length,
                                           pair=False)
@@ -118,7 +142,7 @@ class BertEmbedding(object):
 
     def oov(self, batches, oov_way='avg'):
         """
-        How to handle oov
+        How to handle oov. Also filter out [CLS], [SEP] tokens.
 
         Parameters
         ----------
@@ -144,8 +168,10 @@ class BertEmbedding(object):
             oov_len = 1
             for token_id, sequence_output in zip(token_ids, sequence_outputs):
                 if token_id == 1:
+                    # [PAD] token, sequence is finished.
                     break
                 if token_id in (2, 3):
+                    # [CLS], [SEP]
                     continue
                 token = self.vocab.idx_to_token[token_id]
                 if token.startswith('##'):
@@ -175,10 +201,13 @@ if __name__ == '__main__':
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('--gpu', type=int, default=None,
                         help='id of the gpu to use. Set it to empty means to use cpu.')
+    parser.add_argument('--dtype', type=str, default='float32', help='data dtype')
     parser.add_argument('--model', type=str, default='bert_12_768_12',
                         help='pre-trained model')
     parser.add_argument('--dataset_name', type=str, default='book_corpus_wiki_en_uncased',
                         help='dataset')
+    parser.add_argument('--params_path', type=str, default=None,
+                        help='path to a params file to load instead of the pretrained model.')
     parser.add_argument('--max_seq_length', type=int, default=25,
                         help='max length of each sequence')
     parser.add_argument('--batch_size', type=int, default=256,
@@ -194,7 +223,15 @@ if __name__ == '__main__':
                         help='file for encoding')
 
     args = parser.parse_args()
-    context = mx.gpu(args.gpu) if args.gpu else mx.cpu()
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.getLogger().setLevel(level)
+    logging.info(args)
+
+    if args.gpu is not None:
+        context = mx.gpu(args.gpu)
+    else:
+        context = mx.cpu()
     bert_embedding = BertEmbedding(ctx=context, model=args.model, dataset_name=args.dataset_name,
                                    max_seq_length=args.max_seq_length, batch_size=args.batch_size)
     result = []
@@ -208,7 +245,7 @@ if __name__ == '__main__':
                 sents.append(line.strip())
         result = bert_embedding(sents, oov_way=args.oov_way)
     else:
-        print('Please specify --sentence or --file')
+        logger.error('Please specify --sentence or --file')
 
     if result:
         for sent, embeddings in zip(sents, result):

--- a/scripts/bert/embedding.py
+++ b/scripts/bert/embedding.py
@@ -84,14 +84,11 @@ class BertEmbedding(object):
         self.max_seq_length = max_seq_length
         self.batch_size = batch_size
         self.dataset_name = dataset_name
-        if params_path is not None:
-            # Don't download the pretrained models if we have a parameter path
-            pretrained = False
-        else:
-            pretrained = True
+
+        # Don't download the pretrained models if we have a parameter path
         self.bert, self.vocab = gluonnlp.model.get_model(model,
                                                          dataset_name=self.dataset_name,
-                                                         pretrained=pretrained,
+                                                         pretrained=params_path is None,
                                                          ctx=self.ctx,
                                                          use_pooler=False,
                                                          use_decoder=False,

--- a/scripts/bert/embedding.py
+++ b/scripts/bert/embedding.py
@@ -93,7 +93,7 @@ class BertEmbedding(object):
         self.bert.cast(self.dtype)
 
         if params_path:
-            logger.info('Loading params from {}' % params_path)
+            logger.info('Loading params from %s', params_path)
             self.bert.load_parameters(params_path, ctx=ctx, ignore_extra=True)
 
     def __call__(self, sentences, oov_way='avg'):

--- a/scripts/bert/run_pretraining.py
+++ b/scripts/bert/run_pretraining.py
@@ -338,7 +338,7 @@ def train(data_train, model, nsp_loss, mlm_loss, vocab_size, ctx, store):
     fp16_trainer = FP16Trainer(trainer, dynamic_loss_scale=dynamic_loss_scale)
 
     if args.ckpt_dir and args.start_step:
-        logging.info('Loading checkpoint from {}' % args.ckpt_dir)
+        logging.info('Loading checkpoint from %s',  args.ckpt_dir)
         trainer.load_states(os.path.join(args.ckpt_dir, '%07d.states' % args.start_step))
 
     accumulate = args.accumulate

--- a/scripts/bert/run_pretraining.py
+++ b/scripts/bert/run_pretraining.py
@@ -39,7 +39,6 @@ import glob
 import time
 import numpy as np
 
-import gluonnlp
 import mxnet as mx
 from mxnet import gluon
 from mxnet.gluon.data import DataLoader
@@ -100,14 +99,14 @@ level = logging.DEBUG if args.verbose else logging.INFO
 logging.getLogger().setLevel(level)
 logging.info(args)
 
-def get_model(ctx):
+def load_model(ctx):
     """get model"""
     # model
     pretrained = args.pretrained
     dataset = args.dataset_name
-    model, vocabulary = gluonnlp.model.get_model(args.model,
-                                                 dataset_name=dataset,
-                                                 pretrained=pretrained, ctx=ctx)
+    model, vocabulary = get_model(args.model,
+                                  dataset_name=dataset,
+                                  pretrained=pretrained, ctx=ctx)
     if not pretrained:
         model.initialize(init=mx.init.Normal(0.02), ctx=ctx)
 
@@ -447,7 +446,7 @@ if __name__ == '__main__':
     ctx = [mx.cpu()] if args.gpus is None or args.gpus == '' else \
           [mx.gpu(int(x)) for x in args.gpus.split(',')]
 
-    model, nsp_loss, mlm_loss, vocabulary = get_model(ctx)
+    model, nsp_loss, mlm_loss, vocabulary = load_model(ctx)
 
     lower = 'uncased' in args.dataset_name
     tokenizer = BERTTokenizer(vocabulary, lower=lower)
@@ -460,11 +459,11 @@ if __name__ == '__main__':
 
     if not args.eval_only:
         if args.data:
-            logging.info("Using training data at {}".format(args.data))
+            logging.info('Using training data at {}'.format(args.data))
             data_train = get_dataset(args.data, args.batch_size, len(ctx), True, store)
             train(data_train, model, nsp_loss, mlm_loss, len(tokenizer.vocab), ctx, store)
 
     if args.data_eval:
-        logging.info("Using evaluation data at {}".format(args.data_eval))
+        logging.info('Using evaluation data at {}'.format(args.data_eval))
         data_eval = get_dataset(args.data_eval, args.batch_size_eval, len(ctx), False, store)
         evaluate(data_eval, model, nsp_loss, mlm_loss, len(tokenizer.vocab), ctx)

--- a/scripts/bert/run_pretraining.py
+++ b/scripts/bert/run_pretraining.py
@@ -48,7 +48,7 @@ from gluonnlp.utils import Parallelizable, Parallel
 from gluonnlp.metric import MaskedAccuracy
 from gluonnlp.model import get_model
 from gluonnlp.data.batchify import Tuple, Stack, Pad
-from gluonnlp.data import SimpleDatasetStream, FixedBucketSampler, NumpyDataset, BERTTokenizer
+from gluonnlp.data import SimpleDatasetStream, FixedBucketSampler, NumpyDataset
 from utils import profile
 from fp16_utils import FP16Trainer
 
@@ -447,9 +447,6 @@ if __name__ == '__main__':
           [mx.gpu(int(x)) for x in args.gpus.split(',')]
 
     model, nsp_loss, mlm_loss, vocabulary = load_model(ctx)
-
-    lower = 'uncased' in args.dataset_name
-    tokenizer = BERTTokenizer(vocabulary, lower=lower)
     store = mx.kv.create(args.kvstore)
 
     if args.ckpt_dir:
@@ -461,9 +458,9 @@ if __name__ == '__main__':
         if args.data:
             logging.info('Using training data at {}'.format(args.data))
             data_train = get_dataset(args.data, args.batch_size, len(ctx), True, store)
-            train(data_train, model, nsp_loss, mlm_loss, len(tokenizer.vocab), ctx, store)
+            train(data_train, model, nsp_loss, mlm_loss, len(vocabulary), ctx, store)
 
     if args.data_eval:
         logging.info('Using evaluation data at {}'.format(args.data_eval))
         data_eval = get_dataset(args.data_eval, args.batch_size_eval, len(ctx), False, store)
-        evaluate(data_eval, model, nsp_loss, mlm_loss, len(tokenizer.vocab), ctx)
+        evaluate(data_eval, model, nsp_loss, mlm_loss, len(vocabulary), ctx)

--- a/scripts/bert/run_pretraining.py
+++ b/scripts/bert/run_pretraining.py
@@ -338,8 +338,8 @@ def train(data_train, model, nsp_loss, mlm_loss, vocab_size, ctx, store):
     fp16_trainer = FP16Trainer(trainer, dynamic_loss_scale=dynamic_loss_scale)
 
     if args.ckpt_dir and args.start_step:
-        logging.info("Loading checkpoint from {}".format(args.ckpt_dir))
-        trainer.load_states(os.path.join(args.ckpt_dir, '%07d.states'%args.start_step))
+        logging.info('Loading checkpoint from {}' % args.ckpt_dir)
+        trainer.load_states(os.path.join(args.ckpt_dir, '%07d.states' % args.start_step))
 
     accumulate = args.accumulate
     num_train_steps = args.num_steps

--- a/scripts/bert/run_pretraining.py
+++ b/scripts/bert/run_pretraining.py
@@ -338,7 +338,7 @@ def train(data_train, model, nsp_loss, mlm_loss, vocab_size, ctx, store):
     fp16_trainer = FP16Trainer(trainer, dynamic_loss_scale=dynamic_loss_scale)
 
     if args.ckpt_dir and args.start_step:
-        logging.info('Loading checkpoint from %s',  args.ckpt_dir)
+        logging.info('Loading checkpoint from %s', args.ckpt_dir)
         trainer.load_states(os.path.join(args.ckpt_dir, '%07d.states' % args.start_step))
 
     accumulate = args.accumulate

--- a/scripts/tests/test_bert_embedding.py
+++ b/scripts/tests/test_bert_embedding.py
@@ -36,12 +36,21 @@ def test_bert_embedding_dataset():
 def test_bert_embedding_data_loader():
     sentence = u'is this jacksonville ?'
     bert = BertEmbedding(max_seq_length=10)
-    iter = bert.data_loader([sentence])
-    first_sentence = []
-    for i in iter:
+    first_sentence = None
+    for i in bert.data_loader([sentence]):
         first_sentence = i
         break
     assert len(first_sentence[0][0]) == 10
+
+
+def test_bert_embedding_data_loader_works_with_cased_data():
+    bert = BertEmbedding(dataset_name="book_corpus_wiki_en_cased")
+    assert bert.tokenizer.basic_tokenizer.lower = False
+
+
+def test_bert_embedding_data_loader_works_with_uncased_data():
+    bert = BertEmbedding(dataset_name="book_corpus_wiki_en_uncased")
+    assert bert.tokenizer.basic_tokenizer.lower = True
 
 
 @pytest.mark.serial

--- a/scripts/tests/test_bert_embedding.py
+++ b/scripts/tests/test_bert_embedding.py
@@ -57,7 +57,7 @@ def test_bert_embedding_data_loader_works_with_uncased_data():
 @pytest.mark.remote_required
 @pytest.mark.gpu
 def test_bert_embedding():
-    process = subprocess.check_call(['python', './scripts/bert/embedding.py', '--gpu', '0',
+    process = subprocess.check_call(['python', './scripts/bert/embedding.py', '--gpu', '0', '--dtype', 'float32',
                                      '--model', 'bert_12_768_12', '--dataset_name', 'book_corpus_wiki_en_uncased',
                                      '--max_seq_length', '25', '--batch_size', '256',
                                      '--oov_way', 'avg', '--sentences', '"is this jacksonville ?"'])

--- a/scripts/tests/test_bert_embedding.py
+++ b/scripts/tests/test_bert_embedding.py
@@ -45,12 +45,12 @@ def test_bert_embedding_data_loader():
 
 def test_bert_embedding_data_loader_works_with_cased_data():
     bert = BertEmbedding(dataset_name="book_corpus_wiki_en_cased")
-    assert bert.tokenizer.basic_tokenizer.lower = False
+    assert bert.tokenizer.basic_tokenizer.lower == False
 
 
 def test_bert_embedding_data_loader_works_with_uncased_data():
     bert = BertEmbedding(dataset_name="book_corpus_wiki_en_uncased")
-    assert bert.tokenizer.basic_tokenizer.lower = True
+    assert bert.tokenizer.basic_tokenizer.lower == True
 
 
 @pytest.mark.serial

--- a/scripts/tests/test_bert_embedding.py
+++ b/scripts/tests/test_bert_embedding.py
@@ -62,4 +62,13 @@ def test_bert_embedding():
                                      '--max_seq_length', '25', '--batch_size', '256',
                                      '--oov_way', 'avg', '--sentences', '"is this jacksonville ?"'])
     time.sleep(5)
+    
+    process = subprocess.check_call(['python', './scripts/bert/embedding.py', '--gpu', '0',
+                                     '--model', 'bert_12_768_12', '--dataset_name', 'book_corpus_wiki_en_uncased',
+                                     '--max_seq_length', '25', '--batch_size', '256',
+                                     '--params_path',
+                                     '~/.mxnet/models/bert_12_768_12_book_corpus_wiki_en_uncased-75cc780f.params',
+                                     '--oov_way', 'avg', '--sentences', '"is this jacksonville ?"'])
 
+
+    time.sleep(5)

--- a/scripts/tests/test_bert_embedding.py
+++ b/scripts/tests/test_bert_embedding.py
@@ -68,7 +68,7 @@ def test_bert_embedding():
                                      '--max_seq_length', '25', '--batch_size', '256',
                                      '--params_path',
                                      '~/.mxnet/models/bert_12_768_12_book_corpus_wiki_en_uncased-75cc780f.params',
-                                     '--oov_way', 'avg', '--sentences', '"is this jacksonville ?"'])
+                                     '--oov_way', 'avg', '--sentences', '"is this jacksonville ?"', '--verbose'])
 
 
     time.sleep(5)


### PR DESCRIPTION
## Description ##

Fix some bugs and add small features to the BERT pretraining and embedding scripts. Summary below:

For `scripts/bert/run_pretraining.py`:

* [FEATURE] The script can load and fine-tune any BERT model, not just BERT base.
* [FEATURE] Add command-line option to only run the eval.
* [BUGFIX] In `evaluate()`, move the total loss calculation outside of checkpointing. If the logging interval is larger than the number of data batches, the total losses would be 0.
* [BUGFIX] Loading would fail when loading a model a model that has already been fine-tuned with float16 (e.g. from a previous checkpoint). Add a `model.cast()` before attepting to load a checkpoint.
* Add some extra comments and logging.

For `scripts/bert/embedding.py`:

* [BUGFIX] Do not lowercase the input data if loading a cased BERT model.
* [BUGFIX] Fix the context selection code so that GPU=0 selects the GPU, and not CPU.
* [FEATURE] Add parameter to specify data type.
* [FEATURE] Allow loading a pre-trained BERT model from a parameter file.
* [FEATURE] Use logging instead of print statements.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
