### PR TITLE
[TUTORIAL] Fix README WikiText2 example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ Load the Wikitext-2 dataset, for example:
 
     >>> import gluonnlp as nlp
     >>> train = nlp.data.WikiText2(segment='train')
-    >>> train[0][0:5]
+    >>> train[0:5]
     ['=', 'Valkyria', 'Chronicles', 'III', '=']
 
 `Vocabulary Construction <http://gluon-nlp.mxnet.io/master/api/modules/vocab.html>`__


### PR DESCRIPTION
## Description ##
This fixes `nlp.data.WikiText2(segment='train')[0][0:5]` to `nlp.data.WikiText2(segment='train')[0:5]` because `nlp.data.WikiText2(segment='train')[0][0:5]` is '='.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
