### PR TITLE
[BUGFIX] Fix multiprocessing bug in create_pretraining_data.py for bert

### DIFF
--- a/scripts/bert/create_pretraining_data.py
+++ b/scripts/bert/create_pretraining_data.py
@@ -595,7 +595,7 @@ def main():
     assert count == len(input_files)
 
     # dispatch to workers
-    if nworker > 0:
+    if nworker > 1:
         pool = Pool(nworker)
         pool.map(create_training_instances, map_args)
     else:


### PR DESCRIPTION
## Description ##
Fix multiprocessing bug which causes unnecessary dispatching to single worker.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Only consider `nworker >= 2` as the condition for multiprocessing.

## Comments ##

I guess the other condition branch is intended for serial execution, while it will never be triggered when `nworker` is 1.
