### PR TITLE
Pytest 4 support

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -150,7 +150,7 @@ def function_scope_seed(request):
 
     """
 
-    seed = request.node.get_marker('seed')
+    seed = request.node.get_closest_marker('seed')
     env_seed_str = os.getenv('MXNET_TEST_SEED')
 
     if seed is not None:

--- a/env/cpu/py2.yml
+++ b/env/cpu/py2.yml
@@ -9,9 +9,9 @@ dependencies:
   - sphinx=1.7.7
   - spacy
   - nltk
-  - pytest<4
-  - flaky<4
-  - pytest-cov=2.6.0
+  - pytest=4.5.0
+  - flaky=3.5.3
+  - pytest-cov=2.7.1
   - mock<3
   - pytest-xdist<2
   - pip:

--- a/env/cpu/py3-master.yml
+++ b/env/cpu/py3-master.yml
@@ -9,9 +9,9 @@ dependencies:
   - sphinx=1.7.7
   - spacy
   - nltk
-  - pytest<4
-  - flaky<4
-  - pytest-cov=2.6.0
+  - pytest=4.5.0
+  - flaky=3.5.3
+  - pytest-cov=2.7.1
   - mock<3
   - pytest-xdist<2
   - pip:

--- a/env/cpu/py3.yml
+++ b/env/cpu/py3.yml
@@ -9,9 +9,9 @@ dependencies:
   - sphinx=1.7.7
   - spacy
   - nltk
-  - pytest<4
-  - flaky<4
-  - pytest-cov=2.6.0
+  - pytest=4.5.0
+  - flaky=3.5.3
+  - pytest-cov=2.7.1
   - mock<3
   - pytest-xdist<1.28
   - recommonmark

--- a/env/gpu/py2.yml
+++ b/env/gpu/py2.yml
@@ -9,9 +9,9 @@ dependencies:
   - sphinx=1.7.7
   - spacy
   - nltk
-  - pytest<4
-  - flaky<4
-  - pytest-cov=2.6.0
+  - pytest=4.5.0
+  - flaky=3.5.3
+  - pytest-cov=2.7.1
   - mock<3
   - pytest-xdist<2
   - pip:

--- a/env/gpu/py3-master.yml
+++ b/env/gpu/py3-master.yml
@@ -9,9 +9,9 @@ dependencies:
   - sphinx=1.7.7
   - spacy
   - nltk
-  - pytest<4
-  - flaky<4
-  - pytest-cov=2.6.0
+  - pytest=4.5.0
+  - flaky=3.5.3
+  - pytest-cov=2.7.1
   - mock<3
   - pytest-xdist<2
   - recommonmark

--- a/env/gpu/py3.yml
+++ b/env/gpu/py3.yml
@@ -9,9 +9,9 @@ dependencies:
   - sphinx=1.7.7
   - spacy
   - nltk
-  - pytest<4
-  - flaky<4
-  - pytest-cov=2.6.0
+  - pytest=4.5.0
+  - flaky=3.5.3
+  - pytest-cov=2.7.1
   - mock<3
   - pytest-xdist<2
   - recommonmark

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
             'sphinx-gallery',
             'sphinx_rtd_theme',
             'nbsphinx',
+            'flaky',
         ],
     },
 )


### PR DESCRIPTION
Should fix pytest > 4 support. See https://github.com/dmlc/gluon-nlp/issues/727