### PR TITLE
[TUTORIAL] Fix vocab construction code in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,7 +147,7 @@ Build vocabulary based on the above dataset, for example:
 
 .. code:: python
 
-    >>> vocab = nlp.Vocab(counter=nlp.data.Counter(train[0]))
+    >>> vocab = nlp.Vocab(counter=nlp.data.Counter(train))
     >>> vocab
     Vocab(size=33280, unk="<unk>", reserved="['<pad>', '<bos>', '<eos>']")
 


### PR DESCRIPTION
## Description ##
fix codes `nlp.Vocab(counter=nlp.data.Counter(train[0]))` to `nlp.Vocab(counter=nlp.data.Counter(train))`, because `train[0]` is '='.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
