### PR TITLE
[BUGFIX] Fix handling of duplicate special tokens in Vocabulary

### DIFF
--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -138,13 +138,13 @@ class Vocab(object):
         self._unknown_token = unknown_token
         special_tokens = []
         self._padding_token = padding_token
-        if padding_token:
+        if padding_token and padding_token not in special_tokens:
             special_tokens.append(padding_token)
         self._bos_token = bos_token
-        if bos_token:
+        if bos_token and bos_token not in special_tokens:
             special_tokens.append(bos_token)
         self._eos_token = eos_token
-        if eos_token:
+        if eos_token and eos_token not in special_tokens:
             special_tokens.append(eos_token)
         if reserved_tokens:
             special_tokens.extend(reserved_tokens)
@@ -170,6 +170,7 @@ class Vocab(object):
             self._reserved_tokens = None
         else:
             self._reserved_tokens = special_tokens[:]
+            assert len(special_tokens) == len(set(special_tokens))  # sanity check
             self._idx_to_token.extend(special_tokens)
 
         if unknown_token:


### PR DESCRIPTION
Example use case in scripts/tests/test_dataprocessor.py where `eos_token ==
padding_token`. Prior to this fix, `eos_token == padding_token` lead to a
corrupted vocabulary index.

Example of the corrupted index:

    > v = nlp.Vocab(...)
    > v.idx_to_token
    ['<unk>', '<eos>', '<eos>', 'c', 'b', 'a']
    > v.token_to_idx
    {'<unk>': 0, '<eos>': 2, 'c': 3, 'b': 4, 'a': 5}

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix handling of duplicate special tokens when creating a Vocabulary

## Comments ##
- This fix does not impact backward compatibility in that previously serialized
  vocabularies will be restored exactly as serialized.
- Newly created vocabularies may differ, if up until now their index was corrupt
- The changes to the deserialization process in
  https://github.com/dmlc/gluon-nlp/pull/732 and resulting execution of sanity
  checks during deserialization would prevent deserialization of vocabularies
  with a corrupt index. I added some backwards compatibility code for loading the corrupted serialized files in #732