### PR TITLE
[CI] Update CI dependencies

### DIFF
--- a/env/cpu/py2.yml
+++ b/env/cpu/py2.yml
@@ -4,9 +4,9 @@ dependencies:
   - python=2.7
   - pip=18.1
   - perl
-  - pylint=1.9.2
+  - pylint<2
   - flake8
-  - sphinx=1.7.7
+  - sphinx=2.1.0
   - spacy
   - nltk
   - pytest=4.5.0
@@ -15,6 +15,6 @@ dependencies:
   - mock<3
   - pytest-xdist<2
   - pip:
-    - pylint-quotes<0.2
+    - pylint-quotes<0.3
     - mxnet-mkl>=1.4.0
     - sentencepiece<0.2

--- a/env/cpu/py2.yml
+++ b/env/cpu/py2.yml
@@ -6,7 +6,7 @@ dependencies:
   - perl
   - pylint<2
   - flake8
-  - sphinx=2.1.0
+  - sphinx<2
   - spacy
   - nltk
   - pytest=4.5.0

--- a/env/cpu/py3-master.yml
+++ b/env/cpu/py3-master.yml
@@ -4,9 +4,9 @@ dependencies:
   - python=3.6
   - pip=18.1
   - perl
-  - pylint=1.9.2
+  - pylint<2
   - flake8
-  - sphinx=1.7.7
+  - sphinx=2.1.0
   - spacy
   - nltk
   - pytest=4.5.0
@@ -15,7 +15,7 @@ dependencies:
   - mock<3
   - pytest-xdist<2
   - pip:
-    - pylint-quotes<0.2
+    - pylint-quotes<0.3
     - mxnet-mkl>=1.5.0b20190407
     - sacremoses
     - sentencepiece<0.2

--- a/env/cpu/py3.yml
+++ b/env/cpu/py3.yml
@@ -4,9 +4,9 @@ dependencies:
   - python=3.6
   - pip=18.1
   - perl
-  - pylint=1.9.2
+  - pylint<2
   - flake8
-  - sphinx=1.7.7
+  - sphinx=2.1.0
   - spacy
   - nltk
   - pytest=4.5.0
@@ -15,17 +15,17 @@ dependencies:
   - mock<3
   - pytest-xdist<1.28
   - recommonmark
-  - pandoc=1.19.2
+  - pandoc=2.7.2
   - notedown
   - numba>=v0.40.0
   - sphinx-gallery
-  - nbsphinx>=0.3.4,<0.4
-  - nbconvert=5.4.0
+  - nbsphinx=0.4.2
+  - nbconvert=5.5.0
   - tornado=5.1.1
   - ipython
   - ipykernel
   - pip:
-    - pylint-quotes<0.2
+    - pylint-quotes<0.3
     - mxnet-mkl>=1.4.0
     - sacremoses
     - sentencepiece<0.2

--- a/env/gpu/py2.yml
+++ b/env/gpu/py2.yml
@@ -4,9 +4,9 @@ dependencies:
   - python=2.7
   - pip=18.1
   - perl
-  - pylint=1.9.2
+  - pylint<2
   - flake8
-  - sphinx=1.7.7
+  - sphinx=2.1.0
   - spacy
   - nltk
   - pytest=4.5.0
@@ -15,6 +15,6 @@ dependencies:
   - mock<3
   - pytest-xdist<2
   - pip:
-    - pylint-quotes<0.2
+    - pylint-quotes<0.3
     - mxnet-cu92mkl>=1.4.0
     - sentencepiece<0.2

--- a/env/gpu/py2.yml
+++ b/env/gpu/py2.yml
@@ -6,7 +6,7 @@ dependencies:
   - perl
   - pylint<2
   - flake8
-  - sphinx=2.1.0
+  - sphinx<2
   - spacy
   - nltk
   - pytest=4.5.0

--- a/env/gpu/py3-master.yml
+++ b/env/gpu/py3-master.yml
@@ -4,9 +4,9 @@ dependencies:
   - python=3.6
   - pip=18.1
   - perl
-  - pylint=1.9.2
+  - pylint<2
   - flake8
-  - sphinx=1.7.7
+  - sphinx=2.1.0
   - spacy
   - nltk
   - pytest=4.5.0
@@ -15,17 +15,17 @@ dependencies:
   - mock<3
   - pytest-xdist<2
   - recommonmark
-  - pandoc=1.19.2
+  - pandoc=2.7.2
   - notedown
   - numba>=v0.40.0
   - sphinx-gallery
-  - nbsphinx>=0.3.4,<0.4
-  - nbconvert=5.4.0
+  - nbsphinx=0.4.2
+  - nbconvert=5.5.0
   - tornado=5.1.1
   - ipython
   - ipykernel
   - pip:
-    - pylint-quotes<0.2
+    - pylint-quotes<0.3
     - mxnet-cu92mkl>=1.5.0b20190407
     - sacremoses
     - sentencepiece<0.2

--- a/env/gpu/py3.yml
+++ b/env/gpu/py3.yml
@@ -4,9 +4,9 @@ dependencies:
   - python=3.6
   - pip=18.1
   - perl
-  - pylint=1.9.2
+  - pylint<2
   - flake8
-  - sphinx=1.7.7
+  - sphinx=2.1.0
   - spacy
   - nltk
   - pytest=4.5.0
@@ -15,17 +15,17 @@ dependencies:
   - mock<3
   - pytest-xdist<2
   - recommonmark
-  - pandoc=1.19.2
+  - pandoc=2.7.2
   - notedown
   - numba>=v0.40.0
   - sphinx-gallery
-  - nbsphinx>=0.3.4,<0.4
-  - nbconvert=5.4.0
+  - nbsphinx=0.4.2
+  - nbconvert=5.5.0
   - tornado=5.1.1
   - ipython
   - ipykernel
   - pip:
-    - pylint-quotes<0.2
+    - pylint-quotes<0.3
     - mxnet-cu92mkl>=1.4.0
     - sacremoses
     - sentencepiece<0.2


### PR DESCRIPTION
After enabling linkcheck again in #752, it turns out that on the master branch linkcheck continues to fail due to issues with our the symbolic link to the model_zoo. There have been a number of bugfixes for sphinx linkcheck in recent versions. Thus let's update the version first before investigating the current continued failure.

Also, nbconvert 5.5 now supports pandoc 2.