### PR TITLE
[DOC] Add alternative link for bert scripts

### DIFF
--- a/docs/examples/sentence_embedding/bert.md
+++ b/docs/examples/sentence_embedding/bert.md
@@ -297,9 +297,9 @@ preprocess the data, automatically download the pre-trained model, and feed the
 transformed data into the model. For demonstration purpose, we skipped the
 warmup learning rate
 schedule and validation on dev dataset used in the original
-implementation. Please visit
-[here](../../model_zoo/bert/index.rst) for the
-complete fine-tuning scripts.
+implementation. Please visit the
+[BERT model zoo webpage](../../model_zoo/bert/index.rst), or the scripts/bert folder
+in the Github repository for complete fine-tuning scripts.
 
 ## References
 


### PR DESCRIPTION
## Description ##
attempt to mitigate issue #666 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
