### PR TITLE
[API] Remove get_bert_model from the public API list

### DIFF
--- a/scripts/bert/finetune_classifier.py
+++ b/scripts/bert/finetune_classifier.py
@@ -209,7 +209,7 @@ if only_inference and not model_parameters:
 get_pretrained = not (pretrained_bert_parameters is not None
                       or model_parameters is not None)
 bert, vocabulary = get_model(
-    model_name=model_name,
+    name=model_name,
     dataset_name=dataset,
     pretrained=get_pretrained,
     ctx=ctx,

--- a/scripts/bert/finetune_classifier.py
+++ b/scripts/bert/finetune_classifier.py
@@ -46,7 +46,7 @@ import numpy as np
 import mxnet as mx
 from mxnet import gluon
 import gluonnlp as nlp
-from gluonnlp.model import get_bert_model
+from gluonnlp.model import get_model
 from gluonnlp.data import BERTTokenizer
 
 from model.classification import BERTClassifier, BERTRegression
@@ -208,7 +208,7 @@ if only_inference and not model_parameters:
 
 get_pretrained = not (pretrained_bert_parameters is not None
                       or model_parameters is not None)
-bert, vocabulary = get_bert_model(
+bert, vocabulary = get_model(
     model_name=model_name,
     dataset_name=dataset,
     pretrained=get_pretrained,

--- a/scripts/bert/ner_utils.py
+++ b/scripts/bert/ner_utils.py
@@ -98,7 +98,7 @@ def get_bert_model(bert_model, cased, ctx, dropout_prob):
     """Get pre-trained BERT model."""
     bert_dataset_name = get_bert_dataset_name(cased)
 
-    return nlp.model.get_bert_model(
+    return nlp.model.get_model(
         model_name=bert_model,
         dataset_name=bert_dataset_name,
         pretrained=True,

--- a/scripts/bert/ner_utils.py
+++ b/scripts/bert/ner_utils.py
@@ -99,7 +99,7 @@ def get_bert_model(bert_model, cased, ctx, dropout_prob):
     bert_dataset_name = get_bert_dataset_name(cased)
 
     return nlp.model.get_model(
-        model_name=bert_model,
+        name=bert_model,
         dataset_name=bert_dataset_name,
         pretrained=True,
         ctx=ctx,

--- a/src/gluonnlp/model/bert.py
+++ b/src/gluonnlp/model/bert.py
@@ -19,7 +19,7 @@
 """BERT models."""
 
 __all__ = ['BERTModel', 'BERTEncoder', 'BERTEncoderCell', 'BERTPositionwiseFFN',
-           'BERTLayerNorm', 'bert_12_768_12', 'bert_24_1024_16', 'get_bert_model',
+           'BERTLayerNorm', 'bert_12_768_12', 'bert_24_1024_16',
            'ernie_12_768_12']
 
 import os


### PR DESCRIPTION
## Description ##
As title. Everything should go through `nlp.model.get_model`. @szha  @leezu 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
