### PR TITLE
[BUGFIX] Fix init bug for multilevel BiLMEncoder

### DIFF
--- a/scripts/tests/test_scripts.py
+++ b/scripts/tests/test_scripts.py
@@ -17,6 +17,8 @@ def test_skipgram_cbow(model, fasttext):
         sys.executable, './scripts/word_embeddings/train_sg_cbow.py', '--gpu', '0',
         '--epochs', '2', '--model', model, '--data', 'toy', '--batch-size',
         '64']
+    cmd += ['--similarity-datasets', 'WordSim353']
+    cmd += ['--analogy-datasets', 'GoogleAnalogyTestSet']
     if fasttext:
         cmd += ['--ngram-buckets', '1000']
     else:
@@ -35,6 +37,8 @@ def test_glove():
     cmd = [
         sys.executable, './scripts/word_embeddings/train_glove.py', cooccur, vocab,
         '--batch-size', '2', '--epochs', '2', '--gpu', '0']
+    cmd += ['--similarity-datasets', 'WordSim353']
+    cmd += ['--analogy-datasets', 'GoogleAnalogyTestSet']
     subprocess.check_call(cmd)
     time.sleep(5)
 
@@ -51,6 +55,8 @@ def test_embedding_evaluate_pretrained(fasttextloadngrams):
         '--embedding-name', 'fasttext', '--embedding-source', 'wiki.simple',
         '--gpu', '0'
     ]
+    cmd += ['--similarity-datasets', 'WordSim353']
+    cmd += ['--analogy-datasets', 'GoogleAnalogyTestSet']
     if fasttextloadngrams:
         cmd.append('--fasttext-load-ngrams')
 

--- a/scripts/tests/test_scripts.py
+++ b/scripts/tests/test_scripts.py
@@ -74,7 +74,7 @@ def test_embedding_evaluate_from_path(evaluateanalogies, maxvocabsize):
     if evaluateanalogies:
         cmd += ['--analogy-datasets', 'GoogleAnalogyTestSet']
     else:
-        cmd += ['--analogy-datasets']
+        cmd += ['--similarity-datasets', 'WordSim353']
     if maxvocabsize is not None:
         cmd += ['--analogy-max-vocab-size', str(maxvocabsize)]
     subprocess.check_call(cmd)

--- a/scripts/tests/test_scripts.py
+++ b/scripts/tests/test_scripts.py
@@ -72,9 +72,11 @@ def test_embedding_evaluate_from_path(evaluateanalogies, maxvocabsize):
         sys.executable, './scripts/word_embeddings/evaluate_pretrained.py',
         '--embedding-path', path, '--gpu', '0']
     if evaluateanalogies:
+        cmd += ['--similarity-datasets=']
         cmd += ['--analogy-datasets', 'GoogleAnalogyTestSet']
     else:
         cmd += ['--similarity-datasets', 'WordSim353']
+        cmd += ['--analogy-datasets=']
     if maxvocabsize is not None:
         cmd += ['--analogy-max-vocab-size', str(maxvocabsize)]
     subprocess.check_call(cmd)

--- a/scripts/word_embeddings/evaluation.py
+++ b/scripts/word_embeddings/evaluation.py
@@ -74,7 +74,7 @@ def validate_args(args):
     """Validate provided arguments and act on --help."""
     # Check correctness of similarity dataset names
     for dataset_name in args.similarity_datasets:
