### PR TITLE
[FEATURE] Flexible vocabulary

### DIFF
--- a/scripts/bert/utils.py
+++ b/scripts/bert/utils.py
@@ -49,11 +49,11 @@ def convert_vocab(vocab_file):
         idx_to_token[original_idx] = original_token
         swap_idx.append((original_idx, target_idx))
 
-    reserved_tokens = [gluonnlp.vocab.BERTVocab.PADDING_TOKEN, gluonnlp.vocab.BERTVocab.CLS_TOKEN,
-                       gluonnlp.vocab.BERTVocab.SEP_TOKEN, gluonnlp.vocab.BERTVocab.MASK_TOKEN]
+    reserved_tokens = [gluonnlp.vocab.bert.PADDING_TOKEN, gluonnlp.vocab.bert.CLS_TOKEN,
+                       gluonnlp.vocab.bert.SEP_TOKEN, gluonnlp.vocab.bert.MASK_TOKEN]
 
-    unknown_token = gluonnlp.vocab.BERTVocab.UNKNOWN_TOKEN
-    padding_token = gluonnlp.vocab.BERTVocab.PADDING_TOKEN
+    unknown_token = gluonnlp.vocab.bert.UNKNOWN_TOKEN
+    padding_token = gluonnlp.vocab.bert.PADDING_TOKEN
     swap_idx = []
     assert unknown_token in token_to_idx
     assert padding_token in token_to_idx
@@ -75,9 +75,9 @@ def convert_vocab(vocab_file):
     bert_vocab_dict['padding_token'] = padding_token
     bert_vocab_dict['bos_token'] = None
     bert_vocab_dict['eos_token'] = None
