### PR TITLE
[BUGFIX] [DOC] Update nlp.model.get_model documentation and get_model API

### DIFF
--- a/docs/api/modules/model.rst
+++ b/docs/api/modules/model.rst
@@ -9,7 +9,7 @@ all requested pre-trained weights are downloaded from public repo and stored in 
 Model Registry
 --------------
 
-The model registry provides an easy interface to obtain pre-defined models.
+The model registry provides an easy interface to obtain pre-defined and pre-trained models.
 
 .. autosummary::
     :nosignatures:

--- a/docs/api/modules/model.rst
+++ b/docs/api/modules/model.rst
@@ -6,24 +6,45 @@ all requested pre-trained weights are downloaded from public repo and stored in 
 
 .. currentmodule:: gluonnlp.model
 
+Model Registry
+--------------
+
+The model registry provides an easy interface to obtain pre-defined models.
+
+.. autosummary::
+    :nosignatures:
+
+    get_model
+
+The `get_model` function returns a pre-defined model given the name of a
+registered model. The following sections of this page present a list of
+registered names for each model category.
+
 Language Modeling
 -----------------
+
+Components
+
+.. autosummary::
+    :nosignatures:
+
+    AWDRNN
+    BiLMEncoder
+    LSTMPCellWithClip
+    StandardRNN
+    BigRNN
+
+Pre-defined models
 
 .. autosummary::
     :nosignatures:
 
     awd_lstm_lm_1150
     awd_lstm_lm_600
-    AWDRNN
-    BiLMEncoder
-    LSTMPCellWithClip
     standard_lstm_lm_200
     standard_lstm_lm_650
     standard_lstm_lm_1500
     big_rnn_lm_2048_512
-    StandardRNN
-    get_model
-    BigRNN
 
 Machine Translation
 -------------------
@@ -35,10 +56,16 @@ Machine Translation
     TransformerEncoder
     TransformerEncoderCell
     PositionwiseFFN
+
+.. autosummary::
+    :nosignatures:
+
     transformer_en_de_512
 
 Bidirectional Encoder Representations from Transformers
 -------------------------------------------------------
+
+Components
 
 .. autosummary::
     :nosignatures:
@@ -48,11 +75,17 @@ Bidirectional Encoder Representations from Transformers
     BERTEncoder
     BERTEncoderCell
     BERTPositionwiseFFN
+
+Pre-defined models
+
+.. autosummary::
+    :nosignatures:
+
     bert_12_768_12
     bert_24_1024_16
 
 Convolutional Encoder
-----------------------
+---------------------
 
 .. autosummary::
     :nosignatures:
@@ -60,13 +93,24 @@ Convolutional Encoder
     ConvolutionalEncoder
 
 ELMo
-----------------------
+----
+
+Components
 
 .. autosummary::
     :nosignatures:
 
     ELMoBiLM
     ELMoCharacterEncoder
+
+Pre-defined models
+
+.. autosummary::
+    :nosignatures:
+
+    elmo_2x1024_128_2048cnn_1xhighway
+    elmo_2x2048_256_2048cnn_1xhighway
+    elmo_2x4096_512_2048cnn_2xhighway
 
 Highway Network
 -----------------

--- a/src/gluonnlp/model/__init__.py
+++ b/src/gluonnlp/model/__init__.py
@@ -96,14 +96,14 @@ __all__ = language_model.__all__ + sequence_sampler.__all__ + attention_cell.__a
           seq2seq_encoder_decoder.__all__ + transformer.__all__ + bert.__all__
 
 
-def get_model(name, dataset_name='wikitext-2', **kwargs):
+def get_model(name, **kwargs):
     """Returns a pre-defined model by name.
 
     Parameters
     ----------
     name : str
         Name of the model.
-    dataset_name : str or None, default 'wikitext-2'.
+    dataset_name : str or None, default None
         The dataset name on which the pre-trained model is trained.
         For language model, options are 'wikitext-2'.
         For ELMo, Options are 'gbw' and '5bw'.
@@ -147,5 +147,4 @@ def get_model(name, dataset_name='wikitext-2', **kwargs):
         raise ValueError(
             'Model %s is not supported. Available options are\n\t%s'%(
                 name, '\n\t'.join(sorted(models.keys()))))
-    kwargs['dataset_name'] = dataset_name
     return models[name](**kwargs)


### PR DESCRIPTION
http://gluon-nlp.mxnet.io/api/modules/model.html currently does not
differentiate pre-defined models exposed by the `get_model` function and other
components. This PR is a quick attempt to improve the distinction.

Further, `get_model` used a hardcoded `dataset=wikitext-2` argument. This is
likely by accident as the `get_model` function was initially mainly used for
language models, but now also provides access to other models such as Bert, for
which hardcoded dataset argument does not make sense.

For example, loading a Bert model with a prespecified Vocab currently requires doing

    nlp.model.get_model('bert_12_768_12', dataset_name=None, vocab=vocabulary, ...)

instead of

    nlp.model.get_model('bert_12_768_12', vocab=vocabulary, ...)
    
The latter version currently fails, as it will pass the "wikitext-2" as
dataset_name to the Bert model constructor.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Change `nlp.model.get_model` dataset argument default to None
- [X] Improve `nlp.model` docs