-        if dataset_name.lower() not in map(
+        if dataset_name and dataset_name.lower() not in map(
                 str.lower,
                 nlp.data.word_embedding_evaluation.word_similarity_datasets):
             print('{} is not a supported dataset.'.format(dataset_name))
@@ -82,7 +82,7 @@ def validate_args(args):
 
     # Check correctness of analogy dataset names
     for dataset_name in args.analogy_datasets:
-        if dataset_name.lower() not in map(
+        if dataset_name and dataset_name.lower() not in map(
                 str.lower,
                 nlp.data.word_embedding_evaluation.word_analogy_datasets):
             print('{} is not a supported dataset.'.format(dataset_name))
@@ -97,6 +97,8 @@ def iterate_similarity_datasets(args):
 
     """
     for dataset_name in args.similarity_datasets:
+        if not dataset_name:
+            continue
         parameters = nlp.data.list_datasets(dataset_name)
         for key_values in itertools.product(*parameters.values()):
             kwargs = dict(zip(parameters.keys(), key_values))
@@ -111,6 +113,8 @@ def iterate_analogy_datasets(args):
 
     """
     for dataset_name in args.analogy_datasets:
+        if not dataset_name:
+            continue
         parameters = nlp.data.list_datasets(dataset_name)
         for key_values in itertools.product(*parameters.values()):
             kwargs = dict(zip(parameters.keys(), key_values))

--- a/src/gluonnlp/data/word_embedding_evaluation.py
+++ b/src/gluonnlp/data/word_embedding_evaluation.py
@@ -456,11 +456,11 @@ class SimVerb3500(WordSimilarityEvaluationDataset):
 
     Examples
     --------
-    >>> simverb3500 = gluonnlp.data.SimVerb3500(root='./datasets/simverb3500')
+    >>> simverb3500 = gluonnlp.data.SimVerb3500(root='./datasets/simverb3500') #doctest:+SKIP
     -etc-
-    >>> len(simverb3500)
+    >>> len(simverb3500) #doctest:+SKIP
     3500
-    >>> simverb3500[0]
+    >>> simverb3500[0] #doctest:+SKIP
     ['take', 'remove', 6.81]
     """
     _url = 'http://people.ds.cam.ac.uk/dsg40/paper/simverb/simverb-3500-data.zip'

--- a/src/gluonnlp/model/bilm_encoder.py
+++ b/src/gluonnlp/model/bilm_encoder.py
@@ -97,7 +97,7 @@ class BiLMEncoder(gluon.HybridBlock):
                                                   proj_clip=self._proj_clip)
 
                     self.forward_layers.add(forward_layer)
-                    lstm_input_size = self._proj_size
+                    lstm_input_size = self._proj_size if self._proj_size else self._hidden_size
 
             lstm_input_size = self._input_size
             self.backward_layers = rnn.HybridSequentialRNNCell()
@@ -121,7 +121,7 @@ class BiLMEncoder(gluon.HybridBlock):
                                                    cell_clip=self._cell_clip,
                                                    proj_clip=self._proj_clip)
                     self.backward_layers.add(backward_layer)
-                    lstm_input_size = self._proj_size
+                    lstm_input_size = self._proj_size if self._proj_size else self._hidden_size
 
     def begin_state(self, func, **kwargs):
         return [self.forward_layers[0][0].begin_state(func=func, **kwargs)

--- a/src/gluonnlp/model/bilm_encoder.py
+++ b/src/gluonnlp/model/bilm_encoder.py
@@ -59,6 +59,7 @@ class BiLMEncoder(gluon.HybridBlock):
     proj_clip : float
         Clip projection between [-projclip, projclip] in LSTMPCellWithClip cell
     """
+
     def __init__(self, mode, num_layers, input_size, hidden_size, dropout=0.0,
                  skip_connection=True, proj_size=None, cell_clip=None, proj_clip=None, **kwargs):
         super(BiLMEncoder, self).__init__(**kwargs)
@@ -97,7 +98,8 @@ class BiLMEncoder(gluon.HybridBlock):
                                                   proj_clip=self._proj_clip)
 
                     self.forward_layers.add(forward_layer)
-                    lstm_input_size = self._proj_size if self._proj_size else self._hidden_size
+                    lstm_input_size = self._hidden_size \
+                        if self._proj_size is None else self._proj_size
 
             lstm_input_size = self._input_size
             self.backward_layers = rnn.HybridSequentialRNNCell()
@@ -121,7 +123,8 @@ class BiLMEncoder(gluon.HybridBlock):
                                                    cell_clip=self._cell_clip,
                                                    proj_clip=self._proj_clip)
                     self.backward_layers.add(backward_layer)
-                    lstm_input_size = self._proj_size if self._proj_size else self._hidden_size
+                    lstm_input_size = self._hidden_size \
+                        if self._proj_size is None else self._proj_size
 
     def begin_state(self, func, **kwargs):
         return [self.forward_layers[0][0].begin_state(func=func, **kwargs)
@@ -170,7 +173,7 @@ class BiLMEncoder(gluon.HybridBlock):
             if layer_index == 0:
                 layer_inputs = inputs
             else:
-                layer_inputs = outputs_forward[layer_index-1]
+                layer_inputs = outputs_forward[layer_index - 1]
             output, states_forward[layer_index] = F.contrib.foreach(
                 self.forward_layers[layer_index],
                 layer_inputs,
@@ -180,7 +183,7 @@ class BiLMEncoder(gluon.HybridBlock):
             if layer_index == 0:
                 layer_inputs = inputs
             else:
-                layer_inputs = outputs_backward[layer_index-1]
+                layer_inputs = outputs_backward[layer_index - 1]
 
             if mask is not None:
                 layer_inputs = F.SequenceReverse(layer_inputs,

--- a/tests/unittest/test_bilm_encoder.py
+++ b/tests/unittest/test_bilm_encoder.py
@@ -25,15 +25,14 @@ from gluonnlp.model import BiLMEncoder
 
 
 @pytest.mark.parametrize('hybridize', [False, True])
-@pytest.mark.parametrize('mode', ['lstm', 'gru', 'rnn_relu', 'rnn_tanh'])
-def test_bi_lm_encoder_output_shape_rnn_lstm_gru(hybridize, mode):
+def test_bilm_encoder_output_shape_lstm(hybridize):
     num_layers = 2
     seq_len = 7
     hidden_size = 100
     input_size = 100
     batch_size = 2
 
-    encoder = BiLMEncoder(mode=mode,
+    encoder = BiLMEncoder(mode='lstm',
                           num_layers=num_layers,
                           input_size=input_size,
                           hidden_size=hidden_size,
@@ -45,7 +44,7 @@ def test_bi_lm_encoder_output_shape_rnn_lstm_gru(hybridize, mode):
 
 
 @pytest.mark.parametrize('hybridize', [False, True])
-def test_bi_lm_encoder_output_shape_lstmpc(hybridize):
+def test_bilm_encoder_output_shape_lstmpc(hybridize):
     num_layers = 2
     seq_len = 7
     hidden_size = 100
@@ -66,15 +65,13 @@ def test_bi_lm_encoder_output_shape_lstmpc(hybridize):
 
 
 def run_bi_lm_encoding(encoder, batch_size, input_size, seq_len, hybridize):
-    print(encoder)
     encoder.initialize()
 
     if hybridize:
         encoder.hybridize()
 
     inputs = mx.random.uniform(shape=(seq_len, batch_size, input_size))
-    inputs_mask = mx.random.randint(0, 1, shape=(batch_size, seq_len))
-    print('testing forward for bi_lm_encoder')
+    inputs_mask = mx.random.uniform(-1, 1, shape=(batch_size, seq_len)) > 1
 
     state = encoder.begin_state(batch_size=batch_size, func=mx.ndarray.zeros)
     output, _ = encoder(inputs, state, inputs_mask)

--- a/tests/unittest/test_bilmencoder.py
+++ b/tests/unittest/test_bilmencoder.py
@@ -1,0 +1,81 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import print_function
+
+import pytest
+import mxnet as mx
+from gluonnlp.model import BiLMEncoder
+
+
+@pytest.mark.parametrize('hybridize', [False, True])
+@pytest.mark.parametrize('mode', ['lstm', 'gru', 'rnn_relu', 'rnn_tanh'])
+def test_bi_lm_encoder_output_shape_rnn_lstm_gru(hybridize, mode):
+    num_layers = 2
+    seq_len = 7
+    hidden_size = 100
+    input_size = 100
+    batch_size = 2
+
+    encoder = BiLMEncoder(mode=mode,
+                          num_layers=num_layers,
+                          input_size=input_size,
+                          hidden_size=hidden_size,
+                          dropout=0.1,
+                          skip_connection=False)
+
+    output = run_bi_lm_encoding(encoder, batch_size, input_size, seq_len, hybridize)
+    assert output.shape == (num_layers, seq_len, batch_size, 2 * hidden_size), output.shape
+
+
+@pytest.mark.parametrize('hybridize', [False, True])
+def test_bi_lm_encoder_output_shape_lstmpc(hybridize):
+    num_layers = 2
+    seq_len = 7
+    hidden_size = 100
+    input_size = 100
+    batch_size = 2
+    proj_size = 15
+
+    encoder = BiLMEncoder(mode='lstmpc',
+                          num_layers=num_layers,
+                          input_size=input_size,
+                          hidden_size=hidden_size,
+                          dropout=0.1,
+                          skip_connection=False,
+                          proj_size=proj_size)
+
+    output = run_bi_lm_encoding(encoder, batch_size, input_size, seq_len, hybridize)
+    assert output.shape == (num_layers, seq_len, batch_size, 2 * proj_size), output.shape
+
+
+def run_bi_lm_encoding(encoder, batch_size, input_size, seq_len, hybridize):
+    print(encoder)
+    encoder.initialize()
+
+    if hybridize:
+        encoder.hybridize()
+
+    inputs = mx.random.uniform(shape=(seq_len, batch_size, input_size))
+    inputs_mask = mx.random.randint(0, 1, shape=(batch_size, seq_len))
+    print('testing forward for bi_lm_encoder')
+
+    state = encoder.begin_state(batch_size=batch_size, func=mx.ndarray.zeros)
+    output, _ = encoder(inputs, state, inputs_mask)
+    return output

--- a/tests/unittest/test_datasets.py
+++ b/tests/unittest/test_datasets.py
@@ -271,8 +271,6 @@ def test_verb130():
     _assert_similarity_dataset(data)
 
 
-@pytest.mark.skipif(datetime.date.today() < datetime.date(2018, 9, 10),
-                    reason='Disabled for 1 weeks due to server downtime.')
 @flaky(max_runs=2, min_passes=1)
 @pytest.mark.serial
 @pytest.mark.remote_required
@@ -296,6 +294,8 @@ def test_simlex999():
 @flaky(max_runs=2, min_passes=1)
 @pytest.mark.serial
 @pytest.mark.remote_required
+@pytest.mark.skipif(datetime.date.today() < datetime.date(2019, 7, 18),
+                    reason='Disabled for 4 weeks due to link move.')
 def test_simverb3500():
     data = nlp.data.SimVerb3500(
         root=os.path.join('tests', 'externaldata', 'simverb3500'))
@@ -306,8 +306,6 @@ def test_simverb3500():
 @flaky(max_runs=2, min_passes=1)
 @pytest.mark.serial
 @pytest.mark.remote_required
-@pytest.mark.skipif(datetime.date.today() < datetime.date(2018, 12, 10),
-                    reason='Disabled for 1 weeks due to server downtime.')
 def test_semeval17task2():
     for segment, length in [("trial", 18), ("test", 500)]:
         data = nlp.data.SemEval17Task2(
@@ -423,8 +421,6 @@ def test_conll2002_esp(segment, length):
         assert all(isinstance(n, _str_types) for n in ner), ner
 
 
-@pytest.mark.skipif(datetime.date.today() < datetime.date(2018, 8, 16),
-                    reason='Disabled for 1 weeks due to server downtime.')
 @flaky(max_runs=2, min_passes=1)
 @pytest.mark.parametrize('segment,length', [
     ('train', 8936),

--- a/tests/unittest/test_vocab_embed.py
+++ b/tests/unittest/test_vocab_embed.py
@@ -1171,13 +1171,13 @@ def test_word_embedding_analogy_evaluation_models(analogy_function):
 
             # If we don't exclude inputs most predictions should be wrong
             words4 = dataset_coded_nd[:, 3]
-            accuracy = nd.mean(pred_idxs[:, 0] == nd.array(words4))
+            accuracy = nd.mean(pred_idxs[:, 0] == nd.array(words4, dtype=np.int32))
             accuracy = accuracy.asscalar()
             if not exclude_question_words:
                 assert accuracy <= 0.1
 
                 # Instead the model would predict W3 most of the time
-                accuracy_w3 = nd.mean(pred_idxs[:, 0] == nd.array(words3))
+                accuracy_w3 = nd.mean(pred_idxs[:, 0] == nd.array(words3, dtype=np.int32))
                 assert accuracy_w3.asscalar() >= 0.89
 
             else:

--- a/tests/unittest/test_vocab_embed.py
+++ b/tests/unittest/test_vocab_embed.py
@@ -1154,7 +1154,7 @@ def test_word_embedding_analogy_evaluation_models(analogy_function):
 
     dataset_coded = [[vocab[d[0]], vocab[d[1]], vocab[d[2]], vocab[d[3]]]
                      for d in dataset]
-    dataset_coded_nd = nd.array(dataset_coded)
+    dataset_coded_nd = nd.array(dataset_coded, dtype=np.int64)
 
     for k in [1, 3]:
         for exclude_question_words in [True, False]:
@@ -1167,17 +1167,17 @@ def test_word_embedding_analogy_evaluation_models(analogy_function):
             words1 = dataset_coded_nd[:, 0]
             words2 = dataset_coded_nd[:, 1]
             words3 = dataset_coded_nd[:, 2]
-            pred_idxs = evaluator(words1, words2, words3)
+            pred_idxs = evaluator(words1, words2, words3).astype(np.int64)
 
             # If we don't exclude inputs most predictions should be wrong
             words4 = dataset_coded_nd[:, 3]
-            accuracy = nd.mean(pred_idxs[:, 0] == nd.array(words4, dtype=np.int32))
+            accuracy = (pred_idxs[:, 0] == words4).astype(np.float64).mean()
             accuracy = accuracy.asscalar()
             if not exclude_question_words:
                 assert accuracy <= 0.1
 
                 # Instead the model would predict W3 most of the time
-                accuracy_w3 = nd.mean(pred_idxs[:, 0] == nd.array(words3, dtype=np.int32))
+                accuracy_w3 = (pred_idxs[:, 0] == words3).astype(np.float64).mean()
                 assert accuracy_w3.asscalar() >= 0.89
 
             else:


### PR DESCRIPTION
## Description ##
Fix of initialization for the case of multiple levels in Bidirectional LM encoder. The problem was in passing `None` as an `input_size` to next layers for non-lstmpc cell types.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
