### PR TITLE
[CI] Fix links in contribute.rst

### DIFF
--- a/ci/jenkins/build_steps.groovy
+++ b/ci/jenkins/build_steps.groovy
@@ -117,7 +117,6 @@ def website_linkcheck(workspace_name, conda_env_name) {
         if [[ ${enforce_linkcheck} == true ]]; then
             make -C docs linkcheck SPHINXOPTS=-W
         else
-            set +e
             make -C docs linkcheck
         fi;
         set +ex

--- a/docs/community/contribute.rst
+++ b/docs/community/contribute.rst
@@ -41,10 +41,15 @@ Make changes
 ------------
 
 Our package uses continuous integration and code coverage tools for verifying pull requests. Before
-submitting, contributor should perform the following checks:
+submitting, contributor should ensure that the following checks do not fail:
 
-- `Lint (code style) check <https://github.com/dmlc/gluon-nlp/blob/master/Jenkinsfile#L5>`__.
-- `Py2 <https://github.com/dmlc/gluon-nlp/blob/master/Jenkinsfile#L18>`__ and `Py3 <https://github.com/dmlc/gluon-nlp/blob/master/Jenkinsfile#L28>`__ tests.
+- Lint (code style)
+- Unittest (running under Python 2 and Python 3)
+- Doctest (running under Python 2 and Python 3)
+
+The commands executed by the continuous integration server to perform the tests
+are listed in the `build_steps.groovy file
+<https://github.com/dmlc/gluon-nlp/blob/master/ci/jenkins/build_steps.groovy>`__.
 
 Contribute to model zoo
 -----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,8 +99,9 @@ This toolkit assumes that users have basic knowledge about deep learning and
 NLP. Otherwise, please refer to an introductory course such as
 `Dive into Deep Learning <https://www.d2l.ai/>`_ or
 `Stanford CS224n <http://web.stanford.edu/class/cs224n/>`_.
-If you are not familiar with Gluon, check out the
-`60-min Gluon crash course <http://beta.mxnet.io/guide/crash-course/index.html>`_.
+If you are not familiar with Gluon, check out the `Gluon documentation
+<http://mxnet.apache.org/versions/master/tutorials/index.html#python-tutorials>`__.
+You may find the 60-min Gluon crash course linked from there especially helpful.
 
 
 .. toctree::


### PR DESCRIPTION
contribute.rst currently contains invalid links. As CI checks links, this broke
all CI runs on the master branch. This should have broken all CI runs, including
pull-requests, but somehow didn't. This is tracked in #751.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Fix links in contribute.rst