### PR TITLE
[MODEL] BiDAF and QANet use common data pipeline

### DIFF
--- a/scripts/question_answering/bidaf_config.py
+++ b/scripts/question_answering/bidaf_config.py
@@ -1,0 +1,94 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Configuration for running BiDAF model"""
+
+import argparse
+
+
+def get_args():
+    """Get console arguments
+    """
+    parser = argparse.ArgumentParser(description='Question Answering example using BiDAF & SQuAD',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--train', default=False, action='store_true',
+                        help='Run training')
+    parser.add_argument('--evaluate', default=False, action='store_true',
+                        help='Run evaluation on dev dataset')
+    parser.add_argument('--epochs', type=int, default=12, help='Upper epoch limit')
+    parser.add_argument('--embedding_size', type=int, default=100,
+                        help='Dimension of the word embedding')
+    parser.add_argument('--embedding_file_name', type=str, default='glove.6B.100d',
+                        help='Embedding file name')
+    parser.add_argument('--dropout', type=float, default=0.2,
+                        help='dropout applied to layers (0 = no dropout)')
+    parser.add_argument('--ctx_embedding_num_layers', type=int, default=2,
+                        help='Number of layers in Contextual embedding layer of BiDAF')
+    parser.add_argument('--highway_num_layers', type=int, default=2,
+                        help='Number of layers in Highway layer of BiDAF')
+    parser.add_argument('--modeling_num_layers', type=int, default=2,
+                        help='Number of layers in Modeling layer of BiDAF')
+    parser.add_argument('--output_num_layers', type=int, default=1,
+                        help='Number of layers in Output layer of BiDAF')
+    parser.add_argument('--batch_size', type=int, default=60, help='Batch size')
+    parser.add_argument('--ctx_max_len', type=int, default=400, help='Maximum length of a context')
+    parser.add_argument('--q_max_len', type=int, default=30, help='Maximum length of a question')
+    parser.add_argument('--word_max_len', type=int, default=16, help='Maximum characters in a word')
+    parser.add_argument('--answer_max_len', type=int, default=30, help='Maximum tokens in answer')
+    parser.add_argument('--optimizer', type=str, default='adadelta', help='optimization algorithm')
+    parser.add_argument('--lr', type=float, default=0.5, help='Initial learning rate')
+    parser.add_argument('--rho', type=float, default=0.9,
+                        help='Adadelta decay rate for both squared gradients and delta.')
+    parser.add_argument('--lr_warmup_steps', type=int, default=0,
+                        help='Defines how many iterations to spend on warming up learning rate')
+    parser.add_argument('--clip', type=float, default=0, help='gradient clipping')
+    parser.add_argument('--weight_decay', type=float, default=0,
+                        help='Weight decay for parameter updates')
+    parser.add_argument('--log_interval', type=int, default=0, metavar='N',
+                        help='Report interval applied to last epoch only')
+    parser.add_argument('--early_stop', type=int, default=9,
+                        help='Apply early stopping for the last epoch. Stop after # of consequent '
+                             '# of times F1 is lower than max. Should be used with log_interval')
+    parser.add_argument('--terminate_training_on_reaching_F1_threshold', type=float, default=0,
+                        help='Some tasks, like DAWNBenchmark requires to minimize training time '
+                             'while reaching a particular F1 metric. This parameter controls if '
+                             'training should be terminated as soon as F1 is reached to minimize '
+                             'training time and cost. It would force to do evaluation every epoch.')
+    parser.add_argument('--save_dir', type=str, default='bidaf_output',
+                        help='directory path to save the final model and training log')
+    parser.add_argument('--word_vocab_path', type=str, default=None,
+                        help='Path to preprocessed word-level vocabulary')
+    parser.add_argument('--char_vocab_path', type=str, default=None,
+                        help='Path to preprocessed character-level vocabulary')
+    parser.add_argument('--gpu', type=str, default='0',
+                        help='Coma-separated ids of the gpu to use. Empty means to use cpu.')
+    parser.add_argument('--train_unk_token', default=False, action='store_true',
+                        help='Should train unknown token of embedding')
+    parser.add_argument('--filter_train_examples', default=True, action='store_false',
+                        help='Filter contexts if the answer is after ctx_max_len')
+    parser.add_argument('--save_prediction_path', type=str, default='',
+                        help='Path to save predictions')
+    parser.add_argument('--use_exponential_moving_average', default=True, action='store_false',
+                        help='Should averaged copy of parameters been stored and used '
+                             'during evaluation.')
+    parser.add_argument('--exponential_moving_average_weight_decay', type=float, default=0.999,
+                        help='Weight decay used in exponential moving average')
+
+    options = parser.parse_args()
+    return options

--- a/scripts/question_answering/bidaf_evaluate.py
+++ b/scripts/question_answering/bidaf_evaluate.py
@@ -1,0 +1,213 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Performance evaluator - a proxy class used for plugging in official validation script"""
+import mxnet as mx
+from mxnet import nd, gluon, cpu
+from tqdm import tqdm
+
+try:
+    from official_squad_eval_script import evaluate
+except ImportError:
+    from .official_squad_eval_script import evaluate
+
+
+class PerformanceEvaluator:
+    """Plugin to run prediction and performance evaluation via official eval script"""
+
+    def __init__(self, dev_dataloader, dev_dataset, dev_json):
+        self._dev_dataloader = dev_dataloader
+        self._dev_dataset = dev_dataset
+        self._dev_json = dev_json
+
+    def evaluate_performance(self, net, ctx, options):
+        """Get results of evaluation by official evaluation script
+
+        Parameters
+        ----------
+        net : `Block`
+            Network
+        ctx : `Context`
+            Execution context
+        options : `Namespace`
+            Training arguments
+
+        Returns
+        -------
+        data : `dict`
+            Returns a dictionary of {'exact_match': <value>, 'f1': <value>}
+        """
+
+        pred = {}
+
+        # Allows to ensure that start index is always <= than end index
+        for _ in ctx:
+            answer_mask_matrix = nd.zeros(shape=(1, options.ctx_max_len, options.ctx_max_len),
+                                          ctx=cpu(0))
+            for idx in range(options.answer_max_len):
+                answer_mask_matrix += nd.eye(N=options.ctx_max_len, M=options.ctx_max_len,
+                                             k=idx, ctx=cpu(0))
+
+        for idxs, context, query, context_char, query_char, _, _ in tqdm(
+                self._dev_dataloader):
+
+            # This is required for multigpu setting. When number of items in the batch is less
+            # then number of devices in the context, then it will throw an error if not added
+            # fake items
+            idxs = PerformanceEvaluator._extend_to_batch_size(options.batch_size * len(ctx),
+                                                              idxs, -1)
+            query = PerformanceEvaluator._extend_to_batch_size(options.batch_size * len(ctx),
+                                                               query)
+            context = PerformanceEvaluator._extend_to_batch_size(options.batch_size * len(ctx),
+                                                                 context)
+            query_char = PerformanceEvaluator._extend_to_batch_size(options.batch_size * len(ctx),
+                                                                    query_char)
+            context_char = PerformanceEvaluator._extend_to_batch_size(options.batch_size * len(ctx),
+                                                                      context_char)
+
+            record_index = gluon.utils.split_and_load(idxs, ctx, even_split=False)
+            ctx_words = gluon.utils.split_and_load(context, ctx, even_split=False)
+            q_words = gluon.utils.split_and_load(query, ctx, even_split=False)
+            q_chars = gluon.utils.split_and_load(query_char, ctx, even_split=False)
+            ctx_chars = gluon.utils.split_and_load(context_char, ctx, even_split=False)
+
+            outs = []
+
+            for ri, qw, cw, qc, cc in zip(record_index, q_words, ctx_words,
+                                          q_chars, ctx_chars):
+                ctx_embedding_state = net.ctx_embedding._contextual_embedding.begin_state(
+                    batch_size=ri.shape[0], func=mx.ndarray.zeros, ctx=qw.context)
+
+                modeling_layer_state = net.modeling_layer.begin_state(
+                    batch_size=ri.shape[0], func=mx.ndarray.zeros, ctx=qw.context)
+
+                end_index_states = net.output_layer._end_index_lstm.begin_state(
+                    batch_size=ri.shape[0], func=mx.ndarray.zeros, ctx=qw.context)
+
+                begin, end = net(qw, cw, qc, cc,
+                                 ctx_embedding_state,
+                                 modeling_layer_state,
+                                 end_index_states)
+
+                outs.append((ri.as_in_context(cpu(0)),
+                             begin.as_in_context(cpu(0)),
+                             end.as_in_context(cpu(0))))
+
+            for out in outs:
+                ri = out[0]
+                start = out[1].softmax(axis=1)
+                end = out[2].softmax(axis=1)
+                start_end_span = PerformanceEvaluator._get_indices(start, end, answer_mask_matrix)
+
+                # iterate over batches
+                for idx, start_end in zip(ri, start_end_span):
+                    if idx == -1:
+                        continue
+
+                    idx = int(idx.asscalar())
+                    start = int(start_end[0].asscalar())
+                    end = int(start_end[1].asscalar())
+
+                    question_id = self._dev_dataset.get_q_id_by_rec_idx(idx)
+                    pred[question_id] = (start, end, self.get_text_result(idx, (start, end)))
+
+        if options.save_prediction_path:
+            with open(options.save_prediction_path, 'w') as f:
+                for item in pred.items():
+                    f.write('{}: {}-{} Answer: {}\n'.format(item[0], item[1][0],
+                                                            item[1][1], item[1][2]))
+
+        return evaluate(self._dev_json['data'], {k: v[2] for k, v in pred.items()})
+
+    def get_text_result(self, idx, answer_span):
+        """Converts answer span into actual text from paragraph
+
+        Parameters
+        ----------
+        idx : `int`
+            Question index
+        answer_span : `Tuple`
+            Answer span (start_index, end_index)
+
+        Returns
+        -------
+        text : `str`
+            A chunk of text for provided answer_span or None if answer span cannot be provided
+        """
+
+        start, end = answer_span
+        context = self._dev_dataset.get_record_by_idx(idx)[8]
+        spans = self._dev_dataset.get_record_by_idx(idx)[9]
+
+        # get text from cutting string from the initial context
+        # because tokens are hard to combine together
+        text = context[spans[start][0]:spans[end][1]]
+        return text
+
+    @staticmethod
+    def _get_indices(begin, end, answer_mask_matrix):
+        r"""Select the begin and end position of answer span.
+
+            At inference time, the predicted span (s, e) is chosen such that
+            begin_hat[s] * end_hat[e] is maximized and s ≤ e.
+
+        Parameters
+        ----------
+        begin : NDArray
+            input tensor with shape `(batch_size, context_sequence_length)`
+        end : NDArray
+            input tensor with shape `(batch_size, context_sequence_length)`
+
+        Returns
+        -------
+        prediction: Tuple
+            Tuple containing first and last token indices of the answer
+        """
+        begin_hat = begin.reshape(begin.shape + (1,))
+        end_hat = end.reshape(end.shape + (1,))
+        end_hat = end_hat.transpose(axes=(0, 2, 1))
+
+        result = nd.batch_dot(begin_hat, end_hat) * answer_mask_matrix.slice(
+            begin=(0, 0, 0), end=(1, begin_hat.shape[1], begin_hat.shape[1]))
+        yp1 = result.max(axis=2).argmax(axis=1, keepdims=True).astype('int32')
+        yp2 = result.max(axis=1).argmax(axis=1, keepdims=True).astype('int32')
+        return nd.concat(yp1, yp2, dim=-1)
+
+    @staticmethod
+    def _extend_to_batch_size(batch_size, prototype, fill_value=0):
+        """Provides NDArray, which consist of prototype NDArray and NDArray filled with fill_value
+        to batch_size number of items. New NDArray appended to batch dimension (dim=0).
+
+        Parameters
+        ----------
+        batch_size: ``int``
+            Expected value for batch_size dimension (dim=0).
+        prototype: ``NDArray``
+            NDArray to be extended of shape (batch_size, ...)
+        fill_value: ``float``
+            Value to use for filling
+        """
+        if batch_size == prototype.shape[0]:
+            return prototype
+
+        new_shape = (batch_size - prototype.shape[0],) + prototype.shape[1:]
+        dummy_elements = nd.full(val=fill_value, shape=new_shape, dtype=prototype.dtype,
+                                 ctx=prototype.context)
+
+        return nd.concat(prototype, dummy_elements, dim=0)