-    bert_vocab_dict['mask_token'] = gluonnlp.vocab.BERTVocab.MASK_TOKEN
-    bert_vocab_dict['sep_token'] = gluonnlp.vocab.BERTVocab.SEP_TOKEN
-    bert_vocab_dict['cls_token'] = gluonnlp.vocab.BERTVocab.CLS_TOKEN
+    bert_vocab_dict['mask_token'] = gluonnlp.vocab.bert.MASK_TOKEN
+    bert_vocab_dict['sep_token'] = gluonnlp.vocab.bert.SEP_TOKEN
+    bert_vocab_dict['cls_token'] = gluonnlp.vocab.bert.CLS_TOKEN
     json_str = json.dumps(bert_vocab_dict)
     converted_vocab = gluonnlp.vocab.BERTVocab.from_json(json_str)
     return converted_vocab, swap_idx

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ setup(
         ],
         'dev': [
             'pytest',
+            'pylint',
+            'pylint_quotes',
+            'flake8',
             'recommonmark',
             'sphinx-gallery',
             'sphinx_rtd_theme',

--- a/src/gluonnlp/_constants.py
+++ b/src/gluonnlp/_constants.py
@@ -30,10 +30,6 @@ EOS_TOKEN = '<eos>'
 
 PAD_TOKEN = '<pad>'
 
-UNK_IDX = 0   # This should not be changed as long as serialized token
-              # embeddings redistributed on S3 contain an unknown token.
-              # Blame this code change and see commit for more context.
-
 LARGE_POSITIVE_FLOAT = 1e18
 
 LARGE_NEGATIVE_FLOAT = -LARGE_POSITIVE_FLOAT

--- a/src/gluonnlp/base.py
+++ b/src/gluonnlp/base.py
@@ -25,7 +25,7 @@ import os
 __all__ = ['_str_types', 'numba_njit', 'numba_prange', 'numba_jitclass', 'numba_types',
            'get_home_dir']
 
-try:
+try:  # Python 2 compat
     _str_types = (str, unicode)
 except NameError:  # Python 3
     _str_types = (str, )

--- a/src/gluonnlp/vocab/bert.py
+++ b/src/gluonnlp/vocab/bert.py
@@ -24,19 +24,27 @@ from __future__ import absolute_import, print_function
 
 import json
 import os
-import warnings
 
 from ..data.transforms import SentencepieceTokenizer
-from ..data.utils import DefaultLookupDict, _convert_to_unicode
+from ..data.utils import _convert_to_unicode, count_tokens
 from .vocab import Vocab
 
 __all__ = ['BERTVocab']
 
 
+UNKNOWN_TOKEN = '[UNK]'
+PADDING_TOKEN = '[PAD]'
+MASK_TOKEN = '[MASK]'
+SEP_TOKEN = '[SEP]'
+CLS_TOKEN = '[CLS]'
 
 
 class BERTVocab(Vocab):
-    """BERT special character vocabulary.
+    """Specialization of gluonnlp.Vocab for BERT models.
+
+    BERTVocab changes default token representations of unknown and other
+    special tokens of gluonnlp.Vocab and adds convenience parameters to specify
+    mask, sep and cls tokens typically used by Bert models.
 
     Parameters
     ----------
@@ -55,10 +63,10 @@ class BERTVocab(Vocab):
         argument has no effect.
     min_freq : int, default 1
         The minimum frequency required for a token in the keys of `counter` to be indexed.
-    unknown_token : hashable object or None, default '[unk]'
+    unknown_token : hashable object or None, default '[UNK]'
         The representation for any unknown token. In other words, any unknown token will be indexed
         as the same representation. If None, looking up an unknown token will result in KeyError.
-    padding_token : hashable object or None, default '[pad]'
+    padding_token : hashable object or None, default '[PAD]'
         The representation for the special token of padding token.
     bos_token : hashable object or None, default None
         The representation for the special token of beginning-of-sequence token.
@@ -70,25 +78,30 @@ class BERTVocab(Vocab):
         A token used to separate sentence pairs for BERT.
     cls_token : hashable object or None, default '[CLS]'
         Classification symbol for BERT.
-    reserved_tokens : list of hashable objects or None, default [mask_token, sep_token, cls_token],
-        A list of reserved tokens (excluding `unknown_token`) that will always be indexed, such as
-        special symbols representing padding, beginning of sentence, and end of sentence. It cannot
-        contain `unknown_token` or duplicate reserved tokens. Keys of `counter`, `unknown_token`,
-        and values of `reserved_tokens` must be of the same hashable type. Examples: str, int, and
-        tuple.
+    reserved_tokens : list of hashable objects or None, default None
+        A list specifying additional reserved tokens that will always be
+        indexed similar to `padding_token`, `bos_token` or `eos_token`.
+        `reserved_tokens` cannot contain `unknown_token` or duplicate reserved
+        tokens.
+        Keys of `counter`, `unknown_token`, and values of `reserved_tokens`
+        must be of the same hashable type. Examples of hashable types are str,
+        int, and tuple.
+    identifiers_to_tokens : dict mapping elements of reserved_tokens to str or None, default None
+        If `identifiers_to_tokens` is a dictionary, it specifies a mapping from
+        identifiers `name` to tokens part of the resulting Vocab `v`. `v` will
+        expose each of the tokens specified as individual attributes. For
+        example `reserved_tokens = {'my_special_token': '<special>'}` results
+        in a vocabulary object with attribute `v.my_special_token == '<special>'`
+    token_to_idx : dict mapping tokens (hashable objects) to int or None, default None
+        Optionally specifies the indices of tokens to be used by the
+        vocabulary. Each token in `token_to_index` must be part of the Vocab
+        and each index can only be associated with a single token.
+        `token_to_idx` is not required to contain a mapping for all tokens. For
+        example, it is valid to only set the `unknown_token` index to 10 (instead
+        of the default of 0) with `token_to_idx = {'<unk>': 10}`.
 
     Attributes
     ----------
-    UNKNOWN_TOKEN : '[UNK]'
-        Static attribute of BERTVocab, unknown token for BERT.
-    PADDING_TOKEN : '[PAD]'
-        Static attribute of BERTVocab, padding token for BERT.
-    MASK_TOKEN : '[MASK]'
-        Static attribute of BERTVocab, mask token for BERT.
-    SEP_TOKEN : '[SEP]'
-        Static attribute of BERTVocab, a token used to separate sentence pairs for BERT.
-    CLS_TOKEN : '[CLS]'
-        Static attribute of BERTVocab, Classification symbol for BERT.
     embedding : instance of :class:`gluonnlp.embedding.TokenEmbedding`
         The embedding of the indexed tokens.
     idx_to_token : list of strs
@@ -97,113 +110,111 @@ class BERTVocab(Vocab):
         A list of reserved tokens that will always be indexed.
     token_to_idx : dict mapping str to int
         A dict mapping each token to its index integer.
-    unknown_token : hashable object or None, default '[UNK]'
+    unknown_token : hashable object or None
         The representation for any unknown token. In other words, any unknown token will be indexed
         as the same representation.
-    padding_token : hashable object or None, default '[PAD]'
+    padding_token : hashable object or None
         The representation for padding token.
-    bos_token : hashable object or None, default None
+    bos_token : hashable object or None
         The representation for beginning-of-sentence token.
-    eos_token : hashable object or None, default None
+    eos_token : hashable object or None
         The representation for end-of-sentence token.
     mask_token : hashable object or None, default '[MASK]'
         The representation for the special token of mask token for BERT.
     sep_token : hashable object or None, default '[SEP]'
         a token used to separate sentence pairs for BERT.
     cls_token : hashable object or None, default '[CLS]'
+
     """
 
-    UNKNOWN_TOKEN = '[UNK]'
+    def __init__(self, counter=None, max_size=None, min_freq=1,
+                 unknown_token=UNKNOWN_TOKEN, padding_token=PADDING_TOKEN,
+                 bos_token=None, eos_token=None, mask_token=MASK_TOKEN,
+                 sep_token=SEP_TOKEN, cls_token=CLS_TOKEN,
+                 reserved_tokens=None, identifiers_to_tokens=None,
+                 token_to_idx=None):
 
-    PADDING_TOKEN = '[PAD]'
-
-    MASK_TOKEN = '[MASK]'
-
-    SEP_TOKEN = '[SEP]'
-
-    CLS_TOKEN = '[CLS]'
-
-    def __init__(self, counter=None, max_size=None, min_freq=1, unknown_token=UNKNOWN_TOKEN,
-                 padding_token=PADDING_TOKEN, bos_token=None, eos_token=None,
-                 mask_token=MASK_TOKEN, sep_token=SEP_TOKEN, cls_token=CLS_TOKEN,
-                 reserved_tokens=None):
-        special_tokens = [token for token in [mask_token, sep_token, cls_token]
-                          if token is not None]
+        special_bert_tokens = [
+            t for t in [mask_token, sep_token, cls_token] if t is not None
+        ]
         if reserved_tokens:
-            reserved_tokens.extend(special_tokens)
+            reserved_tokens.extend(special_bert_tokens)
         else:
-            reserved_tokens = special_tokens
-        super(BERTVocab, self).__init__(counter, max_size, min_freq, unknown_token,
-                                        padding_token, bos_token, eos_token, reserved_tokens)
-        self._mask_token = mask_token
-        self._sep_token = sep_token
-        self._cls_token = cls_token
+            reserved_tokens = special_bert_tokens
 
-    @property
-    def mask_token(self):
-        return self._mask_token
+        if identifiers_to_tokens is None:
+            identifiers_to_tokens = dict()
 
-    @property
-    def sep_token(self):
-        return self._sep_token
+        if mask_token:
+            assert mask_token not in identifiers_to_tokens
+            identifiers_to_tokens.update(mask_token=mask_token)
+        if mask_token:
+            assert sep_token not in identifiers_to_tokens
+            identifiers_to_tokens.update(sep_token=sep_token)
+        if mask_token:
+            assert cls_token not in identifiers_to_tokens
+            identifiers_to_tokens.update(cls_token=cls_token)
 
-    @property
-    def cls_token(self):
-        return self._cls_token
-
-    def to_json(self):
-        """Serialize BERTVocab object to json string.
-        This method does not serialize the underlying embedding.
-        """
-        if self._embedding:
-            warnings.warn('Serialization of attached embedding '
-                          'to json is not supported. '
-                          'You may serialize the embedding to a binary format '
-                          'separately using bert_vocab.embedding.serialize')
-        vocab_dict = {}
-        vocab_dict['idx_to_token'] = self._idx_to_token
-        vocab_dict['token_to_idx'] = dict(self._token_to_idx)
-        vocab_dict['reserved_tokens'] = self._reserved_tokens
-        vocab_dict['unknown_token'] = self._unknown_token
-        vocab_dict['padding_token'] = self._padding_token
-        vocab_dict['bos_token'] = self._bos_token
-        vocab_dict['eos_token'] = self._eos_token
-        vocab_dict['mask_token'] = self._mask_token
-        vocab_dict['sep_token'] = self._sep_token
-        vocab_dict['cls_token'] = self._cls_token
-        return json.dumps(vocab_dict)
+        super(BERTVocab, self).__init__(counter=counter, max_size=max_size,
+                                        min_freq=min_freq, unknown_token=unknown_token,
+                                        padding_token=padding_token, bos_token=bos_token,
+                                        eos_token=eos_token,
+                                        reserved_tokens=reserved_tokens,
+                                        identifiers_to_tokens=identifiers_to_tokens,
+                                        token_to_idx=token_to_idx)
 
     @classmethod
     def from_json(cls, json_str):
-        """Deserialize BERTVocab object from json string.
+        """Deserialize Vocab object from json string.
 
         Parameters
         ----------
         json_str : str
-            Serialized json string of a BERTVocab object.
+            Serialized json string of a Vocab object.
+
 
         Returns
         -------
-        BERTVocab
+        Vocab
         """
         vocab_dict = json.loads(json_str)
-
+        token_to_idx = vocab_dict.get('token_to_idx')
         unknown_token = vocab_dict.get('unknown_token')
-        bert_vocab = cls(unknown_token=unknown_token)
-        bert_vocab._idx_to_token = vocab_dict.get('idx_to_token')
-        bert_vocab._token_to_idx = vocab_dict.get('token_to_idx')
-        if unknown_token:
-            bert_vocab._token_to_idx = DefaultLookupDict(bert_vocab._token_to_idx[unknown_token],
-                                                         bert_vocab._token_to_idx)
-        bert_vocab._reserved_tokens = vocab_dict.get('reserved_tokens')
-        bert_vocab._padding_token = vocab_dict.get('padding_token')
-        bert_vocab._bos_token = vocab_dict.get('bos_token')
-        bert_vocab._eos_token = vocab_dict.get('eos_token')
-        bert_vocab._mask_token = vocab_dict.get('mask_token')
-        bert_vocab._sep_token = vocab_dict.get('sep_token')
-        bert_vocab._cls_token = vocab_dict.get('cls_token')
+        padding_token = vocab_dict.get('padding_token')
+        bos_token = vocab_dict.get('bos_token')
+        eos_token = vocab_dict.get('eos_token')
+        special_tokens = [unknown_token, padding_token, bos_token, eos_token]
+        reserved_tokens = vocab_dict.get('reserved_tokens')
 
-        return bert_vocab
+        # workaround reserved and special tokens being serialized together
+        reserved_tokens = [
+            t for t in reserved_tokens if t not in special_tokens
+        ]
+
+        # Backwards compatibility with BERTVocab serialization in GluonNLP 0.7
+        identifiers_to_tokens = vocab_dict.get('identifiers_to_tokens')
+        bertidentifiers = ['mask_token', 'sep_token', 'cls_token']
+        if any(identifier in vocab_dict for identifier in bertidentifiers):
+            if identifiers_to_tokens is None:
+                identifiers_to_tokens = dict()
+            for identifier in bertidentifiers:
+                token = vocab_dict.get(identifier)
+                if token is not None:
+                    assert token in reserved_tokens
+                    assert identifier not in identifiers_to_tokens
+                    identifiers_to_tokens[identifier] = token
+
+        return cls(counter=count_tokens(token_to_idx.keys()),
+                   unknown_token=unknown_token,
+                   padding_token=padding_token,
+                   bos_token=bos_token,
+                   eos_token=eos_token,
+                   mask_token=None,
+                   sep_token=None,
+                   cls_token=None,
+                   reserved_tokens=reserved_tokens,
+                   token_to_idx=token_to_idx,
+                   identifiers_to_tokens=identifiers_to_tokens)
 
     @classmethod
     def from_sentencepiece(cls,
@@ -257,7 +268,6 @@ class BERTVocab(Vocab):
             _convert_to_unicode(t): i
             for i, t in enumerate(sp.tokens)
         }
-        idx_to_token = list(sp.tokens)
 
         def _check_consistency(processor, token_id, provided_token):
             """Check if provided_token is consistent with the special token inferred
@@ -271,44 +281,18 @@ class BERTVocab(Vocab):
                 provided_token = token
             return provided_token
 
-        def _register_token(token, token_to_idx, idx_to_token):
-            """Register reserved tokens based on sentencepiece vocab"""
-            token = _convert_to_unicode(token)
-            if token not in token_to_idx:
-                # Append the new token to the end of the vocab.
-                # We append it to the end of the list,
-                # instead of inserting it to the beginning,
-                # because we want to retain the same id/order for words in the vocab.
-                token_to_idx[token] = len(token_to_idx)
-                idx_to_token.append(token)
-
         unknown_token = _check_consistency(processor, processor.unk_id(), unknown_token)
         bos_token = _check_consistency(processor, processor.bos_id(), bos_token)
         eos_token = _check_consistency(processor, processor.eos_id(), eos_token)
         padding_token = _check_consistency(processor, processor.pad_id(), padding_token)
 
-        # construct reserved_tokens list
-        reserved_tokens = reserved_tokens if reserved_tokens else []
-        for token in [mask_token, sep_token, cls_token, bos_token, eos_token, padding_token]:
-            if token and token not in reserved_tokens:
-                reserved_tokens.append(token)
-        if unknown_token:
-            _register_token(unknown_token, token_to_idx, idx_to_token)
-        for token in reserved_tokens:
-            _register_token(token, token_to_idx, idx_to_token)
-        reserved_tokens = reserved_tokens if reserved_tokens else None
-
-        bert_vocab_dict = {}
-        bert_vocab_dict['idx_to_token'] = idx_to_token
-        bert_vocab_dict['token_to_idx'] = token_to_idx
-        bert_vocab_dict['reserved_tokens'] = reserved_tokens
-        bert_vocab_dict['unknown_token'] = unknown_token
-        bert_vocab_dict['padding_token'] = padding_token
-        bert_vocab_dict['bos_token'] = bos_token
-        bert_vocab_dict['eos_token'] = eos_token
-        bert_vocab_dict['mask_token'] = mask_token
-        bert_vocab_dict['sep_token'] = sep_token
-        bert_vocab_dict['cls_token'] = cls_token
-        json_str = json.dumps(bert_vocab_dict)
-        bert_vocab = cls.from_json(json_str)
-        return bert_vocab
+        return cls(counter=count_tokens(token_to_idx.keys()),
+                   unknown_token=unknown_token,
+                   padding_token=padding_token,
+                   bos_token=bos_token,
+                   eos_token=eos_token,
+                   mask_token=mask_token,
+                   sep_token=sep_token,
+                   cls_token=cls_token,
+                   reserved_tokens=reserved_tokens,
+                   token_to_idx=token_to_idx)

--- a/src/gluonnlp/vocab/bert.py
+++ b/src/gluonnlp/vocab/bert.py
@@ -79,19 +79,21 @@ class BERTVocab(Vocab):
     cls_token : hashable object or None, default '[CLS]'
         Classification symbol for BERT.
     reserved_tokens : list of hashable objects or None, default None
-        A list specifying additional reserved tokens that will always be
-        indexed similar to `padding_token`, `bos_token` or `eos_token`.
+        A list specifying additional tokens to be added to the vocabulary.
         `reserved_tokens` cannot contain `unknown_token` or duplicate reserved
         tokens.
         Keys of `counter`, `unknown_token`, and values of `reserved_tokens`
         must be of the same hashable type. Examples of hashable types are str,
         int, and tuple.
-    identifiers_to_tokens : dict mapping elements of reserved_tokens to str or None, default None
-        If `identifiers_to_tokens` is a dictionary, it specifies a mapping from
-        identifiers `name` to tokens part of the resulting Vocab `v`. `v` will
-        expose each of the tokens specified as individual attributes. For
-        example `reserved_tokens = {'my_special_token': '<special>'}` results
-        in a vocabulary object with attribute `v.my_special_token == '<special>'`
+    identifiers_to_tokens : dict mapping str used as identifier to tokens or None, default None
+        `identifiers_to_tokens` specifies a mapping from identifiers `name` to
+        tokens part of the resulting Vocab `v`. `v` will expose each of the
+        tokens specified as individual attributes. For example `reserved_tokens
+        = {'my_special_token': '<special>'}` results in a vocabulary object
+        with attribute `v.my_special_token == '<special>'` assuming that
+        '<special>' is part of the vocabulary. The `reserved_tokens` argument
+        can be used to add arbitrary tokens to the vocabulary. Raises
+        ValueError if a specified token is not part of the vocabulary.
     token_to_idx : dict mapping tokens (hashable objects) to int or None, default None
         Optionally specifies the indices of tokens to be used by the
         vocabulary. Each token in `token_to_index` must be part of the Vocab

--- a/src/gluonnlp/vocab/bert.py
+++ b/src/gluonnlp/vocab/bert.py
@@ -110,14 +110,14 @@ class BERTVocab(Vocab):
         A list of reserved tokens that will always be indexed.
     token_to_idx : dict mapping str to int
         A dict mapping each token to its index integer.
-    unknown_token : hashable object or None
+    unknown_token : hashable object or None, default '[UNK]'
         The representation for any unknown token. In other words, any unknown token will be indexed
         as the same representation.
-    padding_token : hashable object or None
+    padding_token : hashable object or None, default '[PAD]'
         The representation for padding token.
-    bos_token : hashable object or None
+    bos_token : hashable object or None, default None
         The representation for beginning-of-sentence token.
-    eos_token : hashable object or None
+    eos_token : hashable object or None, default None
         The representation for end-of-sentence token.
     mask_token : hashable object or None, default '[MASK]'
         The representation for the special token of mask token for BERT.

--- a/src/gluonnlp/vocab/bert.py
+++ b/src/gluonnlp/vocab/bert.py
@@ -145,14 +145,15 @@ class BERTVocab(Vocab):
         if identifiers_to_tokens is None:
             identifiers_to_tokens = dict()
 
+        if any(t in identifiers_to_tokens
+               for t in ('mask_token', 'sep_token', 'cls_token')):
+            raise ValueError('"mask_token", "sep_token" and "cls_token" '
+                             'cannot be specified in identifiers_to_tokens for BERTVocab')
         if mask_token:
-            assert mask_token not in identifiers_to_tokens
             identifiers_to_tokens.update(mask_token=mask_token)
-        if mask_token:
-            assert sep_token not in identifiers_to_tokens
+        if sep_token:
             identifiers_to_tokens.update(sep_token=sep_token)
-        if mask_token:
-            assert cls_token not in identifiers_to_tokens
+        if cls_token:
             identifiers_to_tokens.update(cls_token=cls_token)
 
         super(BERTVocab, self).__init__(counter=counter, max_size=max_size,
@@ -165,17 +166,17 @@ class BERTVocab(Vocab):
 
     @classmethod
     def from_json(cls, json_str):
-        """Deserialize Vocab object from json string.
+        """Deserialize BERTVocab object from json string.
 
         Parameters
         ----------
         json_str : str
-            Serialized json string of a Vocab object.
+            Serialized json string of a BERTVocab object.
 
 
         Returns
         -------
-        Vocab
+        BERTVocab
         """
         vocab_dict = json.loads(json_str)
         token_to_idx = vocab_dict.get('token_to_idx')

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -544,10 +544,10 @@ class Vocab(object):
         padding_token = vocab_dict.get('padding_token')
         bos_token = vocab_dict.get('bos_token')
         eos_token = vocab_dict.get('eos_token')
-        special_tokens = [unknown_token, padding_token, bos_token, eos_token]
         reserved_tokens = vocab_dict.get('reserved_tokens')
 
         # workaround reserved and special tokens being serialized together
+        special_tokens = [unknown_token, padding_token, bos_token, eos_token]
         reserved_tokens = [
             t for t in reserved_tokens if t not in special_tokens
         ]

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -143,6 +143,32 @@ class Vocab(object):
     [[-0.38497   0.80092   0.064106 -0.28355  -0.026759]
      [-0.41486   0.71848  -0.3045    0.87445   0.22441 ]]
     <NDArray 2x5 @cpu(0)>
+
+    With the `identifiers_to_tokens` argument the `Vocab` object can be
+    configured to expose specified tokens as attributes.
+
+    >>> id2tok = {'special_token': '<special>'}
+    >>> my_vocab2 = gluonnlp.Vocab(counter, identifiers_to_tokens=id2tok)
+    >>> # <special> is exposed as my_vocab2.special_token
+    >>> print(my_vocab2.special_token)
+    <special>
+
+    With the `token_to_idx` argument the order of the `Vocab`'s index can be
+    adapted. It is not necessary to specify the complete order but sufficient
+    to specify only the indices of tokens for a which a specific index is
+    desired. For example: By default `Vocab` assigns the index `0` to the
+    `unknown_token`. With the `token_to_idx` argument, the default can be
+    overwritten. Here we assign index `3` to the `unknown_token`.
+
+    >>> tok2idx = {'unknown_token': 3}
+    >>> my_vocab3 = gluonnlp.Vocab(counter, token_to_idx=tok2idx)
+    >>> my_vocab3.unknown_token
+    <unk>
+    >>> my_vocab3[my_vocab3.unknown_token]
+    3
+    >>> my_vocab[my_vocab.unknown_token]
+    0
+
     """
 
     # Declare internal attributes; if not declared, property getters will raise
@@ -267,7 +293,8 @@ class Vocab(object):
             raise ValueError('User-specified indices must not contain duplicates.')
         if min(token_to_idx.values()) < 0 or max(token_to_idx.values()) >= len(self.token_to_idx):
             raise ValueError('User-specified indices must not be < 0 or >= the number of tokens '
-                             'that will be in the vocabulary.')
+                             'that will be in the vocabulary. The current vocab contains {}'
+                             'tokens.'.format(len(self.token_to_idx)))
 
         # Update index ordering
         for token, new_idx in token_to_idx.items():

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -149,11 +149,11 @@ class Vocab(object):
     With the `identifiers_to_tokens` argument the `Vocab` object can be
     configured to expose specified tokens as attributes.
 
-    >>> id2tok = {'special_token': '<special>'}
+    >>> id2tok = {'special_token': 'hi'}
     >>> my_vocab2 = gluonnlp.Vocab(counter, identifiers_to_tokens=id2tok)
     >>> # <special> is exposed as my_vocab2.special_token
     >>> print(my_vocab2.special_token)
-    <special>
+    hi
 
     With the `token_to_idx` argument the order of the `Vocab`'s index can be
     adapted. It is not necessary to specify the complete order but sufficient
@@ -162,10 +162,10 @@ class Vocab(object):
     `unknown_token`. With the `token_to_idx` argument, the default can be
     overwritten. Here we assign index `3` to the `unknown_token`.
 
-    >>> tok2idx = {'unknown_token': 3}
+    >>> tok2idx = {'<unk>': 3}
     >>> my_vocab3 = gluonnlp.Vocab(counter, token_to_idx=tok2idx)
     >>> my_vocab3.unknown_token
-    <unk>
+    '<unk>'
     >>> my_vocab3[my_vocab3.unknown_token]
     3
     >>> my_vocab[my_vocab.unknown_token]

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -34,6 +34,8 @@ from ..data.utils import DefaultLookupDict, count_tokens
 from .. import _constants as C
 from .. import embedding as emb
 
+UNK_IDX = 0
+
 
 class Vocab(object):
     """Indexing and embedding attachment for text tokens.
@@ -207,7 +209,7 @@ class Vocab(object):
             self._idx_to_token.extend(special_tokens)
 
         if unknown_token:
-            self._token_to_idx = DefaultLookupDict(C.UNK_IDX)
+            self._token_to_idx = DefaultLookupDict(UNK_IDX)
         else:
             self._token_to_idx = {}
         self._token_to_idx.update((token, idx) for idx, token in enumerate(self._idx_to_token))

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -69,19 +69,21 @@ class Vocab(object):
     eos_token : hashable object or None, default '<eos>'
         The representation for the special token of end-of-sequence token.
     reserved_tokens : list of hashable objects or None, default None
-        A list specifying additional reserved tokens that will always be
-        indexed similar to `padding_token`, `bos_token` or `eos_token`.
+        A list specifying additional tokens to be added to the vocabulary.
         `reserved_tokens` cannot contain `unknown_token` or duplicate reserved
         tokens.
         Keys of `counter`, `unknown_token`, and values of `reserved_tokens`
         must be of the same hashable type. Examples of hashable types are str,
         int, and tuple.
-    identifiers_to_tokens : dict mapping elements of reserved_tokens to str or None, default None
-        If `identifiers_to_tokens` is a dictionary, it specifies a mapping from
-        identifiers `name` to tokens part of the resulting Vocab `v`. `v` will
-        expose each of the tokens specified as individual attributes. For
-        example `reserved_tokens = {'my_special_token': '<special>'}` results
-        in a vocabulary object with attribute `v.my_special_token == '<special>'`
+    identifiers_to_tokens : dict mapping str used as identifier to tokens or None, default None
+        `identifiers_to_tokens` specifies a mapping from identifiers `name` to
+        tokens part of the resulting Vocab `v`. `v` will expose each of the
+        tokens specified as individual attributes. For example `reserved_tokens
+        = {'my_special_token': '<special>'}` results in a vocabulary object
+        with attribute `v.my_special_token == '<special>'` assuming that
+        '<special>' is part of the vocabulary. The `reserved_tokens` argument
+        can be used to add arbitrary tokens to the vocabulary. Raises
+        ValueError if a specified token is not part of the vocabulary.
     token_to_idx : dict mapping tokens (hashable objects) to int or None, default None
         Optionally specifies the indices of tokens to be used by the
         vocabulary. Each token in `token_to_index` must be part of the Vocab

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -151,7 +151,7 @@ class Vocab(object):
 
     >>> id2tok = {'special_token': 'hi'}
     >>> my_vocab2 = gluonnlp.Vocab(counter, identifiers_to_tokens=id2tok)
-    >>> # <special> is exposed as my_vocab2.special_token
+    >>> # 'hi' is exposed as my_vocab2.special_token
     >>> print(my_vocab2.special_token)
     hi
 
@@ -160,7 +160,8 @@ class Vocab(object):
     to specify only the indices of tokens for a which a specific index is
     desired. For example: By default `Vocab` assigns the index `0` to the
     `unknown_token`. With the `token_to_idx` argument, the default can be
-    overwritten. Here we assign index `3` to the `unknown_token`.
+    overwritten. Here we assign index `3` to the unknown token representation
+    `<unk>`.
 
     >>> tok2idx = {'<unk>': 3}
     >>> my_vocab3 = gluonnlp.Vocab(counter, token_to_idx=tok2idx)

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -525,10 +525,10 @@ class Vocab(object):
 
         vocab = cls(
             counter=count_tokens(token_to_idx.keys()),
-            unknown_token=vocab_dict.get('unknown_token'),
-            padding_token=vocab_dict.get('padding_token'),
-            bos_token=vocab_dict.get('bos_token'),
-            eos_token=vocab_dict.get('eos_token'),
+            unknown_token=unknown_token,
+            padding_token=padding_token,
+            bos_token=bos_token,
+            eos_token=eos_token,
             reserved_tokens=reserved_tokens,
             token_to_idx=token_to_idx,
             identifiers_to_tokens=vocab_dict.get('identifiers_to_tokens'))

--- a/tests/data/vocab/backward_compat_0_7_corrupted_index
+++ b/tests/data/vocab/backward_compat_0_7_corrupted_index
@@ -1,0 +1,1 @@
+{"eos_token": "<eos>", "unknown_token": "<unk>", "bos_token": "<bos>", "padding_token": "<eos>", "idx_to_token": ["<unk>", "<eos>", "<bos>", "<eos>", "token"], "token_to_idx": {"<unk>": 0, "<bos>": 2, "<eos>": 3, "token": 4}, "reserved_tokens": ["<eos>", "<bos>", "<eos>"]}

--- a/tests/unittest/corpora/test_wikitext.py
+++ b/tests/unittest/corpora/test_wikitext.py
@@ -51,7 +51,6 @@ def test_wikitext2():
 
     vocab = nlp.Vocab(train_freq)
     serialized_vocab = vocab.to_json()
-    assert len(serialized_vocab) == 962190, len(serialized_vocab)
     assert json.loads(serialized_vocab)['idx_to_token'] == vocab._idx_to_token
 
     bptt_discard = nlp.data.batchify.CorpusBPTTBatchify(

--- a/tests/unittest/test_bertvocab.py
+++ b/tests/unittest/test_bertvocab.py
@@ -22,6 +22,9 @@ import gluonnlp as nlp
 import pytest
 
 
+from mxnet.test_utils import *
+
+
 @pytest.mark.serial
 @pytest.mark.remote_required
 def test_bertvocab():
@@ -57,23 +60,44 @@ def test_bertvocab():
                                              use_decoder=False, use_classifier=False,
                                              root='tests/data/model/')
 
-    assert nlp.vocab.BERTVocab.CLS_TOKEN == '[CLS]'
-    assert nlp.vocab.BERTVocab.SEP_TOKEN == '[SEP]'
-    assert nlp.vocab.BERTVocab.MASK_TOKEN == '[MASK]'
-    assert nlp.vocab.BERTVocab.PADDING_TOKEN == '[PAD]'
-    assert nlp.vocab.BERTVocab.UNKNOWN_TOKEN == '[UNK]'
-
     assert vocab1.cls_token == vocab2.cls_token == vocab3.cls_token == \
-        vocab4.cls_token == vocab5.cls_token == nlp.vocab.BERTVocab.CLS_TOKEN
+        vocab4.cls_token == vocab5.cls_token == nlp.vocab.bert.CLS_TOKEN
 
     assert vocab1.sep_token == vocab2.sep_token == vocab3.sep_token == \
-        vocab4.sep_token == vocab5.sep_token == nlp.vocab.BERTVocab.SEP_TOKEN
+        vocab4.sep_token == vocab5.sep_token == nlp.vocab.bert.SEP_TOKEN
 
     assert vocab1.mask_token == vocab2.mask_token == vocab3.mask_token == \
-        vocab4.mask_token == vocab5.mask_token == nlp.vocab.BERTVocab.MASK_TOKEN
+        vocab4.mask_token == vocab5.mask_token == nlp.vocab.bert.MASK_TOKEN
 
     assert vocab1.padding_token == vocab2.padding_token == vocab3.padding_token == \
-        vocab4.padding_token == vocab5.padding_token == nlp.vocab.BERTVocab.PADDING_TOKEN
+        vocab4.padding_token == vocab5.padding_token == nlp.vocab.bert.PADDING_TOKEN
 
     assert vocab1.unknown_token == vocab2.unknown_token == vocab3.unknown_token == \
-        vocab4.unknown_token == vocab5.unknown_token == nlp.vocab.BERTVocab.UNKNOWN_TOKEN
+        vocab4.unknown_token == vocab5.unknown_token == nlp.vocab.bert.UNKNOWN_TOKEN
+
+
+@pytest.mark.remote_required
+def test_bert_vocab_from_sentencepiece():
+    # the downloaded bpe vocab includes tokens for unk and padding, but without bos/eos.
+    url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-682b5d15.bpe'
+    f = download(url, overwrite=True)
+    bert_vocab = nlp.vocab.BERTVocab.from_sentencepiece(f, eos_token=u'<eos>')
+
+    import sentencepiece
+    spm = sentencepiece.SentencePieceProcessor()
+    spm.Load(f)
+
+    # check special tokens
+    from gluonnlp.data.utils import _convert_to_unicode
+    assert _convert_to_unicode(spm.IdToPiece(spm.unk_id())) == bert_vocab.unknown_token
+    assert _convert_to_unicode(spm.IdToPiece(spm.pad_id())) == bert_vocab.padding_token
+    assert None == bert_vocab.bos_token
+    assert u'<eos>' == bert_vocab.eos_token
+    assert u'<eos>' in bert_vocab
+    reserved_tokens = [u'[MASK]', u'[SEP]', u'[CLS]', u'<eos>', u'[PAD]']
+    assert  len(reserved_tokens) == len(bert_vocab.reserved_tokens)
+    assert all(t in bert_vocab.reserved_tokens for t in reserved_tokens)
+    num_tokens = len(spm)
+    for i in range(num_tokens):
+        token = _convert_to_unicode(spm.IdToPiece(i))
+        assert bert_vocab[token] == i

--- a/tests/unittest/test_bertvocab.py
+++ b/tests/unittest/test_bertvocab.py
@@ -134,3 +134,27 @@ def test_bert_vocab_from_sentencepiece():
     for i in range(num_tokens):
         token = _convert_to_unicode(spm.IdToPiece(i))
         assert bert_vocab[token] == i
+
+
+@pytest.mark.parametrize('unknown_token', ['<unk>', None])
+def test_bert_vocab_serialization(unknown_token):
+    def check(vocab):
+        assert vocab.mask_token == '[MASK]'
+        assert vocab.sep_token == '[SEP]'
+        assert vocab.cls_token == '[CLS]'
+
+        if not unknown_token:
+            with pytest.raises(KeyError):
+                vocab['hello']
+        else:
+            vocab['hello']
+
+    vocab = nlp.vocab.BERTVocab(unknown_token=unknown_token)
+    check(vocab)
+
+    loaded_vocab = nlp.vocab.BERTVocab.from_json(vocab.to_json())
+    check(loaded_vocab)
+
+    # Interoperability of serialization format with nlp.Vocab
+    loaded_vocab = nlp.Vocab.from_json(vocab.to_json())
+    check(loaded_vocab)

--- a/tests/unittest/test_bertvocab.py
+++ b/tests/unittest/test_bertvocab.py
@@ -83,32 +83,6 @@ def test_bertvocab():
         vocab4.unknown_token == vocab5.unknown_token == nlp.vocab.bert.UNKNOWN_TOKEN
 
 
-def test_bertvocab_special_bert_tokens(counter):
-    Vocab = functools.partial(nlp.vocab.BERTVocab,
-                              counter,
-                              max_size=None,
-                              min_freq=1,
-                              unknown_token=None,
-                              bos_token=None,
-                              eos_token=None)
-
-    # Double specification of special bert tokens
-    with pytest.raises(ValueError):
-        Vocab(identifiers_to_tokens={'mask_token': '[MASK2]'})
-    with pytest.raises(ValueError):
-        Vocab(identifiers_to_tokens={'sep_token': '[SEP2]'})
-    with pytest.raises(ValueError):
-        Vocab(identifiers_to_tokens={'cls_token': '[CLS2]'})
-
-    # Specification of special bert token
-    with pytest.raises(ValueError):
-        Vocab(identifiers_to_tokens={'mask_token': '[MASK2]'}, mask_token=None)
-    with pytest.raises(ValueError):
-        Vocab(identifiers_to_tokens={'sep_token': '[SEP2]'}, sep_token=None)
-    with pytest.raises(ValueError):
-        Vocab(identifiers_to_tokens={'cls_token': '[CLS2]'}, cls_token=None)
-
-
 @pytest.mark.remote_required
 def test_bert_vocab_from_sentencepiece():
     # the downloaded bpe vocab includes tokens for unk and padding, but without bos/eos.

--- a/tests/unittest/test_bertvocab.py
+++ b/tests/unittest/test_bertvocab.py
@@ -17,12 +17,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import functools
+
 import mxnet as mx
-import gluonnlp as nlp
 import pytest
-
-
 from mxnet.test_utils import *
+
+import gluonnlp as nlp
+
+
+@pytest.fixture
+def counter():
+    return nlp.data.utils.Counter( ['a', 'b', 'b', 'c', 'c', 'c',
+                                    'some_word$'])
 
 
 @pytest.mark.serial
@@ -74,6 +81,32 @@ def test_bertvocab():
 
     assert vocab1.unknown_token == vocab2.unknown_token == vocab3.unknown_token == \
         vocab4.unknown_token == vocab5.unknown_token == nlp.vocab.bert.UNKNOWN_TOKEN
+
+
+def test_bertvocab_special_bert_tokens(counter):
+    Vocab = functools.partial(nlp.vocab.BERTVocab,
+                              counter,
+                              max_size=None,
+                              min_freq=1,
+                              unknown_token=None,
+                              bos_token=None,
+                              eos_token=None)
+
+    # Double specification of special bert tokens
+    with pytest.raises(ValueError):
+        Vocab(identifiers_to_tokens={'mask_token': '[MASK2]'})
+    with pytest.raises(ValueError):
+        Vocab(identifiers_to_tokens={'sep_token': '[SEP2]'})
+    with pytest.raises(ValueError):
+        Vocab(identifiers_to_tokens={'cls_token': '[CLS2]'})
+
+    # Specification of special bert token
+    with pytest.raises(ValueError):
+        Vocab(identifiers_to_tokens={'mask_token': '[MASK2]'}, mask_token=None)
+    with pytest.raises(ValueError):
+        Vocab(identifiers_to_tokens={'sep_token': '[SEP2]'}, sep_token=None)
+    with pytest.raises(ValueError):
+        Vocab(identifiers_to_tokens={'cls_token': '[CLS2]'}, cls_token=None)
 
 
 @pytest.mark.remote_required

--- a/tests/unittest/test_vocab_embed.py
+++ b/tests/unittest/test_vocab_embed.py
@@ -38,6 +38,11 @@ else:
     _str_types = (str, unicode)
 
 
+@pytest.fixture
+def counter():
+    return nlp.data.utils.Counter( ['a', 'b', 'b', 'c', 'c', 'c',
+                                    'some_word$'])
+
 def _get_test_str_of_tokens(token_delim, seq_delim):
     seq1 = token_delim + token_delim.join(['Life', 'is', 'great', '!']) + token_delim + seq_delim
     seq2 = token_delim + token_delim.join(['life', 'is', 'good', '.']) + token_delim + seq_delim
@@ -80,9 +85,7 @@ def test_count_tokens():
     _test_count_tokens('IS', 'LIFE')
 
 
-def test_vocabulary_getitem():
-    counter = nlp.data.utils.Counter(['a', 'b', 'b', 'c', 'c', 'c', 'some_word$'])
-
+def test_vocabulary_getitem(counter):
     vocab = nlp.Vocab(counter, max_size=None, min_freq=1, unknown_token='<unk>',
                       bos_token=None, eos_token=None, reserved_tokens=None)
 
@@ -115,9 +118,7 @@ def test_vocabulary_getitem():
             no_unk_vocab.to_indices(words)
 
 
-def test_vocabulary_to_tokens():
-    counter = nlp.data.utils.Counter(['a', 'b', 'b', 'c', 'c', 'c', 'some_word$'])
-
+def test_vocabulary_to_tokens(counter):
     vocab = nlp.Vocab(counter, max_size=None, min_freq=1,unknown_token='<unknown>',
                       bos_token=None, eos_token=None, reserved_tokens=None)
     i1 = vocab.to_tokens(2)
@@ -137,9 +138,7 @@ def test_vocabulary_to_tokens():
             vocab.to_tokens(indices)
 
 
-def test_vocabulary():
-    counter = nlp.data.utils.Counter(['a', 'b', 'b', 'c', 'c', 'c', 'some_word$'])
-
+def test_vocabulary(counter):
     v1 = nlp.Vocab(counter, max_size=None, min_freq=1, unknown_token='<unk>',
                    padding_token=None, bos_token=None, eos_token=None, reserved_tokens=None)
     assert len(v1) == 5
@@ -477,7 +476,7 @@ def test_embedding_get_and_pretrain_file_names():
 
 
 @pytest.mark.parametrize('allow_extend', [True, False])
-def test_vocab_set_embedding_with_one_custom_embedding(tmpdir, allow_extend):
+def test_vocab_set_embedding_with_one_custom_embedding(tmpdir, allow_extend, counter):
     embed_root = str(tmpdir)
     embed_name = 'my_embed'
     elem_delim = '\t'
@@ -488,8 +487,6 @@ def test_vocab_set_embedding_with_one_custom_embedding(tmpdir, allow_extend):
     _mk_my_pretrain_file(os.path.join(embed_root, embed_name), elem_delim, pretrain_file)
 
     pretrain_file_path = os.path.join(embed_root, embed_name, pretrain_file)
-
-    counter = nlp.data.utils.Counter(['a', 'b', 'b', 'c', 'c', 'c', 'some_word$'])
 
     v1 = nlp.Vocab(counter, max_size=None, min_freq=1, unknown_token='<unk>',
                    padding_token=None, bos_token=None, eos_token=None, reserved_tokens=['<pad>'])
@@ -617,7 +614,7 @@ def test_vocab_set_embedding_with_one_custom_embedding(tmpdir, allow_extend):
 
 
 @pytest.mark.parametrize('allow_extend', [True, False])
-def test_vocab_set_embedding_with_two_custom_embeddings(tmpdir, allow_extend):
+def test_vocab_set_embedding_with_two_custom_embeddings(tmpdir, allow_extend, counter):
     embed_root = str(tmpdir)
     embed_name = 'my_embed'
     elem_delim = '\t'
@@ -634,8 +631,6 @@ def test_vocab_set_embedding_with_two_custom_embeddings(tmpdir, allow_extend):
 
     my_embed1 = from_file(pretrain_file_path1, elem_delim, init_unknown_vec=nd.ones)
     my_embed2 = from_file(pretrain_file_path2, elem_delim)
-
-    counter = nlp.data.utils.Counter(['a', 'b', 'b', 'c', 'c', 'c', 'some_word$'])
 
     v1 = nlp.Vocab(counter, max_size=None, min_freq=1, unknown_token='<unk>',
                    padding_token=None, bos_token=None, eos_token=None, reserved_tokens=None)

--- a/tests/unittest/test_vocab_embed.py
+++ b/tests/unittest/test_vocab_embed.py
@@ -1418,3 +1418,34 @@ def test_vocab_token_to_idx(unknown_token, padding_token, identifiers_to_tokens,
         consistency_check(v)
         for token, idx in token_to_idx.items():
             token_idx_check(token, idx)
+
+
+@pytest.mark.parametrize('unknown_token', ['<unk>', None])
+@pytest.mark.parametrize('padding_token', ['<pad>', '<eos>', None])
+@pytest.mark.parametrize('eos_token', ['<eos>', None])
+@pytest.mark.parametrize('reserved_tokens', [['<tok>'], []])
+def test_vocab_duplicate_special_tokens(unknown_token, padding_token,
+                                        eos_token, reserved_tokens, counter):
+    """Different special tokens are allowed to map to the same representations.
+
+    Special tokens are a subset of the reserved tokens. In general reserved
+    tokens must not contain duplicates; however, it is allowed that multiple
+    special tokens use the same reserved token.
+
+    """
+    Vocab = functools.partial(nlp.Vocab,counter,
+                  max_size=None,
+                  min_freq=1,
+                  unknown_token=unknown_token,
+                  padding_token=padding_token,
+                  bos_token=None,
+                  eos_token=eos_token
+                  )
+
+    v = Vocab(reserved_tokens=reserved_tokens)
+
+    # Specifying a special tokens as reserved tokens is counted as duplicate
+    if eos_token is not None:
+        with pytest.raises(AssertionError):
+            Vocab(reserved_tokens=reserved_tokens + [eos_token])
+

--- a/tests/unittest/test_vocab_embed.py
+++ b/tests/unittest/test_vocab_embed.py
@@ -1196,30 +1196,6 @@ def test_subword_function_ngramhashes():
     assert 1669484008 % num_subwords == next(iter(sf.subwords_to_indices([u'<te'])))
     assert 2688791429 % num_subwords == next(iter(sf.subwords_to_indices([u'<τε'])))
 
-@pytest.mark.remote_required
-def test_bert_vocab_from_sentencepiece():
-    # the downloaded bpe vocab includes tokens for unk and padding, but without bos/eos.
-    url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-682b5d15.bpe'
-    f = download(url, overwrite=True)
-    bert_vocab = nlp.vocab.BERTVocab.from_sentencepiece(f, eos_token=u'<eos>')
-
-    import sentencepiece
-    spm = sentencepiece.SentencePieceProcessor()
-    spm.Load(f)
-
-    # check special tokens
-    from gluonnlp.data.utils import _convert_to_unicode
-    assert _convert_to_unicode(spm.IdToPiece(spm.unk_id())) == bert_vocab.unknown_token
-    assert _convert_to_unicode(spm.IdToPiece(spm.pad_id())) == bert_vocab.padding_token
-    assert None == bert_vocab.bos_token
-    assert u'<eos>' == bert_vocab.eos_token
-    assert u'<eos>' in bert_vocab
-    assert [u'[MASK]', u'[SEP]', u'[CLS]', u'<eos>', u'[PAD]'] == bert_vocab.reserved_tokens
-    num_tokens = len(spm)
-    for i in range(num_tokens):
-        token = _convert_to_unicode(spm.IdToPiece(i))
-        assert bert_vocab[token] == i
-
 
 @pytest.mark.parametrize('unknown_token', ['<unk>', None])
 @pytest.mark.parametrize('padding_token', ['<pad>', '<eos>', None])  # padding_token == eos_token

--- a/tests/unittest/test_vocab_embed.py
+++ b/tests/unittest/test_vocab_embed.py
@@ -1449,3 +1449,20 @@ def test_vocab_duplicate_special_tokens(unknown_token, padding_token,
         with pytest.raises(AssertionError):
             Vocab(reserved_tokens=reserved_tokens + [eos_token])
 
+
+def test_vocab_backwards_compatibility_prior_v0_7_corrupted_index_bug():
+    with open('tests/data/vocab/backward_compat_0_7_corrupted_index', 'r') as f:
+        v = nlp.Vocab.from_json(f.read())
+
+    assert len(set(v.idx_to_token)) == len(v.token_to_idx)
+    assert v['<unk>'] == 0
+    assert v['<bos>'] == 2
+    assert v['<eos>'] == 3
+    assert v['token'] == 4
+
+    assert v.idx_to_token[0] == '<unk>'
+    assert v.idx_to_token[1] == '<eos>'  # corruption preserved for backward
+                                         # compatibility
+    assert v.idx_to_token[2] == '<bos>'
+    assert v.idx_to_token[3] == '<eos>'
+    assert v.idx_to_token[4] == 'token'


### PR DESCRIPTION
Currently the `gluonnlp.Vocab` always assigns 0 as id of `<unk>` (#393). Further
reserved tokens are not exposed as attributes of the vocab (#572). This PR
addresses both issues.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Add `token_to_idx` argument to `gluonnlp.Vocab` which allows users to
      optionally specify the index to be associated to a token for a subset of
      tokens in the vocabulary. (Fixes #393)
- [X] Add `identifiers_to_tokens` argument to `gluonnlp.Vocab` which allows users to
      optionally specify a Mapping, specifying identifiers for tokens that will be
      exposed as attributes of the vocabulary (Fixes #572)

## Comments ##
- The `token_to_idx` argument can only contain tokens that will actually be part
  of the vocabulary. On the one hand, a user may not know which tokens will be
  part of the vocabulary, eg. when specifying a maximum size argument. On the
  other hand, if the user does not know if a certain token will be part of the
  vocab or not, it seems unlikely that the user would like to pre-specify the
  index of that token. Thus this shouldn't pose any problems.