### PR TITLE
[FIX] fix bert forward call parameter mismatch in convert_tf_model.py

### DIFF
--- a/scripts/bert/convert_tf_model.py
+++ b/scripts/bert/convert_tf_model.py
@@ -151,7 +151,7 @@ bert = BERTModel(encoder, len(vocab),
 bert.initialize(init=mx.init.Normal(0.02))
 
 ones = mx.nd.ones((2, 8))
-out = bert(ones, ones, mx.nd.array([1, 2]))
+out = bert(ones, ones, mx.nd.array([5, 6]), mx.nd.array([[1], [2]]))
 params = bert._collect_params_with_prefix()
 
 # set parameter data


### PR DESCRIPTION
## Description ##
fix bert forward call parameter mismatch in scripts/bert/convert_tf_model.py line 154

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x]  fix bert forward call parameter mismatch 

## Comments ##
- fix error below:
Traceback (most recent call last):
  File "/data/etb/data1/NLP/Program/bert/gluon_nlp_fork/scripts/bert/convert_tf_model.py", line 154, in <module>
    out = bert(ones, ones, mx.nd.array([1, 2])) 
  File "/data/etb/miniconda3/envs/mxnet_py3/lib/python3.6/site-packages/mxnet/gluon/block.py", line 540, in __call__
    out = self.forward(*args)
  File "/data/etb/miniconda3/envs/mxnet_py3/lib/python3.6/site-packages/gluonnlp/model/bert.py", line 435, in forward
    'masked_positions tensor is required for decoding masked language model'
AssertionError: masked_positions tensor is required for decoding masked language model