--- a/scripts/question_answering/bidaf_model.py
+++ b/scripts/question_answering/bidaf_model.py
@@ -1,0 +1,487 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Bidirectional attention flow model with all subblocks"""
+import numpy as np
+from mxnet import gluon
+from mxnet import initializer
+from mxnet.gluon import HybridBlock
+from mxnet.gluon import nn
+from mxnet.initializer import MSRAPrelu, Xavier
+
+from gluonnlp.model import ConvolutionalEncoder, Highway, BiLMEncoder
+
+try:
+    from similarity_function import DotProductSimilarity, LinearSimilarity
+except ImportError:
+    from .similarity_function import DotProductSimilarity, LinearSimilarity
+
+
+class AttentionFlow(gluon.HybridBlock):
+    """
+    This ``block`` takes two ndarrays as input and returns a ndarray of attentions.
+
+    We compute the similarity between each row in each matrix and return unnormalized similarity
+    scores.  Because these scores are unnormalized, we don't take a mask as input; it's up to the
+    caller to deal with masking properly when this output is used.
+
+    By default similarity is computed with a dot product, but you can alternatively use a
+    parameterized similarity function if you wish.
+
+
+    Input:
+        - ndarray_1: ``(batch_size, num_rows_1, embedding_dim)``
+        - ndarray_2: ``(batch_size, num_rows_2, embedding_dim)``
+
+    Output:
+        - ``(batch_size, num_rows_1, num_rows_2)``
+
+    Parameters
+    ----------
+    similarity_function: ``SimilarityFunction``, optional (default=``DotProductSimilarity``)
+        The similarity function to use when computing the attention.
+    """
+
+    def __init__(self, similarity_function, passage_length,
+                 question_length, **kwargs):
+        super(AttentionFlow, self).__init__(**kwargs)
+
+        self._similarity_function = similarity_function or DotProductSimilarity()
+        self._passage_length = passage_length
+        self._question_length = question_length
+
+    def hybrid_forward(self, F, matrix_1, matrix_2):
+        # pylint: disable=arguments-differ,unused-argument,missing-docstring
+        tiled_matrix_1 = F.broadcast_axis(matrix_1.expand_dims(2), axis=2,
+                                          size=self._question_length)
+
+        tiled_matrix_2 = F.broadcast_axis(matrix_2.expand_dims(1), axis=1,
+                                          size=self._passage_length)
+
+        return self._similarity_function(tiled_matrix_1, tiled_matrix_2)
+
+
+class BidirectionalAttentionFlow(gluon.HybridBlock):
+    """
+    This class implements Minjoon Seo's `Bidirectional Attention Flow model
+    <https://www.semanticscholar.org/paper/Bidirectional-Attention-Flow-for-Machine-Seo-Kembhavi/7586b7cca1deba124af80609327395e613a20e9d>`_
+    for answering reading comprehension questions (ICLR 2017).
+    """
+
+    def __init__(self,
+                 passage_length,
+                 question_length,
+                 **kwargs):
+        super(BidirectionalAttentionFlow, self).__init__(**kwargs)
+
+        self._passage_length = passage_length
+        self._question_length = question_length
+
+    def _get_big_negative_value(self):
+        """Provides maximum negative Float32 value
+        Returns
+        -------
+        value : float32
+            Maximum negative float32 value
+        """
+        return np.finfo(np.float32).min
+
+    def _get_small_positive_value(self):
+        """Provides minimal possible Float32 value
+        Returns
+        -------
+        value : float32
+            Minimal float32 value
+        """
+        return np.finfo(np.float32).eps
+
+    def hybrid_forward(self, F, passage_question_similarity,
+                       encoded_passage, encoded_question, question_mask, passage_mask):
+        # pylint: disable=arguments-differ,missing-docstring
+        # Shape: (batch_size, passage_length, question_length)
+        question_mask_reshaped = F.broadcast_axis(question_mask.expand_dims(1), axis=1,
+                                                  size=self._passage_length)
+
+        # Shape: (batch_size, passage_length, question_length)
+        passage_question_attention = last_dim_softmax(F,
+                                                      passage_question_similarity,
+                                                      question_mask_reshaped,
+                                                      epsilon=self._get_small_positive_value())
+        # Shape: (batch_size, passage_length, encoding_dim)
+        passage_question_vectors = F.batch_dot(passage_question_attention, encoded_question)
+
+        # We replace masked values with something really negative here, so they don't affect the
+        # max below.
+        masked_similarity = passage_question_similarity if question_mask is None else \
+            replace_masked_values(F,
+                                  passage_question_similarity,
+                                  question_mask.expand_dims(1),
+                                  replace_with=self._get_big_negative_value())
+
+        # Shape: (batch_size, passage_length)
+        question_passage_similarity = masked_similarity.max(axis=-1)
+
+        # Shape: (batch_size, passage_length)
+        question_passage_attention = masked_softmax(F, question_passage_similarity, passage_mask,
+                                                    epsilon=self._get_small_positive_value())
+
+        # Shape: (batch_size, encoding_dim)
+        question_passage_vector = F.squeeze(F.batch_dot(question_passage_attention.expand_dims(1),
+                                                        encoded_passage), axis=1)
+
+        # Shape: (batch_size, passage_length, encoding_dim)
+        tiled_question_passage_vector = question_passage_vector.expand_dims(1)
+
+        # Shape: (batch_size, passage_length, encoding_dim * 4)
+        final_merged_passage = F.concat(encoded_passage,
+                                        passage_question_vectors,
+                                        encoded_passage * passage_question_vectors,
+                                        F.broadcast_mul(encoded_passage,
+                                                        tiled_question_passage_vector),
+                                        dim=-1)
+
+        return final_merged_passage
+
+
+class BiDAFEmbedding(HybridBlock):
+    """BiDAFEmbedding is a class describing embeddings that are separately applied to question
+    and context of the datasource. Both question and context are passed in two NDArrays:
+    1. Matrix of words: batch_size x words_per_question/context
+    2. Tensor of characters: batch_size x words_per_question/context x chars_per_word
+    """
+
+    def __init__(self, word_vocab, char_vocab, max_seq_len,
+                 contextual_embedding_nlayers=2, highway_nlayers=2, embedding_size=100,
+                 dropout=0.2, prefix=None, params=None):
+        super(BiDAFEmbedding, self).__init__(prefix=prefix, params=params)
+
+        self._word_vocab = word_vocab
+        self._max_seq_len = max_seq_len
+        self._embedding_size = embedding_size
+
+        with self.name_scope():
+            self._char_dense_embedding = nn.Embedding(input_dim=len(char_vocab),
+                                                      output_dim=8,
+                                                      weight_initializer=initializer.Uniform(0.001))
+            self._dropout = nn.Dropout(rate=dropout)
+            self._char_conv_embedding = ConvolutionalEncoder(
+                embed_size=8,
+                num_filters=(100,),
+                ngram_filter_sizes=(5,),
+                num_highway=None,
+                conv_layer_activation='relu',
+                output_size=None
+            )
+
+            self._word_embedding = nn.Embedding(prefix='predefined_embedding_layer',
+                                                input_dim=len(word_vocab),
+                                                output_dim=embedding_size)
+
+            self._highway_network = Highway(2 * embedding_size, num_layers=highway_nlayers)
+            self._contextual_embedding = BiLMEncoder(mode='lstm',
+                                                     num_layers=contextual_embedding_nlayers,
+                                                     input_size=2 * embedding_size,
+                                                     hidden_size=embedding_size,
+                                                     dropout=dropout,
+                                                     skip_connection=False)
+
+    def init_embeddings(self, grad_req='null'):
+        """Initialize words embeddings with provided embedding values
+
+        Parameters
+        ----------
+        grad_req: str
+            How to treat gradients of embedding layer
+        """
+        self._word_embedding.weight.set_data(self._word_vocab.embedding.idx_to_vec)
+        self._word_embedding.collect_params().setattr('grad_req', grad_req)
+
+    def hybrid_forward(self, F, w, c, ctx_embedding_state, word_mask):
+        # pylint: disable=arguments-differ,missing-docstring
+        word_embedded = self._word_embedding(w)
+        char_level_data = self._char_dense_embedding(c)
+        char_level_data = self._dropout(char_level_data)
+
+        # Transpose to put seq_len first axis to iterate over it
+        char_level_data = F.transpose(char_level_data, axes=(1, 2, 0, 3))
+
+        def convolute(token_of_all_batches, _):
+            return self._char_conv_embedding(token_of_all_batches), []
+
+        char_embedded, _ = F.contrib.foreach(convolute, char_level_data, [])
+
+        # Transpose to TNC, to join with character embedding
+        word_embedded = F.transpose(word_embedded, axes=(1, 0, 2))
+
+        # batch_size x seq_len x embedding
+        highway_input = F.concat(char_embedded, word_embedded, dim=2)
+
+        def highway(token_of_all_batches, _):
+            return self._highway_network(token_of_all_batches), []
+
+        # Pass through highway, shape remains unchanged
+        highway_output, _ = F.contrib.foreach(highway, highway_input, [])
+
+        ce_output, _ = self._contextual_embedding(highway_output, ctx_embedding_state, word_mask)
+        ce_output = ce_output.slice_axis(axis=0, begin=-1, end=None).squeeze(axis=0)
+        return ce_output
+
+
+class BiDAFOutputLayer(HybridBlock):
+    """
+    ``BiDAFOutputLayer`` produces the final prediction of an answer. The output is a tuple of
+    start and end index of token in the paragraph per each batch.
+
+    It accepts 2 inputs:
+        `x` : the output of Attention layer of shape:
+        seq_max_length x batch_size x 8 * span_start_input_dim
+
+        `m` : the output of Modeling layer of shape:
+         seq_max_length x batch_size x 2 * span_start_input_dim
+
+    Parameters
+    ----------
+    batch_size : `int`
+        Size of a batch
+    span_start_input_dim : `int`, default 100
+        The number of features in the hidden state h of LSTM
+    nlayers : `int`, default 1
+        Number of recurrent layers.
+    biflag: `bool`, default True
+        If `True`, becomes a bidirectional RNN.
+    dropout: `float`, default 0
+        If non-zero, introduces a dropout layer on the outputs of each
+        RNN layer except the last layer.
+    prefix : `str` or None
+        Prefix of this `Block`.
+    params : `ParameterDict` or `None`
+        Shared Parameters for this `Block`.
+    """
+
+    def __init__(self, span_start_input_dim=100, nlayers=1,
+                 dropout=0.2, prefix=None, params=None):
+        super(BiDAFOutputLayer, self).__init__(prefix=prefix, params=params)
+
+        with self.name_scope():
+            self._dropout = nn.Dropout(rate=dropout)
+            self._start_index_combined = nn.Dense(units=1, in_units=8 * span_start_input_dim,
+                                                  flatten=False)
+            self._start_index_model = nn.Dense(units=1, in_units=2 * span_start_input_dim,
+                                               flatten=False)
+            self._end_index_lstm = BiLMEncoder(mode='lstm',
+                                               num_layers=nlayers,
+                                               input_size=2 * span_start_input_dim,
+                                               hidden_size=span_start_input_dim,
+                                               dropout=dropout,
+                                               skip_connection=False)
+            self._end_index_combined = nn.Dense(units=1, in_units=8 * span_start_input_dim,
+                                                flatten=False)
+            self._end_index_model = nn.Dense(units=1, in_units=2 * span_start_input_dim,
+                                             flatten=False)
+
+    def hybrid_forward(self, F, x, m, end_index_states, mask):
+        # pylint: disable=arguments-differ,missing-docstring
+        # setting batch size as the first dimension
+        x = F.transpose(x, axes=(1, 0, 2))
+
+        start_index_dense_output = self._start_index_combined(self._dropout(x)) + \
+                                   self._start_index_model(self._dropout(
+                                       F.transpose(m, axes=(1, 0, 2))))
+
+        m2, _ = self._end_index_lstm(m, end_index_states, mask)
+        m2 = m2.slice_axis(axis=0, begin=-1, end=None).squeeze(axis=0)
+        end_index_dense_output = self._end_index_combined(self._dropout(x)) + \
+                                 self._end_index_model(self._dropout(F.transpose(m2,
+                                                                                 axes=(1, 0, 2))))
+
+        start_index_dense_output = F.squeeze(start_index_dense_output)
+        start_index_dense_output_masked = start_index_dense_output + ((1 - mask) * -1e30)
+
+        end_index_dense_output = F.squeeze(end_index_dense_output)
+        end_index_dense_output_masked = end_index_dense_output + ((1 - mask) * -1e30)
+
+        return start_index_dense_output_masked, \
+               end_index_dense_output_masked
+
+
+class BiDAFModel(HybridBlock):
+    """Bidirectional attention flow model for Question answering. Implemented according to the
+    following work:
+
+        @article{DBLP:journals/corr/abs-1804-09541,
+        author    = {Minjoon Seo and
+                    Aniruddha Kembhavi and
+                    Ali Farhadi and
+                    Hannaneh Hajishirzi},
+        title     = {Bidirectional Attention Flow for Machine Comprehension},
+        year      = {2016},
+        url       = {https://arxiv.org/abs/1611.01603}
+    }
+    """
+
+    def __init__(self, word_vocab, char_vocab, options, prefix=None, params=None):
+        super(BiDAFModel, self).__init__(prefix=prefix, params=params)
+        self._options = options
+        self._padding_token_idx = word_vocab[word_vocab.padding_token]
+
+        with self.name_scope():
+            self.ctx_embedding = BiDAFEmbedding(word_vocab,
+                                                char_vocab,
+                                                options.ctx_max_len,
+                                                options.ctx_embedding_num_layers,
+                                                options.highway_num_layers,
+                                                options.embedding_size,
+                                                dropout=options.dropout,
+                                                prefix='context_embedding')
+
+            self.similarity_function = LinearSimilarity(array_1_dim=6 * options.embedding_size,
+                                                        array_2_dim=1,
+                                                        combination='x,y,x*y')
+
+            self.matrix_attention = AttentionFlow(self.similarity_function,
+                                                  options.ctx_max_len,
+                                                  options.q_max_len)
+
+            # we multiple embedding_size by 2 because we use bidirectional embedding
+            self.attention_layer = BidirectionalAttentionFlow(options.ctx_max_len,
+                                                              options.q_max_len)
+
+            self.modeling_layer = BiLMEncoder(mode='lstm',
+                                              num_layers=1,
+                                              input_size=8 * options.embedding_size,
+                                              hidden_size=options.embedding_size,
+                                              dropout=0.0,
+                                              skip_connection=False)
+
+            self.output_layer = BiDAFOutputLayer(span_start_input_dim=options.embedding_size,
+                                                 nlayers=options.output_num_layers,
+                                                 dropout=options.dropout)
+
+    def initialize(self, init=initializer.Uniform(), ctx=None, verbose=False,
+                   force_reinit=False):
+        super(BiDAFModel, self).initialize(init, ctx, verbose, force_reinit)
+        self.ctx_embedding.init_embeddings('null' if not self._options.train_unk_token else 'write')
+
+    def hybrid_forward(self, F, qw, cw, qc, cc,
+                       ctx_embedding_state, modeling_layer_state, end_index_state):
+        # Both masks can be None
+        q_mask = qw != self._padding_token_idx
+        ctx_mask = cw != self._padding_token_idx
+
+        # pylint: disable=arguments-differ,missing-docstring
+        ctx_embedding_output = self.ctx_embedding(cw, cc, ctx_embedding_state, ctx_mask)
+        q_embedding_output = self.ctx_embedding(qw, qc, ctx_embedding_state, q_mask)
+
+        # attention layer expect batch_size x seq_length x channels
+        ctx_embedding_output = F.transpose(ctx_embedding_output, axes=(1, 0, 2))
+        q_embedding_output = F.transpose(q_embedding_output, axes=(1, 0, 2))
+
+        passage_question_similarity = self.matrix_attention(ctx_embedding_output,
+                                                            q_embedding_output)
+
+        passage_question_similarity = passage_question_similarity.reshape(
+            shape=(0,
+                   self._options.ctx_max_len,
+                   self._options.q_max_len))
+
+        attention_layer_output = self.attention_layer(passage_question_similarity,
+                                                      ctx_embedding_output,
+                                                      q_embedding_output,
+                                                      q_mask,
+                                                      ctx_mask)
+
+        attention_layer_output = F.transpose(attention_layer_output, axes=(1, 0, 2))
+
+        # modeling layer expects seq_length x batch_size x channels
+        modeling_layer_output, _ = self.modeling_layer(attention_layer_output,
+                                                       modeling_layer_state,
+                                                       ctx_mask)
+
+        ml_last_layer = modeling_layer_output.slice_axis(axis=0, begin=-1, end=None).squeeze(axis=0)
+
+        output = self.output_layer(attention_layer_output,
+                                   ml_last_layer,
+                                   end_index_state,
+                                   ctx_mask)
+
+        return output
+
+
+def last_dimension_applicator(F,
+                              function_to_apply,
+                              tensor,
+                              mask,
+                              **kwargs):
+    """
+    Takes a tensor with 3 or more dimensions and applies a function over the last dimension.  We
+    assume the tensor has shape ``(batch_size, ..., sequence_length)`` and that the mask
+    is of same shape . We flatten both tensor and mask to be 2D, pass them through
+    the function and put the tensor back in its original shape.
+    """
+    reshaped_tensor = tensor.reshape(shape=(-3, -1))
+
+    if mask is not None:
+        mask = mask.reshape(shape=(-3, -1))
+
+    reshaped_result = function_to_apply(F, reshaped_tensor, mask, **kwargs)
+    return F.reshape_like(lhs=reshaped_result, rhs=tensor)
+
+
+def masked_softmax(F, vector, mask, epsilon):
+    """
+    ``nd.softmax(vector)`` does not work if some elements of ``vector`` should be
+    masked.  This performs a softmax on just the non-masked portions of ``vector``.  Passing
+    ``None`` in for the mask is also acceptable; you'll just get a regular softmax.
+
+    We assume that both ``vector`` and ``mask`` (if given) have shape ``(batch_size, vector_dim)``.
+
+    In the case that the input vector is completely masked, this function returns an array
+    of ``0.0``. This behavior may cause ``NaN`` if this is used as the last layer of a model
+    that uses categorical cross-entropy loss.
+    """
+    if mask is None:
+        result = F.softmax(vector, axis=-1)
+    else:
+        # To limit numerical errors from large vector elements outside the mask, we zero these out.
+        result = F.softmax(vector * mask, axis=-1)
+        result = result * mask
+        result = F.broadcast_div(result, (result.sum(axis=1, keepdims=True) + epsilon))
+    return result
+
+
+def last_dim_softmax(F, tensor, mask, epsilon):
+    """
+    Takes a tensor with 3 or more dimensions and does a masked softmax over the last dimension.  We
+    assume the tensor has shape ``(batch_size, ..., sequence_length)`` and that the mask (if given)
+    has shape ``(batch_size, sequence_length)``.
+    """
+    return last_dimension_applicator(F, masked_softmax, tensor, mask, epsilon=epsilon)
+
+
+def replace_masked_values(F, tensor, mask, replace_with):
+    """
+    Replaces all masked values in ``tensor`` with ``replace_with``.  ``mask`` must be broadcastable
+    to the same shape as ``tensor``. We require that ``tensor.dim() == mask.dim()``, as otherwise we
+    won't know which dimensions of the mask to unsqueeze.
+    """
+    # We'll build a tensor of the same shape as `tensor`, zero out masked values, then add back in
+    # the `replace_with` value.
+    one_minus_mask = 1.0 - mask
+    values_to_add = replace_with * one_minus_mask
+    return F.broadcast_add(F.broadcast_mul(tensor, mask), values_to_add)

--- a/scripts/question_answering/bidaf_train.py
+++ b/scripts/question_answering/bidaf_train.py
@@ -1,0 +1,445 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Main script to train BiDAF model"""
+
+import copy
+import multiprocessing
+import os
+from time import time
+
+import mxnet as mx
+from mxnet import gluon, init, autograd
+from mxnet.gluon import Trainer
+from mxnet.gluon.data import DataLoader
+from mxnet.gluon.loss import SoftmaxCrossEntropyLoss
+
+try:
+    from bidaf_config import get_args
+    from bidaf_evaluate import PerformanceEvaluator
+    from data_pipeline import SQuADDataPipeline, SQuADDataLoaderTransformer
+    from utils import warm_up_lr, create_output_dir
+    from ema import ExponentialMovingAverage
+    from bidaf_model import BiDAFModel
+except ImportError:
+    from .bidaf_config import get_args
+    from .bidaf_evaluate import PerformanceEvaluator
+    from .data_pipeline import SQuADDataPipeline, SQuADDataLoaderTransformer
+    from .utils import warm_up_lr, create_output_dir
+    from .ema import ExponentialMovingAverage
+    from .bidaf_model import BiDAFModel
+
+
+def get_context(options):
+    """Return context list to work on
+
+    Parameters
+    ----------
+    options : `Namespace`
+        Command arguments
+
+    Returns
+    -------
+    ctx : list[Context]
+        List of contexts
+    """
+    ctx = []
+
+    if options.gpu is None:
+        ctx.append(mx.cpu(0))
+        print('Use CPU')
+    else:
+        indices = options.gpu.split(',')
+
+        for index in indices:
+            ctx.append(mx.gpu(int(index)))
+
+    return ctx
+
+
+def run_training(net, train_dataloader, dev_dataloader, dev_dataset, dev_json, ctx, ema, options):
+    """Main function to do training of the network
+
+    Parameters
+    ----------
+    net : `Block`
+        Network to train
+    train_dataloader : `DataLoader`
+        Initialized training dataloader
+    dev_dataloader : `DataLoader`
+        Initialized dev dataloader
+    dev_dataset : `SQuADQADataset`
+        Initialized dev dataset
+    dev_json : `dict`
+        Original dev JSON data
+    ctx: `Context`
+        Training context
+    ema : `ExponentialMovingAverage`
+        Exponential moving average to be used for inference.
+    options : `Namespace`
+        Training arguments
+    """
+
+    hyperparameters = {'learning_rate': options.lr}
+
+    if options.rho:
+        hyperparameters['rho'] = options.rho
+
+    trainer = Trainer(net.collect_params(), options.optimizer, hyperparameters, kvstore='device')
+    loss_function = SoftmaxCrossEntropyLoss()
+
+    train_start = time()
+    avg_loss = mx.nd.zeros((1,), ctx=ctx[0])
+    iteration = 1
+    max_dev_exact = -1
+    max_dev_f1 = -1
+    max_iteration = -1
+    early_stop_tries = 0
+
+    print('Starting training...')
+
+    for e in range(options.epochs):
+        i = 0
+        avg_loss *= 0  # Zero average loss of each epoch
+        records_per_epoch_count = 0
+        e_start = time()
+
+        for i, (r_idx, ctx_words, q_words, ctx_chars, q_chars, start, end) in enumerate(
+                train_dataloader):
+
+            records_per_epoch_count += r_idx.shape[0]
+            q_words = gluon.utils.split_and_load(q_words, ctx, even_split=False)
+            ctx_words = gluon.utils.split_and_load(ctx_words, ctx, even_split=False)
+            q_chars = gluon.utils.split_and_load(q_chars, ctx, even_split=False)
+            ctx_chars = gluon.utils.split_and_load(ctx_chars, ctx, even_split=False)
+            start = gluon.utils.split_and_load(start, ctx, even_split=False)
+            end = gluon.utils.split_and_load(end, ctx, even_split=False)
+
+            losses = []
+
+            for qw, cw, qc, cc, s, ee in zip(q_words, ctx_words, q_chars, ctx_chars, start, end):
+                with autograd.record():
+                    ctx_embedding_state = net.ctx_embedding._contextual_embedding.begin_state(
+                        batch_size=r_idx.shape[0], func=mx.ndarray.zeros, ctx=qw.context)
+
+                    modeling_layer_state = net.modeling_layer.begin_state(
+                        batch_size=r_idx.shape[0], func=mx.ndarray.zeros, ctx=qw.context)
+
+                    end_index_states = net.output_layer._end_index_lstm.begin_state(
+                        batch_size=r_idx.shape[0], func=mx.ndarray.zeros, ctx=qw.context)
+
+                    begin_hat, end_hat = net(qw, cw, qc, cc,
+                                             ctx_embedding_state,
+                                             modeling_layer_state,
+                                             end_index_states)
+                    loss = loss_function(begin_hat, s) + loss_function(end_hat, ee)
+                    losses.append(loss)
+                    # mx.nd.waitall()
+
+            for loss in losses:
+                loss.backward()
+
+            # mx.nd.waitall()
+
+            if iteration == 1 and options.use_exponential_moving_average:
+                ema.initialize(net.collect_params())
+
+            if options.lr_warmup_steps:
+                trainer.set_learning_rate(
+                    warm_up_lr(options.lr, iteration, options.lr_warmup_steps))
+
+            execute_trainer_step(net, trainer, ctx, options)
+
+            if options.use_exponential_moving_average:
+                ema.update()
+
+            if options.log_interval > 0 and iteration % options.log_interval == 0:
+                evaluate_options = copy.deepcopy(options)
+                evaluate_options.epochs = iteration
+                eval_result = run_evaluate(net, dev_dataloader, dev_dataset, dev_json,
+                                           evaluate_options, ema)
+
+                print('Iteration {} evaluation results on dev dataset: {}'.format(iteration,
+                                                                                  eval_result))
+                if not options.early_stop:
+                    continue
+
+                if eval_result['f1'] > max_dev_f1:
+                    max_dev_f1 = eval_result['f1']
+                    max_dev_exact = eval_result['exact_match']
+                    max_iteration = iteration
+                    early_stop_tries = 0
+                else:
+                    early_stop_tries += 1
+                    if early_stop_tries < options.early_stop:
+                        print('Results decreased for {} times'.format(early_stop_tries))
+                    else:
+                        print('Results decreased for {} times. Stop training. '
+                              'Best results are stored at {} params file. F1={}, EM={}'
+                              .format(options.early_stop + 1, max_iteration,
+                                      max_dev_f1, max_dev_exact))
+                        break
+
+            for l in losses:
+                avg_loss += l.mean().as_in_context(avg_loss.context)
+
+            iteration += 1
+
+        mx.nd.waitall()
+
+        avg_loss /= (i * len(ctx))
+
+        # block the call here to get correct Time per epoch
+        avg_loss_scalar = avg_loss.asscalar()
+
+        evaluate_options = copy.deepcopy(options)
+        evaluate_options.epochs = e
+        eval_result = run_evaluate(net, dev_dataloader, dev_dataset, dev_json, evaluate_options,
+                                   ema)
+
+        epoch_time = time() - e_start
+
+        print('\tEPOCH {:2}: train loss {:6.4f} | batch {:4} | lr {:5.3f} '
+              '| throughtput {:5.3f} of samples/sec | Time per epoch {:5.2f} seconds '
+              '| Evaluation result  {}'.format(e, avg_loss_scalar, options.batch_size,
+                                               trainer.learning_rate,
+                                               records_per_epoch_count / epoch_time,
+                                               epoch_time, eval_result))
+        if eval_result['f1'] > max_dev_f1:
+            max_dev_f1 = eval_result['f1']
+            max_dev_exact = eval_result['exact_match']
+            save_parameters(net.collect_params(), 'bidaf_model.params', options)
+            save_parameters(ema.get_params(), 'bidaf_ema.params', options)
+
+        if options.terminate_training_on_reaching_F1_threshold:
+            if eval_result['f1'] >= options.terminate_training_on_reaching_F1_threshold:
+                print('Finishing training on {} epoch, because dev F1 score is >= required {}. {}'
+                      .format(e, options.terminate_training_on_reaching_F1_threshold, eval_result))
+                break
+
+    print('Training time {:6.2f} seconds'.format(time() - train_start))
+
+
+def get_gradients(model, ctx, options):
+    """Get gradients and apply gradient decay to all layers if required.
+
+    Parameters
+    ----------
+    model : `BiDAFModel`
+        Model in training
+    ctx : `Context`
+        Training context
+    options : `Namespace`
+        Training options
+
+    Returns
+    -------
+    gradients : List
+        List of gradients
+    """
+    gradients = []
+
+    for name, parameter in model.collect_params().items():
+        if is_fixed_embedding_layer(name) and not options.train_unk_token:
+            continue
+
+        grad = parameter.grad(ctx)
+
+        if options.weight_decay:
+            if is_fixed_embedding_layer(name):
+                grad[0] += options.weight_decay * parameter.data(ctx)[0]
+            else:
+                grad += options.weight_decay * parameter.data(ctx)
+
+        gradients.append(grad)
+
+    return gradients
+
+
+def reset_embedding_gradients(model, ctx):
+    """Gradients for embedding layer doesn't need to be trained. We train only UNK token of
+    embedding if required.
+
+    Parameters
+    ----------
+    model : `BiDAFModel`
+        Model in training
+    ctx : `Context`
+        Training context
+    """
+    model.ctx_embedding._word_embedding.weight.grad(ctx=ctx)[1:] = 0
+
+
+def is_fixed_embedding_layer(name):
+    """Check if this is an embedding layer which parameters are supposed to be fixed
+
+    Parameters
+    ----------
+    name : `str`
+        Layer name to check
+    """
+    return True if 'predefined_embedding_layer' in name else False
+
+
+def execute_trainer_step(net, trainer, ctx, options):
+    """Does training step if doesn't need to do gradient clipping or train unknown symbols.
+
+    Parameters
+    ----------
+    net : `Block`
+        Network to train
+    trainer : `Trainer`
+        Trainer
+    ctx: `List[Context]`
+        Context list
+    options: `SimpleNamespace`
+        Training options
+    """
+    scailing_coeff = len(ctx) * options.batch_size
+
+    if options.clip or options.train_unk_token:
+        trainer.allreduce_grads()
+        gradients = get_gradients(net, ctx[0], options)
+
+        if options.clip:
+            gluon.utils.clip_global_norm(gradients, options.clip)
+
+        if options.train_unk_token:
+            reset_embedding_gradients(net, ctx[0])
+
+        if len(ctx) > 1:
+            # in multi gpu mode we propagate new gradients to the rest of gpus
+            for _, parameter in net.collect_params().items():
+                grads = parameter.list_grad()
+                source = grads[0]
+                destination = grads[1:]
+
+                for dest in destination:
+                    source.copyto(dest)
+
+        trainer.update(scailing_coeff)
+    else:
+        trainer.step(scailing_coeff)
+
+
+def save_parameters(params, filename, options):
+    """Save parameters of the trained model
+
+    Parameters
+    ----------
+    params : `gluon.ParameterDict`
+        Model with trained parameters
+    filename : `str`
+        Filename of parameters file
+    options : `Namespace`
+        Saving arguments
+
+    Returns
+    -------
+    save_path : `str`
+        Save path
+    """
+    if not os.path.exists(options.save_dir):
+        os.mkdir(options.save_dir)
+
+    save_path = os.path.join(options.save_dir, filename)
+    params.save(save_path)
+    return save_path
+
+
+def run_evaluate(net, dev_dataloader, dev_dataset, dev_json, options, existing_ema=None):
+    """Run program in evaluating mode
+
+    Parameters
+    ----------
+    net : `Block`
+        Trained existing network
+    dev_dataloader : `DataLoader`
+        Dev dataloader
+    dev_dataset : `SQuADQADataset`
+        Dev dataset
+    dev_json : `dict`
+        Original JSON dictionary of dev dataset
+    existing_ema : `ExponentialMovingAverage`
+        Averaged parameters of the network
+    options : `Namespace`
+        Model evaluation arguments
+
+    Returns
+    -------
+    result : dict
+        Dictionary with exact_match and F1 scores
+    """
+
+    if existing_ema is not None:
+        params_path = save_parameters(net.collect_params(), 'tmp.params', options)
+
+        for name, params in net.collect_params().items():
+            params.set_data(existing_ema.get_param(name))
+
+    evaluator = PerformanceEvaluator(dev_dataloader, dev_dataset, dev_json)
+    performance = evaluator.evaluate_performance(net, ctx, options)
+
+    if existing_ema is not None:
+        net.collect_params().load(params_path, ctx=ctx)
+
+    return performance
+
+
+if __name__ == '__main__':
+    args = get_args()
+    args.batch_size = int(args.batch_size / len(get_context(args)))
+    print(args)
+    create_output_dir(args.save_dir)
+
+    pipeline = SQuADDataPipeline(args.ctx_max_len, args.q_max_len,
+                                 args.ctx_max_len, args.q_max_len,
+                                 args.answer_max_len, args.word_max_len,
+                                 args.embedding_file_name)
+    train_json, dev_json, train_dataset, dev_dataset, word_vocab, char_vocab = \
+        pipeline.get_processed_data(use_spacy=False, shrink_word_vocab=True,
+                                    filter_train_examples=False)
+
+    ctx = get_context(args)
+
+    ema = ExponentialMovingAverage(args.exponential_moving_average_weight_decay) \
+        if args.use_exponential_moving_average else None
+
+    net = BiDAFModel(word_vocab, char_vocab, args, prefix='bidaf')
+    net.initialize(init.Xavier(), ctx=ctx)
+    net.hybridize(static_alloc=True)
+
+    train_dataloader = DataLoader(train_dataset.transform(SQuADDataLoaderTransformer()),
+                                  batch_size=len(ctx) * args.batch_size, shuffle=True,
+                                  last_batch='rollover', num_workers=multiprocessing.cpu_count(),
+                                  pin_memory=True)
+    dev_dataloader = DataLoader(dev_dataset.transform(SQuADDataLoaderTransformer()),
+                                batch_size=len(ctx) * args.batch_size, shuffle=False,
+                                last_batch='keep', num_workers=multiprocessing.cpu_count(),
+                                pin_memory=True)
+
+    if args.train or not args.evaluate:
+        print('Running in training mode')
+        run_training(net, train_dataloader, dev_dataloader, dev_dataset, dev_json, ctx, ema,
+                     options=args)
+
+    if args.evaluate:
+        print('Running in evaluation mode')
+        result = run_evaluate(net, dev_dataloader, dev_dataset, dev_json, args)
+        print('Evaluation results on dev dataset: {}'.format(result))

--- a/scripts/question_answering/data_pipeline.py
+++ b/scripts/question_answering/data_pipeline.py
@@ -91,7 +91,8 @@ class SQuADDataPipeline(object):
         self._word_vocab_file_name = 'word_vocab.bin'
         self._char_vocab_file_name = 'char_vocab.bin'
 
-    def get_processed_data(self, use_spacy=True, shrink_word_vocab=True, squad_data_root=None):
+    def get_processed_data(self, use_spacy=True, shrink_word_vocab=True, squad_data_root=None,
+                           filter_train_examples=True):
         """Main method to start data processing
 
         Parameters
@@ -103,6 +104,8 @@ class SQuADDataPipeline(object):
             word_vocab. Otherwise tokens with no embedding also stay
         squad_data_root : str, default None
             Data path to store downloaded original SQuAD data
+        filter_train_examples : bool, default True
+            Filter training data based on commonsense heuristics
         Returns
         -------
         train_json_data : dict
@@ -137,10 +140,11 @@ class SQuADDataPipeline(object):
                                                                    shrink_word_vocab,
                                                                    pool)
 
-        filter_provider = SQuADDataFilter(self._train_para_limit,
-                                          self._train_ques_limit,
-                                          self._ans_limit)
-        train_examples = list(filter(filter_provider.filter, train_examples))
+        if filter_train_examples:
+            filter_provider = SQuADDataFilter(self._train_para_limit,
+                                              self._train_ques_limit,
+                                              self._ans_limit)
+            train_examples = list(filter(filter_provider.filter, train_examples))
 
         train_featurizer = SQuADDataFeaturizer(word_vocab,
                                                char_vocab,
@@ -309,19 +313,33 @@ class SQuADDataPipeline(object):
         embedding = nlp.embedding.create('glove', source=emb_file_name)
 
         if is_cased_embedding:
-            word_counts = itertools.chain(*[[(item[0], item[1]),
-                                             (item[0].lower(), item[1]),
-                                             (item[0].capitalize(), item[1]),
-                                             (item[0].upper(), item[1])] for item in word_counts])
+            updated_counter = {}
+            for item in word_counts:
+                if item[0] in embedding.token_to_idx:
+                    updated_counter[item[0]] = item[1]
+                else:
+                    for cased_item in [(item[0].lower(), item[1]),
+                                       (item[0].capitalize(), item[1]),
+                                       (item[0].upper(), item[1])]:
+                        if cased_item[0] in embedding.token_to_idx:
+                            updated_counter[cased_item[0]] = cased_item[1]
+                            break
+
+                    if not shrink_word_vocab:
+                        updated_counter[item[0]] = item[1]
+
+            word_vocab = Vocab(updated_counter, bos_token=None, eos_token=None)
+            char_vocab = Vocab({item[0]: item[1] for item in char_counts},
+                               bos_token=None, eos_token=None)
         else:
             word_counts = [(item[0].lower(), item[1]) for item in word_counts]
+            word_vocab = Vocab({item[0]: item[1] for item in word_counts if
+                                not shrink_word_vocab or item[0] in embedding.token_to_idx},
+                               bos_token=None, eos_token=None)
+            char_vocab = Vocab({item[0].lower(): item[1] for item in char_counts},
+                               bos_token=None, eos_token=None)
 
-        word_vocab = Vocab({item[0]: item[1] for item in word_counts if
-                            not shrink_word_vocab or item[0] in embedding.token_to_idx},
-                           bos_token=None, eos_token=None)
         word_vocab.set_embedding(embedding)
-        char_vocab = Vocab({item[0]: item[1] for item in char_counts},
-                           bos_token=None, eos_token=None)
 
         return word_vocab, char_vocab
 
@@ -763,6 +781,24 @@ class SQuADDataFeaturizer(object):
 
         return result
 
+    def _get_chars_emb(self, chars):
+        """Get embedding for the characters
+
+        Parameters
+        ----------
+        chars : list[str]
+            Words to embed
+
+        Returns
+        -------
+        ret : np.array
+            Array of embeddings for words
+        """
+        if not self._is_cased_embedding:
+            return self._char_vocab[[char.lower() for char in chars]]
+        else:
+            return self._char_vocab[chars]
+
     def build_features(self, example):
         """Generate features for a given example
 
@@ -803,11 +839,12 @@ class SQuADDataFeaturizer(object):
 
         for i in range(0, context_len):
             char_len = min(len(example['context_chars'][i]), self._char_limit)
-            ctx_chars_idxs[i, :char_len] = self._char_vocab[example['context_chars'][i][:char_len]]
+            ctx_chars_idxs[i, :char_len] = self._get_chars_emb(
+                example['context_chars'][i][:char_len])
 
         for i in range(0, ques_len):
             char_len = min(len(example['ques_chars'][i]), self._char_limit)
-            ques_char_idxs[i, :char_len] = self._char_vocab[example['ques_tokens'][i][:char_len]]
+            ques_char_idxs[i, :char_len] = self._get_chars_emb(example['ques_tokens'][i][:char_len])
 
         start, end = example['y1s'][-1], example['y2s'][-1]
 

--- a/scripts/question_answering/ema.py
+++ b/scripts/question_answering/ema.py
@@ -1,0 +1,107 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Exponential moving average"""
+import mxnet as mx
+
+from mxnet import gluon
+
+
+class ExponentialMovingAverage(object):
+    r"""An implement of Exponential Moving Average.
+
+        shadow variable = decay * shadow variable + (1 - decay) * variable
+
+    Parameters
+    ----------
+    decay : float, default 0.9999
+        The axis to sum over when computing softmax and entropy.
+    """
+
+    def __init__(self, decay=0.9999, **kwargs):
+        super(ExponentialMovingAverage, self).__init__(**kwargs)
+        self._params = None
+        self._decay = decay
+        self._shadow_params = gluon.ParameterDict()
+
+    def initialize(self, params):
+        """Initialize EMA. Usually it should be called after 1st forward pass happened as
+        EMA requires shape information to be available.
+
+        Parameters
+        ----------
+        params : `ParameterDict`
+            Parameters of the network, usually obtained by calling net.collect_params()
+        """
+        self._params = params
+
+        for param in self._params.values():
+            shadow_param = self._shadow_params.get(param.name, shape=param.shape)
+            shadow_param.initialize(mx.init.Constant(self._param_data_to_cpu(param)), ctx=mx.cpu())
+
+    def update(self):
+        """
+        Updates currently held saved parameters with current state of network.
+        All calculations for this average occur on the cpu context.
+        """
+        for param in self._params.values():
+            shadow_param = self._shadow_params.get(param.name)
+            shadow_param.set_data(
+                (1 - self._decay) * self._param_data_to_cpu(param) +
+                self._decay * shadow_param.data(mx.cpu()))
+
+    def get_param(self, name):
+        """Return the shadow variable.
+
+        Parameters
+        -----------
+        name : string
+            the name of shadow variable.
+
+        Returns
+        --------
+        return : NDArray
+            the value of shadow variable.
+        """
+        return self._shadow_params.get(name).data(mx.cpu())
+
+    def get_params(self):
+        """ Provides averaged parameters
+
+        Returns
+        -------
+        gluon.ParameterDict
+            Averaged parameters
+        """
+        return self._shadow_params
+
+    def _param_data_to_cpu(self, param):
+        """Returns a copy (on CPU context) of the data held in some context of given parameter.
+
+        Parameters
+        ----------
+        param: gluon.Parameter
+            Parameter's whose data needs to be copied.
+
+        Returns
+        -------
+        NDArray
+            Copy of data on CPU context.
+        """
+        return param.list_data()[0].copyto(mx.cpu())

--- a/scripts/question_answering/official_squad_eval_script.py
+++ b/scripts/question_answering/official_squad_eval_script.py
@@ -1,0 +1,143 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" Official evaluation script for v1.1 of the SQuAD dataset. """
+from __future__ import print_function
+from collections import Counter
+import string
+import re
+import argparse
+import json
+import sys
+
+
+def f1_score(prediction, ground_truth):
+    """Calculate F1 score
+
+    Parameters
+    ----------
+    prediction : str
+        Prediction
+
+    ground_truth : str
+        Ground truth
+
+    Returns
+    -------
+    F1 : float
+        F1 score
+    """
+    prediction_tokens = normalize_answer(prediction).split()
+    ground_truth_tokens = normalize_answer(ground_truth).split()
+    common = Counter(prediction_tokens) & Counter(ground_truth_tokens)
+    num_same = sum(common.values())
+    if num_same == 0:
+        return 0
+    precision = 1.0 * num_same / len(prediction_tokens)
+    recall = 1.0 * num_same / len(ground_truth_tokens)
+    f1 = (2 * precision * recall) / (precision + recall)
+    return f1
+
+
+def normalize_answer(s):
+    """Lower text and remove punctuation, articles and extra whitespace."""
+    def remove_articles(text):
+        return re.sub(r'\b(a|an|the)\b', ' ', text)
+
+    def white_space_fix(text):
+        return ' '.join(text.split())
+
+    def remove_punc(text):
+        exclude = set(string.punctuation)
+        return ''.join(ch for ch in text if ch not in exclude)
+
+    def lower(text):
+        return text.lower()
+
+    return white_space_fix(remove_articles(remove_punc(lower(s))))
+
+
+def exact_match_score(prediction, ground_truth):
+    return (normalize_answer(prediction) == normalize_answer(ground_truth))
+
+
+def metric_max_over_ground_truths(metric_fn, prediction, ground_truths):
+    scores_for_ground_truths = []
+    for ground_truth in ground_truths:
+        score = metric_fn(prediction, ground_truth)
+        scores_for_ground_truths.append(score)
+    return max(scores_for_ground_truths)
+
+
+def evaluate(dataset, predictions):
+    """Evaluate dataset against predictions
+
+    Parameters
+    ----------
+    dataset : `dict`
+        Dictionary containing JSON of SQuAD 1.1 dataset
+
+    predictions : `dict`
+        Map of Question id and prediction
+
+    Returns
+    -------
+    result : `dict`
+        Dictionary with F1 and Exact Match scores
+    """
+    f1 = exact_match = total = 0
+    for article in dataset:
+        for paragraph in article['paragraphs']:
+            for qa in paragraph['qas']:
+                total += 1
+                if qa['id'] not in predictions:
+                    message = 'Unanswered question ' + qa['id'] + \
+                              ' will receive score 0.'
+                    print(message, file=sys.stderr)
+                    continue
+                ground_truths = list(map(lambda x: x['text'], qa['answers']))
+                prediction = predictions[qa['id']]
+                exact_match += metric_max_over_ground_truths(
+                    exact_match_score, prediction, ground_truths)
+                f1 += metric_max_over_ground_truths(
+                    f1_score, prediction, ground_truths)
+
+    exact_match = 100.0 * exact_match / total
+    f1 = 100.0 * f1 / total
+
+    return {'exact_match': exact_match, 'f1': f1}
+
+
+if __name__ == '__main__':
+    expected_version = '1.1'
+    parser = argparse.ArgumentParser(
+        description='Evaluation for SQuAD ' + expected_version)
+    parser.add_argument('dataset_file', help='Dataset file')
+    parser.add_argument('prediction_file', help='Prediction File')
+    args = parser.parse_args()
+    with open(args.dataset_file) as dataset_file:
+        dataset_json = json.load(dataset_file)
+        if (dataset_json['version'] != expected_version):
+            print('Evaluation expects v-' + expected_version +
+                  ', but got dataset with v-' + dataset_json['version'],
+                  file=sys.stderr)
+        dataset_data = dataset_json['data']
+    with open(args.prediction_file) as prediction_file:
+        predictions_json = json.load(prediction_file)
+    print(json.dumps(evaluate(dataset_data, predictions_json)))

--- a/scripts/question_answering/qanet_config.py
+++ b/scripts/question_answering/qanet_config.py
@@ -1,0 +1,119 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+r"""
+This file contains all hyperparameters.
+"""
+import argparse
+import mxnet as mx
+
+# Data preprocessing parameters
+TRAIN_PARA_LIMIT = 400
+TRAIN_QUES_LIMIT = 50
+DEV_PARA_LIMIT = 1000
+DEV_QUES_LIMIT = 100
+ANS_LIMIT = 30
+CHAR_LIMIT = 16
+
+GLOVE_FILE_NAME = 'glove.840B.300d'
+
+ACCUM_AVG_TRAIN_CROSS_ENTROPY_PREFIX = 'qanet_accum_avg_train_cross_entropy'
+BATCH_TRAIN_CROSS_ENTROPY_PREFIX = 'qanet_batch_train_cross_entropy'
+TRAIN_F1 = 'qanet_train_f1.json'
+TRAIN_EM = 'qanet_train_em.json'
+DEV_CROSS_ENTROPY = 'qanet_dev_cross_entropy.json'
+DEV_F1 = 'qanet_dev_f1.json'
+DEV_EM = 'qanet_dev_em.json'
+
+EVALUATE_INTERVAL = 0
+
+TRAIN_FLAG = True
+CTX = [mx.gpu(0)]
+
+EPOCHS = 60
+TRAIN_BATCH_SIZE = 32
+EVAL_BATCH_SIZE = 16
+
+# model save & load
+BEST_MODEL_FILE_NAME = 'qanet_model.params'
+BEST_MODEL_EMA_FILE_NAME = 'qanet_ema.params'
+NEED_LOAD_TRAINED_MODEL = False
+LAST_GLOBAL_STEP = 0
+
+# dropout
+LAYERS_DROPOUT = 0.1
+p_L = 0.9
+WORD_EMBEDDING_DROPOUT = 0.1
+CHAR_EMBEDDING_DROPOUT = 0.05
+HIGHWAY_LAYERS_DROPOUT = 0.1
+
+# padding parameter
+MAX_CONTEXT_SENTENCE_LEN = 400
+MAX_QUESTION_SENTENCE_LEN = 50
+MAX_CHARACTER_PER_WORD = 16
+
+# embedding parameter
+UNK = 1
+PAD = 0
+
+DIM_WORD_EMBED = 300
+DIM_CHAR_EMBED = 200
+
+NUM_HIGHWAY_LAYERS = 2
+
+# embedding encoder parameter
+EMB_ENCODER_CONV_CHANNELS = 128
+EMB_ENCODER_CONV_KERNEL_SIZE = 7
+EMB_ENCODER_NUM_CONV_LAYERS = 4
+EMB_ENCODER_NUM_HEAD = 1
+EMB_ENCODER_NUM_BLOCK = 1
+
+# model encoder parameter
+MODEL_ENCODER_CONV_KERNEL_SIZE = 5
+MODEL_ENCODER_CONV_CHANNELS = 128
+MODEL_ENCODER_NUM_CONV_LAYERS = 2
+MODEL_ENCODER_NUM_HEAD = 1
+MODEL_ENCODER_NUM_BLOCK = 7
+
+# opt parameter
+INIT_LEARNING_RATE = 0.001
+CLIP_GRADIENT = 5
+WEIGHT_DECAY = 3e-7
+BETA1 = 0.8
+BETA2 = 0.999
+EPSILON = 1e-7
+EXPONENTIAL_MOVING_AVERAGE_DECAY = 0.9999
+WARM_UP_STEPS = 1000
+
+# evaluate
+MAX_ANSWER_LENS = 30
+
+
+def get_args():
+    """Get console arguments
+    """
+    parser = argparse.ArgumentParser(description='Question Answering example using QANet & SQuAD',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--save_dir', type=str, default='qanet_output',
+                        help='directory path to save the final model and training log')
+    parser.add_argument('--save_cross_entropy', default=False, action='store_true',
+                        help='Store cross entropy results after each epoch')
+
+    options = parser.parse_args()
+    return options

--- a/scripts/question_answering/qanet_evaluate.py
+++ b/scripts/question_answering/qanet_evaluate.py
@@ -1,0 +1,111 @@
+"""
+In the evaluate function, we use the offical evaluate function as core function.
+
+offical evaluate.py file can be find in the SQuAD dataset offcial web.
+"""
+from mxnet import autograd, nd
+from tqdm import tqdm
+
+try:
+    from qanet_config import (CTX, MAX_ANSWER_LENS)
+    from official_squad_eval_script import evaluate as official_eval
+except ImportError:
+    from .qanet_config import (CTX, MAX_ANSWER_LENS)
+    from .official_squad_eval_script import evaluate as official_eval
+
+
+ctx = CTX[0]
+ANSWER_MASK_MATRIX = nd.zeros(
+    shape=(1, 1000, 1000), ctx=ctx)
+for idx in range(MAX_ANSWER_LENS):
+    ANSWER_MASK_MATRIX += nd.eye(
+        N=1000, M=1000, k=idx, ctx=ctx)
+
+
+def evaluate(model, dataloader, dataset, original_json_data, ema=None, padding_token_idx=1):
+    r"""Evaluate the model on train/dev/test dataset.
+
+    This function is just an encapsulation of official evaluate function.
+
+    The official evaluate code can be find in https://rajpurkar.github.io/SQuAD-explorer/
+
+    Parameters
+    ----------
+    dataset_type : string, default 'train'
+        which dataset to evaluate.
+    ema : `ExponentialMovingAverage`
+        Whether use the shadow variable to evaluate.
+    """
+    model.save_parameters('tmp')
+
+    if ema is not None:
+        for name, params in model.collect_params().items():
+            params.set_data(ema.get_param(name))
+
+    autograd.set_training(False)
+    total_answers = {}
+
+    for idxs, context, query, context_char, query_char, _, _ in tqdm(dataloader):
+        context = context.as_in_context(ctx)
+        query = query.as_in_context(ctx)
+        context_char = context_char.as_in_context(ctx)
+        query_char = query_char.as_in_context(ctx)
+
+        context_mask = context != padding_token_idx
+        query_mask = query != padding_token_idx
+
+        raw_context = [dataset.get_record_by_idx(x.asscalar())[8] for x in idxs]
+        spans = [dataset.get_record_by_idx(x.asscalar())[9] for x in idxs]
+
+        begin_hat, end_hat, _, _ = model(
+            context, query, context_char, query_char, context_mask, query_mask, None, None)
+        begin_hat = begin_hat.softmax(axis=1)
+        end_hat = end_hat.softmax(axis=1)
+
+        answer_span_pair = matrix_answer_select(begin_hat, end_hat)
+        for i, a, r, s in zip(idxs, answer_span_pair, raw_context, spans):
+            total_answers[dataset.get_q_id_by_rec_idx(i.asscalar())] = format_answer(a, r, s)
+
+    model.load_parameters('tmp', ctx=CTX)
+    autograd.set_training(True)
+
+    result = official_eval(original_json_data['data'], total_answers)
+    f1_score = result['f1']
+    em_score = result['exact_match']
+    return f1_score, em_score
+
+
+def matrix_answer_select(begin_hat, end_hat):
+    r"""Select the begin and end position of answer span.
+
+        At inference time, the predicted span (s, e) is chosen such that
+        begin_hat[s] * end_hat[e] is maximized and s ≤ e.
+
+    Parameters
+    ----------
+    begin_hat : NDArray
+        input tensor with shape `(batch_size, context_sequence_length)`
+    end_hat : NDArray
+        input tensor with shape `(batch_size, context_sequence_length)`
+    """
+    global ANSWER_MASK_MATRIX
+
+    begin_hat = begin_hat.reshape(begin_hat.shape + (1,))
+    end_hat = end_hat.reshape(end_hat.shape + (1,))
+    end_hat = end_hat.transpose(axes=(0, 2, 1))
+
+    result = nd.batch_dot(begin_hat, end_hat) * ANSWER_MASK_MATRIX.slice(
+        begin=(0, 0, 0), end=(1, begin_hat.shape[1], begin_hat.shape[1]))
+
+    yp1 = result.max(axis=2).argmax(axis=1, keepdims=True).astype('int32')
+    yp2 = result.max(axis=1).argmax(axis=1, keepdims=True).astype('int32')
+
+    return nd.concat(yp1, yp2, dim=-1)
+
+
+def format_answer(answer_span_pair, context, sp):
+    begin = int(answer_span_pair[0].asscalar())
+    end = int(answer_span_pair[1].asscalar())
+
+    prediction_text = context[sp[begin][0]:sp[end][1]]
+    return prediction_text

--- a/scripts/question_answering/qanet_model.py
+++ b/scripts/question_answering/qanet_model.py
@@ -1,0 +1,758 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""QANet model with all used layers"""
+
+import math
+
+import mxnet as mx
+from mxnet import gluon, nd
+from mxnet.initializer import MSRAPrelu, Normal, Uniform, Xavier
+from gluonnlp.model import (DotProductAttentionCell, Highway, MultiHeadAttentionCell)
+
+try:
+    from qanet_config import (LAYERS_DROPOUT, EMB_ENCODER_CONV_CHANNELS, NUM_HIGHWAY_LAYERS,
+                              DIM_WORD_EMBED, WORD_EMBEDDING_DROPOUT,
+                              DIM_CHAR_EMBED, CHAR_EMBEDDING_DROPOUT,
+                              MODEL_ENCODER_CONV_KERNEL_SIZE,
+                              EMB_ENCODER_CONV_KERNEL_SIZE, EMB_ENCODER_NUM_BLOCK,
+                              EMB_ENCODER_NUM_HEAD, MODEL_ENCODER_CONV_CHANNELS,
+                              MAX_CHARACTER_PER_WORD,
+                              MODEL_ENCODER_NUM_BLOCK, EMB_ENCODER_NUM_CONV_LAYERS,
+                              p_L, MODEL_ENCODER_NUM_CONV_LAYERS, MODEL_ENCODER_NUM_HEAD)
+except ImportError:
+    from .qanet_config import (LAYERS_DROPOUT, EMB_ENCODER_CONV_CHANNELS, NUM_HIGHWAY_LAYERS,
+                               DIM_WORD_EMBED, WORD_EMBEDDING_DROPOUT,
+                               DIM_CHAR_EMBED, CHAR_EMBEDDING_DROPOUT,
+                               MODEL_ENCODER_CONV_KERNEL_SIZE,
+                               EMB_ENCODER_CONV_KERNEL_SIZE, EMB_ENCODER_NUM_BLOCK,
+                               EMB_ENCODER_NUM_HEAD, MODEL_ENCODER_CONV_CHANNELS,
+                               MAX_CHARACTER_PER_WORD,
+                               MODEL_ENCODER_NUM_BLOCK, EMB_ENCODER_NUM_CONV_LAYERS,
+                               p_L, MODEL_ENCODER_NUM_CONV_LAYERS, MODEL_ENCODER_NUM_HEAD)
+
+
+class MySoftmaxCrossEntropy(gluon.loss.Loss):
+    r"""Caluate the sum of softmax cross entropy.
+
+    Reference:
+    http://mxnet.incubator.apache.org/api/python/gluon/loss.html#mxnet.gluon.loss.SoftmaxCrossEntropyLoss
+
+    Parameters
+    ----------
+    axis : int, default -1
+        The axis to sum over when computing softmax and entropy.
+    sparse_label : bool, default True
+        Whether label is an integer array instead of probalbility distribution.
+    from_logits : bool, default False
+        Whether input is a log probability (usually from log_softmax) instead of
+        unnormalized numbers.
+    weight : float or None
+        Global scalar weight for loss.
+    batch_axis : int, default 0
+        The axis that represents mini-batch.
+    """
+
+    def __init__(self, axis=-1, sparse_label=True, from_logits=False, weight=None, batch_axis=0,
+                 **kwargs):
+        super(MySoftmaxCrossEntropy, self).__init__(
+            weight, batch_axis, **kwargs)
+        self.loss = gluon.loss.SoftmaxCrossEntropyLoss(axis=axis,
+                                                       sparse_label=sparse_label,
+                                                       from_logits=from_logits,
+                                                       weight=weight,
+                                                       batch_axis=batch_axis)
+
+    def forward(self, predict_begin, predict_end, label_begin, label_end):
+        r"""Implement forward computation.
+
+        Parameters
+        -----------
+        predict_begin : NDArray
+            Predicted probability distribution of answer begin position,
+            input tensor with shape `(batch_size, sequence_length)`
+        predict_end : NDArray
+            Predicted probability distribution of answer end position,
+            input tensor with shape `(batch_size, sequence_length)`
+        label_begin : NDArray
+            True label of the answer begin position,
+            input tensor with shape `(batch_size, )`
+        label_end : NDArray
+            True label of the answer end position,
+            input tensor with shape `(batch_size, )`
+
+        Returns
+        --------
+        out: NDArray
+            output tensor with shape `(batch_size, )`
+        """
+        return self.loss(predict_begin, label_begin) + self.loss(predict_end, label_end)
+
+    def hybrid_forward(self, F):
+        pass
+
+
+class QANet(gluon.HybridBlock):
+    r"""QANet model.
+    We implemented the QANet proposed in the following work::
+        @article{DBLP:journals/corr/abs-1804-09541,
+            author    = {Adams Wei Yu and
+                        David Dohan and
+                        Minh{-}Thang Luong and
+                        Rui Zhao and
+                        Kai Chen and
+                        Mohammad Norouzi and
+                        Quoc V. Le},
+            title     = {QANet: Combining Local Convolution with Global Self-Attention for
+                        Reading Comprehension},
+            year      = {2018},
+            url       = {http://arxiv.org/abs/1804.09541}
+        }
+
+    """
+
+    def __init__(self, corpus_words_count, corpus_chars_count, **kwargs):
+        super(QANet, self).__init__(**kwargs)
+        with self.name_scope():
+            self.flatten = gluon.nn.Flatten()
+            self.dropout = gluon.nn.Dropout(LAYERS_DROPOUT)
+            self.char_conv = gluon.nn.Conv1D(
+                channels=EMB_ENCODER_CONV_CHANNELS,
+                kernel_size=5,
+                activation='relu',
+                weight_initializer=MSRAPrelu(),
+                use_bias=True,
+                padding=5 // 2
+            )
+
+        self.highway = gluon.nn.HybridSequential()
+        with self.highway.name_scope():
+            self.highway.add(
+                gluon.nn.Dense(
+                    units=EMB_ENCODER_CONV_CHANNELS,
+                    flatten=False,
+                    use_bias=False,
+                    weight_initializer=Xavier()
+                )
+            )
+            self.highway.add(
+                Highway(
+                    input_size=EMB_ENCODER_CONV_CHANNELS,
+                    num_layers=NUM_HIGHWAY_LAYERS
+                )
+            )
+
+        self.word_emb = gluon.nn.HybridSequential()
+        with self.word_emb.name_scope():
+            self.word_emb.add(
+                gluon.nn.Embedding(
+                    input_dim=corpus_words_count,
+                    output_dim=DIM_WORD_EMBED
+                )
+            )
+            self.word_emb.add(
+                gluon.nn.Dropout(rate=WORD_EMBEDDING_DROPOUT)
+            )
+        self.char_emb = gluon.nn.HybridSequential()
+        with self.char_emb.name_scope():
+            self.char_emb.add(
+                gluon.nn.Embedding(
+                    input_dim=corpus_chars_count,
+                    output_dim=DIM_CHAR_EMBED,
+                    weight_initializer=Normal(sigma=0.1)
+                )
+            )
+            self.char_emb.add(
+                gluon.nn.Dropout(rate=CHAR_EMBEDDING_DROPOUT)
+            )
+
+        with self.name_scope():
+            self.emb_encoder = Encoder(
+                kernel_size=EMB_ENCODER_CONV_KERNEL_SIZE,
+                num_filters=EMB_ENCODER_CONV_CHANNELS,
+                conv_layers=EMB_ENCODER_NUM_CONV_LAYERS,
+                num_heads=EMB_ENCODER_NUM_HEAD,
+                num_blocks=EMB_ENCODER_NUM_BLOCK
+            )
+
+            self.project = gluon.nn.Dense(
+                units=EMB_ENCODER_CONV_CHANNELS,
+                flatten=False,
+                use_bias=False,
+                weight_initializer=Xavier()
+            )
+
+        with self.name_scope():
+            self.co_attention = CoAttention()
+
+        with self.name_scope():
+            self.model_encoder = Encoder(
+                kernel_size=MODEL_ENCODER_CONV_KERNEL_SIZE,
+                num_filters=MODEL_ENCODER_CONV_CHANNELS,
+                conv_layers=MODEL_ENCODER_NUM_CONV_LAYERS,
+                num_heads=MODEL_ENCODER_NUM_HEAD,
+                num_blocks=MODEL_ENCODER_NUM_BLOCK
+            )
+
+        with self.name_scope():
+            self.predict_begin = gluon.nn.Dense(
+                units=1,
+                use_bias=True,
+                flatten=False,
+                weight_initializer=Xavier(
+                    rnd_type='uniform', factor_type='in', magnitude=1),
+                bias_initializer=Uniform(1.0 / MODEL_ENCODER_CONV_CHANNELS)
+            )
+            self.predict_end = gluon.nn.Dense(
+                units=1,
+                use_bias=True,
+                flatten=False,
+                weight_initializer=Xavier(
+                    rnd_type='uniform', factor_type='in', magnitude=1),
+                bias_initializer=Uniform(1.0 / MODEL_ENCODER_CONV_CHANNELS)
+            )
+
+    def hybrid_forward(self, F, context, query, context_char, query_char,
+                       context_mask, query_mask, y_begin, y_end):
+        r"""Implement forward computation.
+
+        Parameters
+        -----------
+        context : NDArray
+            input tensor with shape `(batch_size, context_sequence_length)`
+        query : NDArray
+            input tensor with shape `(batch_size, query_sequence_length)`
+        context_char : NDArray
+            input tensor with shape `(batch_size, context_sequence_length, num_char_per_word)`
+        query_char : NDArray
+            input tensor with shape `(batch_size, query_sequence_length, num_char_per_word)`
+        context_mask : NDArray
+            input tensor with shape `(batch_size, context_sequence_length)`
+        query_mask : NDArray
+            input tensor with shape `(batch_size, query_sequence_length)`
+        y_begin : NDArray
+            input tensor with shape `(batch_size, )`
+        y_end : NDArray
+            input tensor with shape `(batch_size, )`
+
+        Returns
+        --------
+        predicted_begin : NDArray
+            output tensor with shape `(batch_size, context_sequence_length)`
+        predicted_end : NDArray
+            output tensor with shape `(batch_size, context_sequence_length)`
+        """
+        (batch, _) = context.shape
+
+        context_max_len = int(context_mask.sum(axis=1).max().asscalar())
+        query_max_len = int(query_mask.sum(axis=1).max().asscalar())
+
+        context = F.slice(context, begin=(0, 0), end=(batch, context_max_len))
+        query = F.slice(query, begin=(0, 0), end=(batch, query_max_len))
+        context_mask = F.slice(context_mask, begin=(
+            0, 0), end=(batch, context_max_len))
+        query_mask = F.slice(query_mask, begin=(0, 0),
+                             end=(batch, query_max_len))
+        context_char = F.slice(context_char, begin=(0, 0, 0), end=(
+            batch, context_max_len, MAX_CHARACTER_PER_WORD))
+        query_char = F.slice(query_char, begin=(0, 0, 0), end=(
+            batch, query_max_len, MAX_CHARACTER_PER_WORD))
+
+        # embedding layer
+        # word embedding
+        # (batch, words, word_embs)
+        context_word_emb = self.word_emb(context)
+        query_word_emb = self.word_emb(query)
+
+        # char embedding
+        context_char_flat = self.flatten(context_char)
+        query_char_flat = self.flatten(query_char)
+        context_char_emb = self.char_emb(context_char_flat)
+        query_char_emb = self.char_emb(query_char_flat)
+
+        # bidaf style char conv
+        context_char_emb = context_char_emb.reshape(
+            (batch * context_max_len, MAX_CHARACTER_PER_WORD, DIM_CHAR_EMBED))
+        query_char_emb = query_char_emb.reshape(
+            (batch * query_max_len, MAX_CHARACTER_PER_WORD, DIM_CHAR_EMBED))
+        context_char_emb = context_char_emb.transpose(axes=(0, 2, 1))
+        query_char_emb = query_char_emb.transpose(axes=(0, 2, 1))
+        context_char_emb = self.char_conv(context_char_emb)
+        query_char_emb = self.char_conv(query_char_emb)
+        context_char_emb = context_char_emb.transpose(axes=(0, 2, 1))
+        query_char_emb = query_char_emb.transpose(axes=(0, 2, 1))
+
+        context_char_emb = context_char_emb.reshape(
+            (batch, context_max_len, MAX_CHARACTER_PER_WORD, context_char_emb.shape[-1]))
+        query_char_emb = query_char_emb.reshape(
+            (batch, query_max_len, MAX_CHARACTER_PER_WORD, query_char_emb.shape[-1]))
+        # (batch, words, chars, char_embs)
+        context_char_max = context_char_emb.max(axis=2)
+        query_char_max = query_char_emb.max(axis=2)
+
+        # concat word and char embedding
+        context_concat = nd.concat(context_word_emb, context_char_max, dim=-1)
+        query_concat = nd.concat(query_word_emb, query_char_max, dim=-1)
+
+        # highway net
+        context_final_emb = self.highway(context_concat)
+        query_final_emb = self.highway(query_concat)
+
+        # embedding encoder
+        # share the weights between passage and question
+        context_emb_encoded = self.emb_encoder(context_final_emb, context_mask)
+        query_emb_encoded = self.emb_encoder(query_final_emb, query_mask)
+
+        # context-query attention layer
+        M = self.co_attention(context_emb_encoded, query_emb_encoded, context_mask,
+                              query_mask, context_max_len, query_max_len)
+
+        M = self.project(M)
+        M = self.dropout(M)
+
+        # model encoder layer
+        M_0 = self.model_encoder(M, context_mask)
+        M_1 = self.model_encoder(M_0, context_mask)
+        M_2 = self.model_encoder(M_1, context_mask)
+
+        # predict layer
+        begin_hat = self.flatten(
+            self.predict_begin(nd.concat(M_0, M_1, dim=-1)))
+        end_hat = self.flatten(self.predict_end(nd.concat(M_0, M_2, dim=-1)))
+        predicted_begin = mask_logits(begin_hat, context_mask)
+        predicted_end = mask_logits(end_hat, context_mask)
+        return predicted_begin, predicted_end, y_begin, y_end
+
+
+class Encoder(gluon.HybridBlock):
+    r"""
+    Stacked block of Embedding encoder or Model encoder.
+    """
+
+    def __init__(self, kernel_size, num_filters, conv_layers=2, num_heads=8,
+                 num_blocks=1, **kwargs):
+        super(Encoder, self).__init__(**kwargs)
+        self.dropout = gluon.nn.Dropout(LAYERS_DROPOUT)
+        total_layers = float((conv_layers + 2) * num_blocks)
+        sub_layer_idx = 1
+        self.num_blocks = num_blocks
+        self.stack_encoders = gluon.nn.HybridSequential()
+        with self.stack_encoders.name_scope():
+            for _ in range(num_blocks):
+                self.stack_encoders.add(
+                    OneEncoderBlock(
+                        kernel_size=kernel_size,
+                        num_filters=num_filters,
+                        conv_layers=conv_layers,
+                        num_heads=num_heads,
+                        total_layers=total_layers,
+                        sub_layer_idx=sub_layer_idx
+                    )
+                )
+                sub_layer_idx += (conv_layers + 2)
+
+    def hybrid_forward(self, F, x, mask):
+        r"""Implement forward computation.
+
+        Parameters
+        -----------
+        x : NDArray
+            input tensor with shape `(batch_size, sequence_length, features)`
+        mask : NDArray
+            input tensor with shape `(batch_size, sequence_length)`
+
+        Returns, NDArray
+        --------
+            output tensor with shape `(batch_size, sequence_length, features)`
+        """
+        for encoder in self.stack_encoders:
+            x = encoder(x, mask)
+            x = F.Dropout(x, p=LAYERS_DROPOUT)
+        return x
+
+
+class OneEncoderBlock(gluon.HybridBlock):
+    r"""The basic encoder block.
+
+    Parameters
+    ----------
+    kernel_size : int
+        The kernel size for all depthwise convolution layers.
+    num_filters : int
+        The number of filters for all convolution layers.
+    conv_layers : int
+        The number of convolution layers in one encoder block.
+    num_heads : int
+        The number of heads in multi-head attention layer.
+    total_layers : int
+    sub_layer_idx : int
+        The sub_layer_idx / total_layers is the dropout probability for layer.
+    """
+
+    def __init__(self, kernel_size, num_filters, conv_layers, num_heads, total_layers,
+                 sub_layer_idx, **kwargs):
+        super(OneEncoderBlock, self).__init__(**kwargs)
+        self.position_encoder = PositionEncoder()
+        self.convs = gluon.nn.HybridSequential()
+        with self.convs.name_scope():
+            for _ in range(conv_layers):
+                one_conv_module = gluon.nn.HybridSequential()
+                with one_conv_module.name_scope():
+                    one_conv_module.add(
+                        gluon.nn.LayerNorm(epsilon=1e-06)
+                    )
+                    one_conv_module.add(
+                        gluon.nn.Dropout(LAYERS_DROPOUT)
+                    )
+                    one_conv_module.add(
+                        DepthwiseConv(
+                            kernel_size=kernel_size,
+                            num_filters=num_filters,
+                            input_channels=num_filters
+                        )
+                    )
+                    one_conv_module.add(
+                        StochasticDropoutLayer(
+                            dropout=(sub_layer_idx / total_layers) * (1 - p_L)
+                        )
+                    )
+                sub_layer_idx += 1
+                self.convs.add(one_conv_module)
+
+        with self.name_scope():
+            self.dropout = gluon.nn.Dropout(LAYERS_DROPOUT)
+            self.attention = SelfAttention(num_heads=num_heads)
+            self.attention_dropout = StochasticDropoutLayer(
+                (sub_layer_idx / total_layers) * (1 - p_L))
+            sub_layer_idx += 1
+            self.attention_layer_norm = gluon.nn.LayerNorm(epsilon=1e-06)
+
+        self.positionwise_ffn = gluon.nn.HybridSequential()
+        with self.positionwise_ffn.name_scope():
+            self.positionwise_ffn.add(
+                gluon.nn.LayerNorm(epsilon=1e-06)
+            )
+            self.positionwise_ffn.add(
+                gluon.nn.Dropout(rate=LAYERS_DROPOUT)
+            )
+            self.positionwise_ffn.add(
+                gluon.nn.Dense(
+                    units=EMB_ENCODER_CONV_CHANNELS,
+                    activation='relu',
+                    use_bias=True,
+                    weight_initializer=MSRAPrelu(),
+                    flatten=False
+                )
+            )
+            self.positionwise_ffn.add(
+                gluon.nn.Dense(
+                    units=EMB_ENCODER_CONV_CHANNELS,
+                    use_bias=True,
+                    weight_initializer=Xavier(),
+                    flatten=False
+                )
+            )
+            self.positionwise_ffn.add(
+                StochasticDropoutLayer(
+                    dropout=(sub_layer_idx / total_layers) * (1 - p_L)
+                )
+            )
+
+    def hybrid_forward(self, F, x, mask):
+        r"""Implement forward computation.
+
+        Parameters
+        -----------
+        x : NDArray
+            input tensor with shape `(batch_size, sequence_length, hidden_size)`
+        mask : NDArray
+            input tensor with shape `(batch_size, sequence_length)`
+
+        Returns
+        --------
+        x : NDArray
+            output tensor with shape `(batch_size, sequence_length, hidden_size)`
+        mask : NDArray
+            output tensor with shape `(batch_size, sequence_length)`
+        """
+        x = self.position_encoder(x)
+        for conv in self.convs:
+            residual = x
+            x = conv(x) + residual
+        residual = x
+        x = self.attention_layer_norm(x)
+        x = F.Dropout(x, p=LAYERS_DROPOUT)
+        x = self.attention(x, mask)
+        x = self.attention_dropout(x) + residual
+        return x + self.positionwise_ffn(x)
+
+
+class StochasticDropoutLayer(gluon.HybridBlock):
+    r"""
+    Stochastic dropout a layer.
+    """
+
+    def __init__(self, dropout, **kwargs):
+        super(StochasticDropoutLayer, self).__init__(**kwargs)
+        self.dropout = dropout
+        with self.name_scope():
+            self.dropout_fn = gluon.nn.Dropout(dropout)
+
+    def hybrid_forward(self, F, inputs):
+        if F.random.uniform().asscalar() < self.dropout:
+            return F.zeros(shape=(1,))
+        else:
+            return self.dropout_fn(inputs)
+
+
+class SelfAttention(gluon.HybridBlock):
+    r"""
+    Implementation of self-attention with gluonnlp.model.MultiHeadAttentionCell
+    """
+
+    def __init__(self, num_heads, **kwargs):
+        super(SelfAttention, self).__init__(**kwargs)
+        with self.name_scope():
+            self.attention = MultiHeadAttentionCell(
+                num_heads=num_heads,
+                base_cell=DotProductAttentionCell(
+                    scaled=True,
+                    dropout=LAYERS_DROPOUT,
+                    use_bias=False
+                ),
+                query_units=EMB_ENCODER_CONV_CHANNELS,
+                key_units=EMB_ENCODER_CONV_CHANNELS,
+                value_units=EMB_ENCODER_CONV_CHANNELS,
+                use_bias=False,
+                weight_initializer=Xavier()
+            )
+
+    def hybrid_forward(self, F, x, mask):
+        r"""Implement forward computation.
+
+        Parameters
+        -----------
+        x : NDArray
+            input tensor with shape `(batch_size, sequence_length, hidden_size)`
+        mask : NDArray
+            input tensor with shape `(batch_size, sequence_length)`
+
+        Returns
+        --------
+        x : NDArray
+            output tensor with shape `(batch_size, sequence_length, hidden_size)`
+        """
+        mask = F.batch_dot(mask.expand_dims(axis=2), mask.expand_dims(axis=1))
+        return self.attention(x, x, mask=mask)[0]
+
+
+class PositionEncoder(gluon.HybridBlock):
+    r"""
+    An implementation of position encoder.
+    """
+
+    def __init__(self, **kwargs):
+        super(PositionEncoder, self).__init__(**kwargs)
+        with self.name_scope():
+            pass
+
+    def hybrid_forward(self, F, x, min_timescale=1.0, max_timescale=1e4):
+        r"""Implement forward computation.
+
+        Parameters
+        -----------
+        x : NDArray
+            input tensor with shape `(batch_size, sequence_length, hidden_size)`
+
+        Returns
+        --------
+         : NDArray
+            output tensor with shape `(batch_size, sequence_length, hidden_size)`
+        """
+        length = x.shape[1]
+        channels = x.shape[2]
+        position = nd.array(range(length))
+        num_timescales = channels // 2
+        log_timescale_increment = (math.log(float(max_timescale) /
+                                            float(min_timescale)) /
+                                   (num_timescales - 1))
+        inv_timescales = min_timescale * \
+                         nd.exp(nd.array(range(num_timescales)) * -log_timescale_increment)
+        scaled_time = F.expand_dims(position, 1) * F.expand_dims(inv_timescales, 0)
+        signal = F.concat(F.sin(scaled_time), F.cos(scaled_time), dim=1)
+        signal = F.reshape(signal, (1, length, channels))
+        return x + signal.as_in_context(x.context)
+
+
+class DepthwiseConv(gluon.HybridBlock):
+    r"""
+    An implementation of depthwise-convolution net.
+    """
+
+    def __init__(self, kernel_size, num_filters, input_channels, **kwargs):
+        super(DepthwiseConv, self).__init__(**kwargs)
+        with self.name_scope():
+            self.depthwise_conv = gluon.nn.Conv1D(
+                channels=input_channels,
+                kernel_size=kernel_size,
+                padding=kernel_size // 2,
+                groups=input_channels,
+                use_bias=False,
+                weight_initializer=MSRAPrelu()
+            )
+            self.pointwise_conv = gluon.nn.Conv1D(
+                channels=num_filters,
+                kernel_size=1,
+                activation='relu',
+                use_bias=True,
+                weight_initializer=MSRAPrelu(),
+                bias_initializer='zeros'
+            )
+
+    def hybrid_forward(self, F, inputs):
+        r"""Implement forward computation.
+
+        Parameters
+        -----------
+        inputs : NDArray
+            input tensor with shape `(batch_size, sequence_length, hidden_size)`
+
+        Returns
+        --------
+        x : NDArray
+            output tensor with shape `(batch_size, sequence_length, new_hidden_size)`
+        """
+        tmp = F.transpose(inputs, axes=(0, 2, 1))
+        depthwise_conv = self.depthwise_conv(tmp)
+        outputs = self.pointwise_conv(depthwise_conv)
+        return F.transpose(outputs, axes=(0, 2, 1))
+
+
+class CoAttention(gluon.HybridBlock):
+    r"""
+    An implementation of co-attention block.
+    """
+
+    def __init__(self, **kwargs):
+        super(CoAttention, self).__init__(**kwargs)
+        with self.name_scope():
+            self.w4c = gluon.nn.Dense(
+                units=1,
+                flatten=False,
+                weight_initializer=Xavier(),
+                use_bias=False
+            )
+            self.w4q = gluon.nn.Dense(
+                units=1,
+                flatten=False,
+                weight_initializer=Xavier(),
+                use_bias=False
+            )
+            self.w4mlu = self.params.get(
+                'linear_kernel', shape=(1, 1, EMB_ENCODER_CONV_CHANNELS), init=mx.init.Xavier())
+            self.bias = self.params.get(
+                'coattention_bias', shape=(1,), init=mx.init.Zero())
+
+    def hybrid_forward(self, F, context, query, context_mask, query_mask,
+                       context_max_len, query_max_len, w4mlu, bias):
+        """Implement forward computation.
+
+        Parameters
+        -----------
+        context : NDArray
+            input tensor with shape `(batch_size, context_sequence_length, hidden_size)`
+        query : NDArray
+            input tensor with shape `(batch_size, query_sequence_length, hidden_size)`
+        context_mask : NDArray
+            input tensor with shape `(batch_size, context_sequence_length)`
+        query_mask : NDArray
+            input tensor with shape `(batch_size, query_sequence_length)`
+        context_max_len : int
+        query_max_len : int
+
+        Returns
+        --------
+        return : NDArray
+            output tensor with shape `(batch_size, context_sequence_length, 4*hidden_size)`
+        """
+        context_mask = F.expand_dims(context_mask, axis=-1)
+        query_mask = F.expand_dims(query_mask, axis=1)
+
+        similarity = self._calculate_trilinear_similarity(
+            context, query, context_max_len, query_max_len, w4mlu, bias)
+
+        similarity_dash = F.softmax(mask_logits(similarity, query_mask))
+        similarity_dash_trans = F.transpose(F.softmax(
+            mask_logits(similarity, context_mask), axis=1), axes=(0, 2, 1))
+        c2q = F.batch_dot(similarity_dash, query)
+        q2c = F.batch_dot(F.batch_dot(
+            similarity_dash, similarity_dash_trans), context)
+        return F.concat(context, c2q, context * c2q, context * q2c, dim=-1)
+
+    def _calculate_trilinear_similarity(self, context, query, context_max_len, query_max_len,
+                                        w4mlu, bias):
+        """Implement the computation of trilinear similarity function.
+
+            refer https://github.com/NLPLearn/QANet/blob/master/layers.py#L505
+
+            The similarity function is:
+                    f(w, q) = W[w, q, w * q]
+            where w and q represent the word in context and query respectively,
+            and * operator means hadamard product.
+
+        Parameters
+        -----------
+        context : NDArray
+            input tensor with shape `(batch_size, context_sequence_length, hidden_size)`
+        query : NDArray
+            input tensor with shape `(batch_size, query_sequence_length, hidden_size)`
+        context_max_len : int
+        context_max_len : int
+
+        Returns
+        --------
+        similarity_mat : NDArray
+            output tensor with shape `(batch_size, context_sequence_length, query_sequence_length)`
+        """
+
+        subres0 = nd.tile(self.w4c(context), [1, 1, query_max_len])
+        subres1 = nd.tile(nd.transpose(
+            self.w4q(query), axes=(0, 2, 1)), [1, context_max_len, 1])
+        subres2 = nd.batch_dot(w4mlu * context,
+                               nd.transpose(query, axes=(0, 2, 1)))
+        similarity_mat = subres0 + subres1 + subres2 + bias
+        return similarity_mat
+
+
+def mask_logits(x, mask):
+    r"""Implement mask logits computation.
+
+        Parameters
+        -----------
+        x : NDArray
+            input tensor with shape `(batch_size, sequence_length)`
+        mask : NDArray
+            input tensor with shape `(batch_size, sequence_length)`
+
+        Returns
+        --------
+        return : NDArray
+            output tensor with shape `(batch_size, sequence_length)`
+        """
+    return x + -1e30 * (1 - mask)

--- a/scripts/question_answering/qanet_train.py
+++ b/scripts/question_answering/qanet_train.py
@@ -1,0 +1,307 @@
+r"""
+This file contains the train code.
+"""
+import json
+import multiprocessing
+import os
+
+from mxnet import autograd, gluon, nd
+from mxnet.gluon.data import DataLoader
+from tqdm import tqdm
+
+try:
+    from data_pipeline import SQuADDataPipeline, SQuADDataLoaderTransformer
+    from qanet_config import (TRAIN_PARA_LIMIT, TRAIN_QUES_LIMIT, DEV_PARA_LIMIT, DEV_QUES_LIMIT,
+                              ANS_LIMIT, CHAR_LIMIT, GLOVE_FILE_NAME, EPOCHS,
+                              BEST_MODEL_FILE_NAME, BEST_MODEL_EMA_FILE_NAME,
+                              LAST_GLOBAL_STEP, TRAIN_FLAG, EVALUATE_INTERVAL, BETA2,
+                              NEED_LOAD_TRAINED_MODEL, TRAIN_BATCH_SIZE,
+                              ACCUM_AVG_TRAIN_CROSS_ENTROPY_PREFIX,
+                              BATCH_TRAIN_CROSS_ENTROPY_PREFIX,
+                              CTX, WEIGHT_DECAY, CLIP_GRADIENT, BETA1,
+                              INIT_LEARNING_RATE, EXPONENTIAL_MOVING_AVERAGE_DECAY, EPSILON,
+                              WARM_UP_STEPS, get_args)
+    from qanet_model import MySoftmaxCrossEntropy, QANet
+    from qanet_evaluate import evaluate
+    from ema import ExponentialMovingAverage
+    from utils import warm_up_lr, create_output_dir
+except ImportError:
+    from .data_pipeline import SQuADDataPipeline, SQuADDataLoaderTransformer
+    from .qanet_config import (TRAIN_PARA_LIMIT, TRAIN_QUES_LIMIT, DEV_PARA_LIMIT, DEV_QUES_LIMIT,
+                               ANS_LIMIT, CHAR_LIMIT, GLOVE_FILE_NAME, EPOCHS,
+                               BEST_MODEL_FILE_NAME, BEST_MODEL_EMA_FILE_NAME,
+                               LAST_GLOBAL_STEP, TRAIN_FLAG, EVALUATE_INTERVAL, BETA2,
+                               NEED_LOAD_TRAINED_MODEL, TRAIN_BATCH_SIZE,
+                               ACCUM_AVG_TRAIN_CROSS_ENTROPY_PREFIX,
+                               BATCH_TRAIN_CROSS_ENTROPY_PREFIX,
+                               CTX, WEIGHT_DECAY, CLIP_GRADIENT, BETA1,
+                               INIT_LEARNING_RATE, EXPONENTIAL_MOVING_AVERAGE_DECAY, EPSILON,
+                               WARM_UP_STEPS, get_args)
+    from .qanet_model import MySoftmaxCrossEntropy, QANet
+    from .qanet_evaluate import evaluate
+    from .ema import ExponentialMovingAverage
+    from .utils import warm_up_lr, create_output_dir
+
+accum_avg_train_ce = []
+batch_train_ce = []
+dev_f1 = []
+dev_em = []
+global_step = LAST_GLOBAL_STEP
+
+
+def train(model, train_dataloader, dev_dataloader, dev_dataset, dev_json_data, trainer,
+          loss_function, ema=None, total_batches=0, padding_token_idx=1, options=None):
+    """Start QANet training
+
+    Parameters
+    ----------
+    model : `Block`
+        Model to train
+    train_dataloader : `DataLoader`
+        Training data dataloader
+    dev_dataloader : `DataLoader`
+        Dev data dataloader
+    dev_dataset : `SQuADQADataset`
+        Dev data dataset
+    dev_json_data : `dict`
+        Original dev data JSON dict
+    trainer : `Trainer`
+        Trainer
+    loss_function : `Loss`
+        Loss function to use during training
+    ema : `ExponentialMovingAverage`
+        Exponential Moving Average to be used during evaluation
+    total_batches : int
+        Expected total batches in training dataloader. Used for displaying progress only
+    padding_token_idx : int
+        Index of the padding token
+    options : `Namespace`
+        Command arguments
+    """
+    max_dev_f1 = -1
+
+    for e in tqdm(range(EPOCHS)):
+        print('Begin %d/%d epoch...' % (e + 1, EPOCHS))
+        train_one_epoch(model, train_dataloader, dev_dataloader, dev_dataset, dev_json_data,
+                        trainer, loss_function, ema, total_batches, padding_token_idx)
+
+        f1_score, em_score = evaluate(model, dev_dataloader, dev_dataset, dev_json_data, ema,
+                                      padding_token_idx)
+        print('epoch: {}, Dev F1: {}, EM: {}'.format(e + 1, f1_score, em_score))
+        dev_f1.append([global_step, f1_score])
+        dev_em.append([global_step, em_score])
+
+        if f1_score > max_dev_f1:
+            model.save_parameters(os.path.join(options.save_dir, BEST_MODEL_FILE_NAME))
+
+            ema.get_params().save(os.path.join(options.save_dir, BEST_MODEL_EMA_FILE_NAME))
+
+        if options.save_cross_entropy:
+            ce_template = '{}_epoch_{}.json'
+
+            with open(os.path.join(options.save_dir,
+                                   ce_template.format(ACCUM_AVG_TRAIN_CROSS_ENTROPY_PREFIX, e + 1)),
+                      'w') as f:
+                f.write(json.dumps(accum_avg_train_ce))
+
+            with open(os.path.join(options.save_dir,
+                                   ce_template.format(BATCH_TRAIN_CROSS_ENTROPY_PREFIX, e + 1)),
+                      'w') as f:
+                f.write(json.dumps(batch_train_ce))
+
+
+def train_one_epoch(model, train_dataloader, dev_dataloader, dev_dataset, dev_json_data, trainer,
+                    loss_function, ema=None, total_batches=0, padding_token_idx=1):
+    """Execute one epoch of a training
+
+    Parameters
+    ----------
+    model : `Block`
+        Model to train
+    train_dataloader : `DataLoader`
+        Training data dataloader
+    dev_dataloader : `DataLoader`
+        Dev data dataloader
+    dev_dataset : `SQuADQADataset`
+        Dev data dataset
+    dev_json_data : `dict`
+        Original dev data JSON dict
+    trainer : `Trainer`
+        Trainer
+    loss_function : `Loss`
+        Loss function to use during training
+    ema : `ExponentialMovingAverage`
+        Exponential Moving Average to be used during evaluation
+    total_batches : int
+        Expected total batches in training dataloader. Used for displaying progress only
+    padding_token_idx : int
+        Index of the padding token
+    """
+    total_loss = 0
+    step = 0
+    global global_step
+    for _, context, query, context_char, query_char, begin, end in train_dataloader:
+        step += 1
+        global_step += 1
+        # add evaluate per EVALUATE_INTERVAL batches
+        if EVALUATE_INTERVAL > 0 and global_step % EVALUATE_INTERVAL == 0:
+            print('global_step == %d' % global_step)
+            print('evaluating dev dataset...')
+            f1_score, em_score = evaluate(model, dev_dataloader, dev_dataset, dev_json_data, ema,
+                                          padding_token_idx)
+            print('dev f1:' + str(f1_score) + 'em:' + str(em_score))
+            dev_f1.append([global_step, f1_score])
+            dev_em.append([global_step, em_score])
+
+        c_mask = context != padding_token_idx
+        q_mask = query != padding_token_idx
+        batch_sizes = context.shape[0]
+
+        context = gluon.utils.split_and_load(data=context, ctx_list=CTX)
+        c_mask = gluon.utils.split_and_load(data=c_mask, ctx_list=CTX)
+        query = gluon.utils.split_and_load(data=query, ctx_list=CTX)
+        q_mask = gluon.utils.split_and_load(data=q_mask, ctx_list=CTX)
+        context_char = gluon.utils.split_and_load(data=context_char, ctx_list=CTX)
+        query_char = gluon.utils.split_and_load(data=query_char, ctx_list=CTX)
+        begin = gluon.utils.split_and_load(data=begin, ctx_list=CTX)
+        end = gluon.utils.split_and_load(data=end, ctx_list=CTX)
+
+        with autograd.record():
+            different_ctx_loss = [loss_function(*model(c, q, cc, qc, cm, qm, b, e))
+                                  for c, q, cc, qc, cm, qm, b, e in
+                                  zip(context, query, context_char, query_char,
+                                      c_mask, q_mask, begin, end)]
+
+            for loss in different_ctx_loss:
+                loss.backward()
+
+        if global_step == 1:
+            ema.initialize(model.collect_params())
+
+        trainer.set_learning_rate(warm_up_lr(INIT_LEARNING_RATE, global_step, WARM_UP_STEPS))
+        trainer.allreduce_grads()
+        reset_embedding_grad(model)
+        tmp = []
+
+        for name, parameter in model.collect_params().items():
+            grad = parameter.grad(context[0].context)
+            if name == 'qanet0_embedding0_weight':
+                grad[0:1] += WEIGHT_DECAY * parameter.data(context[0].context)[0:1]
+            else:
+                grad += WEIGHT_DECAY * parameter.data(context[0].context)
+            tmp.append(grad)
+
+        gluon.utils.clip_global_norm(tmp, CLIP_GRADIENT)
+        reset_embedding_grad(model)
+        trainer.update(batch_sizes, ignore_stale_grad=True)
+
+        ema.update()
+
+        batch_loss = .0
+        for loss in different_ctx_loss:
+            batch_loss += loss.mean().asscalar()
+
+        batch_loss /= len(different_ctx_loss)
+        total_loss += batch_loss
+
+        batch_train_ce.append([global_step, batch_loss])
+        accum_avg_train_ce.append([global_step, total_loss / step])
+
+        print('batch %d/%d, total_loss %.2f, batch_loss %.2f' %
+              (step, total_batches, total_loss / step, batch_loss), end='\r', flush=True)
+        nd.waitall()
+
+
+def initial_model_parameters(model, word_embedding):
+    """Init model parameters
+
+    Parameters
+    ----------
+    model : `Block`
+        Model to initialize
+
+    word_embedding : `Embedding`
+        Embedding do be used as pretrained word embedding
+
+    Returns
+    -------
+
+    """
+    model.collect_params().initialize(ctx=CTX)
+    model.word_emb[0].weight.set_data(word_embedding)
+
+
+def reset_embedding_grad(model):
+    """Reset gradients of word embedding layer, except for UNK token.
+
+    Parameters
+    ----------
+    model : `Block`
+        Model in training
+    """
+    for ctx in CTX:
+        model.word_emb[0].weight.grad(ctx=ctx)[1:] = 0
+
+
+def main():
+    """Main function
+    """
+    args = get_args()
+    create_output_dir(args.save_dir)
+    pipeline = SQuADDataPipeline(TRAIN_PARA_LIMIT, TRAIN_QUES_LIMIT, DEV_PARA_LIMIT,
+                                 DEV_QUES_LIMIT, ANS_LIMIT, CHAR_LIMIT, GLOVE_FILE_NAME)
+    _, dev_json, train_dataset, dev_dataset, word_vocab, char_vocab = \
+        pipeline.get_processed_data(use_spacy=True, shrink_word_vocab=True)
+
+    model = QANet(len(word_vocab), len(char_vocab))
+    # initial parameters
+    print('Initial parameters...')
+    if NEED_LOAD_TRAINED_MODEL:
+        model.load_parameters(BEST_MODEL_FILE_NAME, ctx=CTX)
+    else:
+        print('Initial model parameters...')
+        initial_model_parameters(model, word_vocab.embedding.idx_to_vec)
+    print(model)
+    if TRAIN_FLAG is True:
+        loss_function = MySoftmaxCrossEntropy()
+
+        ema = ExponentialMovingAverage(decay=EXPONENTIAL_MOVING_AVERAGE_DECAY)
+
+        # initial trainer
+        trainer = gluon.Trainer(
+            model.collect_params(),
+            'adam',
+            {
+                'learning_rate': INIT_LEARNING_RATE,
+                'beta1': BETA1,
+                'beta2': BETA2,
+                'epsilon': EPSILON
+            }
+        )
+
+        train_dataloader = DataLoader(train_dataset.transform(SQuADDataLoaderTransformer()),
+                                      batch_size=TRAIN_BATCH_SIZE, shuffle=True, last_batch='keep',
+                                      num_workers=multiprocessing.cpu_count(), pin_memory=True)
+        dev_dataloader = DataLoader(dev_dataset.transform(SQuADDataLoaderTransformer()),
+                                    batch_size=TRAIN_BATCH_SIZE, shuffle=False, last_batch='keep',
+                                    num_workers=multiprocessing.cpu_count(), pin_memory=True)
+
+        # train
+        print('Train...')
+        train(model, train_dataloader, dev_dataloader, dev_dataset, dev_json, trainer,
+              loss_function, ema, total_batches=len(train_dataset) // TRAIN_BATCH_SIZE,
+              padding_token_idx=word_vocab[word_vocab.padding_token],
+              options=args)
+    else:
+        print('Evaluating dev set...')
+        dev_dataloader = DataLoader(dev_dataset.transform(SQuADDataLoaderTransformer()),
+                                    batch_size=TRAIN_BATCH_SIZE, shuffle=False, last_batch='keep',
+                                    num_workers=multiprocessing.cpu_count(), pin_memory=True)
+
+        f1_score, em_score = evaluate(model, dev_dataloader, dev_dataset, dev_json, ema=None,
+                                      padding_token_idx=word_vocab[word_vocab.padding_token])
+        print('The dev dataset F1 is:%s, and EM is: %s' % (f1_score, em_score))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/question_answering/similarity_function.py
+++ b/scripts/question_answering/similarity_function.py
@@ -1,0 +1,248 @@
+# coding: utf-8
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Collection of general purpose similarity functions"""
+
+__all__ = ['SimilarityFunction', 'DotProductSimilarity', 'CosineSimilarity',
+           'BilinearSimilarity', 'LinearSimilarity']
+
+import mxnet as mx
+from mxnet import gluon, initializer
+from mxnet.gluon import nn, Parameter
+
+
+def _get_combination(combination, tensors):
+    if combination.isdigit():
+        index = int(combination) - 1
+        return tensors[index]
+    else:
+        first_tensor = _get_combination(combination[0], tensors)
+        second_tensor = _get_combination(combination[2], tensors)
+        operation = combination[1]
+        if operation == '*':
+            return first_tensor * second_tensor
+        elif operation == '/':
+            return first_tensor / second_tensor
+        elif operation == '+':
+            return first_tensor + second_tensor
+        elif operation == '-':
+            return first_tensor - second_tensor
+        else:
+            raise NotImplementedError
+
+
+def combine_tensors(F, combination, tensors):
+    """
+    Combines a list of tensors using element-wise operations and concatenation, specified by a
+    ``combination`` string.  The string refers to (1-indexed) positions in the input tensor list,
+    and looks like ``"1,2,1+2,3-1"``.
+
+    We allow the following kinds of combinations: ``x``, ``x*y``, ``x+y``, ``x-y``, and ``x/y``,
+    where ``x`` and ``y`` are positive integers less than or equal to ``len(tensors)``.  Each of
+    the binary operations is performed elementwise.  You can give as many combinations as you want
+    in the ``combination`` string.  For example, for the input string ``"1,2,1*2"``, the result
+    would be ``[1;2;1*2]``, as you would expect, where ``[;]`` is concatenation along the last
+    dimension.
+
+    If you have a fixed, known way to combine tensors that you use in a model, you should probably
+    just use something like ``ndarray.cat([x_tensor, y_tensor, x_tensor * y_tensor])``.  This
+    function adds some complexity that is only necessary if you want the specific combination used
+    to be `configurable`.
+
+    If you want to do any element-wise operations, the tensors involved in each element-wise
+    operation must have the same shape.
+
+    This function also accepts ``x`` and ``y`` in place of ``1`` and ``2`` in the combination
+    string.
+    """
+    combination = combination.replace('x', '1').replace('y', '2')
+    to_concatenate = [_get_combination(piece, tensors) for piece in combination.split(',')]
+    return F.concat(*to_concatenate, dim=-1)
+
+
+class SimilarityFunction(gluon.HybridBlock):
+    """
+    A ``SimilarityFunction`` takes a pair of tensors with the same shape, and computes a similarity
+    function on the vectors in the last dimension.  For example, the tensors might both have shape
+    `(batch_size, sentence_length, embedding_dim)`, and we will compute some function of the two
+    vectors of length `embedding_dim` for each position `(batch_size, sentence_length)`, returning a
+    tensor of shape `(batch_size, sentence_length)`.
+
+    The similarity function could be as simple as a dot product, or it could be a more complex,
+    parameterized function.
+    """
+    default_implementation = 'dot_product'
+
+    def hybrid_forward(self, F, array_1, array_2):  # pylint: disable=arguments-differ
+        # pylint: disable=arguments-differ
+        """
+        Takes two tensors of the same shape, such as ``(batch_size, length_1, length_2,
+        embedding_dim)``.  Computes a (possibly parameterized) similarity on the final dimension
+        and returns a tensor with one less dimension, such as ``(batch_size, length_1, length_2)``.
+        """
+        raise NotImplementedError
+
+
+class DotProductSimilarity(SimilarityFunction):
+    """
+    This similarity function simply computes the dot product between each pair of vectors, with an
+    optional scaling to reduce the variance of the output elements.
+
+    Parameters
+    ----------
+    scale_output : ``bool``, optional
+        If ``True``, we will scale the output by ``F.sqrt(ndarray.shape[-1])``, to reduce the
+        variance in the result.
+    """
+    def __init__(self, scale_output=False, **kwargs):
+        super(DotProductSimilarity, self).__init__(**kwargs)
+        self._scale_output = scale_output
+
+    def hybrid_forward(self, F, array_1, array_2):
+        result = (array_1 * array_2).sum(axis=-1)
+
+        if self._scale_output:
+            result *= F.sqrt(array_1.shape[-1])
+
+        return result
+
+
+class CosineSimilarity(SimilarityFunction):
+    """
+    This similarity function simply computes the cosine similarity between each pair of vectors.
+    It has no parameters.
+    """
+
+    def hybrid_forward(self, F, array_1, array_2):
+        normalized_array_1 = F.broadcast_div(array_1, F.norm(array_1, axis=-1, keepdims=True))
+        normalized_array_2 = F.broadcast_div(array_2, F.norm(array_2, axis=-1, keepdims=True))
+        return (normalized_array_1 * normalized_array_2).sum(axis=-1)
+
+
+class BilinearSimilarity(SimilarityFunction):
+    """
+    This similarity function performs a bilinear transformation of the two input vectors.  This
+    function has a matrix of weights ``W`` and a bias ``b``, and the similarity between two vectors
+    ``x`` and ``y`` is computed as ``x^T W y + b``.
+
+    Parameters
+    ----------
+    array_1_dim : ``int``
+        The dimension of the first ndarray, ``x``, described above.  This is ``x.shape[-1]`` - the
+        length of the vector that will go into the similarity computation.  We need this so we can
+        build the weight matrix correctly.
+    array_2_dim : ``int``
+        The dimension of the second ndarray, ``y``, described above.  This is ``y.shape[-1]`` - the
+        length of the vector that will go into the similarity computation.  We need this so we can
+        build the weight matrix correctly.
+    activation : ``Activation``, optional (default=linear (i.e. no activation))
+        An activation function applied after the ``x^T W y + b`` calculation.  Default is no
+        activation.
+    """
+    def __init__(self,
+                 array_1_dim,
+                 array_2_dim,
+                 activation='linear',
+                 **kwargs):
+        super(BilinearSimilarity, self).__init__(**kwargs)
+        self._weight_matrix = Parameter(name='weight_matrix',
+                                        shape=(array_1_dim, array_2_dim), init=mx.init.Xavier())
+        self._bias = Parameter(name='bias', shape=(array_1_dim,), init=mx.init.Zero())
+
+        if activation == 'linear':
+            self._activation = None
+        else:
+            self._activation = nn.Activation(activation)
+
+    def hybrid_forward(self, F, array_1, array_2):
+        intermediate = F.broadcast_mull(array_1, self._weight_matrix)
+        result = F.broadcast_mull(intermediate, array_2).sum(axis=-1)
+
+        if not self._activation:
+            return result
+
+        return self._activation(result + self._bias)
+
+
+class LinearSimilarity(SimilarityFunction):
+    """
+    This similarity function performs a dot product between a vector of weights and some
+    combination of the two input vectors, followed by an (optional) activation function.  The
+    combination used is configurable.
+
+    If the two vectors are ``x`` and ``y``, we allow the following kinds of combinations: ``x``,
+    ``y``, ``x*y``, ``x+y``, ``x-y``, ``x/y``, where each of those binary operations is performed
+    elementwise.  You can list as many combinations as you want, comma separated.  For example, you
+    might give ``x,y,x*y`` as the ``combination`` parameter to this class.  The computed similarity
+    function would then be ``w^T [x; y; x*y] + b``, where ``w`` is a vector of weights, ``b`` is a
+    bias parameter, and ``[;]`` is vector concatenation.
+
+    Parameters
+    ----------
+    array_1_dim : ``int``
+        The dimension of the first tensor, ``x``, described above.  This is ``x.size()[-1]`` - the
+        length of the vector that will go into the similarity computation.  We need this so we can
+        build weight vectors correctly.
+    array_2_dim : ``int``
+        The dimension of the second tensor, ``y``, described above.  This is ``y.size()[-1]`` - the
+        length of the vector that will go into the similarity computation.  We need this so we can
+        build weight vectors correctly.
+    combination : ``str``, optional (default="x,y")
+        Described above.
+    activation : ``Activation``, optional (default=linear (i.e. no activation))
+        An activation function applied after the ``w^T * [x;y] + b`` calculation.  Default is no
+        activation.
+    """
+    def __init__(self,
+                 array_1_dim,
+                 array_2_dim,
+                 use_bias=False,
+                 combination='x,y',
+                 activation='linear',
+                 **kwargs):
+        super(LinearSimilarity, self).__init__(**kwargs)
+        self.combination = combination
+        self.use_bias = use_bias
+        self.array_1_dim = array_1_dim
+        self.array_2_dim = array_2_dim
+
+        if activation == 'linear':
+            self._activation = None
+        else:
+            self._activation = nn.Activation(activation)
+
+        with self.name_scope():
+            self.weight_matrix = self.params.get('weight_matrix',
+                                                 shape=(array_2_dim, array_1_dim),
+                                                 init=initializer.Uniform())
+            if use_bias:
+                self.bias = self.params.get('bias',
+                                            shape=(array_2_dim,),
+                                            init=initializer.Zero())
+
+    def hybrid_forward(self, F, array_1, array_2, weight_matrix, bias=None):
+        # pylint: disable=arguments-differ
+        combined_tensors = combine_tensors(F, self.combination, [array_1, array_2])
+        dot_product = F.FullyConnected(combined_tensors, weight_matrix, bias=bias, flatten=False,
+                                       no_bias=not self.use_bias, num_hidden=self.array_2_dim)
+
+        if not self._activation:
+            return dot_product
+
+        return self._activation(dot_product + bias)

--- a/scripts/question_answering/utils.py
+++ b/scripts/question_answering/utils.py
@@ -19,6 +19,7 @@
 
 """Various utility methods for Question Answering"""
 import math
+import os
 
 
 def warm_up_lr(base_lr, iteration, lr_warmup_steps):
@@ -45,3 +46,17 @@ def warm_up_lr(base_lr, iteration, lr_warmup_steps):
         Learning rate
     """
     return min(base_lr, base_lr * (math.log(iteration) / math.log(lr_warmup_steps)))
+
+
+def create_output_dir(path):
+    """Create directory to store execution outputs
+
+    Parameters
+    ----------
+    path : str
+        Directory path
+    """
+    path = os.path.expanduser(path)
+
+    if not os.path.isdir(path):
+        os.makedirs(path)


### PR DESCRIPTION
## Description ##
This is a PR with current results of merging BiDAF and QANet together. Unfortunately, there was something missing / wrong in the merge as I couldn't get models back to their paper-like performance. 

The best result I got:
For BiDAF F1 = 75.31 out of reported in the paper 77.3 (epoch 6 or 7)
For QANet F1 = 79.44 out of reported in the paper 84.6 (epoch 36)

To reproduce the results, just run `bidaf_train.py` or `qanet_train.py` with default configs.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] Code is well-documented