### PR TITLE
[BUGFIX] Fix mlm_loss reporting for eval dataset

### DIFF
--- a/scripts/bert/pretraining_utils.py
+++ b/scripts/bert/pretraining_utils.py
@@ -211,8 +211,8 @@ def evaluate(data_eval, model, nsp_loss, mlm_loss, vocab_size, ctx, log_interval
                 mask_pred_list.append(decoded)
                 mask_weight_list.append(masked_weight)
 
-                running_mlm_loss += ls1.as_in_context(mx.cpu())
-                running_nsp_loss += ls2.as_in_context(mx.cpu())
+                running_mlm_loss += ls1.as_in_context(mx.cpu()).astype('float32')
+                running_nsp_loss += ls2.as_in_context(mx.cpu()).astype('float32')
                 running_num_tks += valid_length.sum().as_in_context(mx.cpu())
             nsp_metric.update(ns_label_list, ns_pred_list)
             mlm_metric.update(mask_label_list, mask_pred_list, mask_weight_list)
@@ -230,6 +230,9 @@ def evaluate(data_eval, model, nsp_loss, mlm_loss, vocab_size, ctx, log_interval
 
     mx.nd.waitall()
     eval_end_time = time.time()
+    if running_mlm_loss != 0:
+        total_mlm_loss += running_mlm_loss
+        total_nsp_loss += running_nsp_loss
     total_mlm_loss /= step_num
     total_nsp_loss /= step_num
     logging.info('mlm_loss={:.3f}\tmlm_acc={:.1f}\tnsp_loss={:.3f}\tnsp_acc={:.1f}\t'

--- a/scripts/bert/pretraining_utils.py
+++ b/scripts/bert/pretraining_utils.py
@@ -211,8 +211,8 @@ def evaluate(data_eval, model, nsp_loss, mlm_loss, vocab_size, ctx, log_interval
                 mask_pred_list.append(decoded)
                 mask_weight_list.append(masked_weight)
 
-                running_mlm_loss += ls1.as_in_context(mx.cpu()).astype('float32')
-                running_nsp_loss += ls2.as_in_context(mx.cpu()).astype('float32')
+                running_mlm_loss += ls1.as_in_context(mx.cpu())
+                running_nsp_loss += ls2.as_in_context(mx.cpu())
                 running_num_tks += valid_length.sum().as_in_context(mx.cpu())
             nsp_metric.update(ns_label_list, ns_pred_list)
             mlm_metric.update(mask_label_list, mask_pred_list, mask_weight_list)

--- a/scripts/bert/pretraining_utils.py
+++ b/scripts/bert/pretraining_utils.py
@@ -230,6 +230,7 @@ def evaluate(data_eval, model, nsp_loss, mlm_loss, vocab_size, ctx, log_interval
 
     mx.nd.waitall()
     eval_end_time = time.time()
+    # accumulate losses from last few batches, too
     if running_mlm_loss != 0:
         total_mlm_loss += running_mlm_loss
         total_nsp_loss += running_nsp_loss


### PR DESCRIPTION
## Description ##
`total_mlm_loss` was only updated every `log_interval` steps, and losses of last few steps are not added to the total loss. This PR fixes that.

@khetan2 @paperplanet @AI-richard FYI 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented