### PR TITLE
Autodoc typehints

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
+    'sphinx_autodoc_typehints',
     'sphinx.ext.mathjax',
     'sphinx_gallery.gen_gallery',
     'nbsphinx',
@@ -253,6 +254,7 @@ sphinx_gallery_conf = {
 
 # Napoleon settings
 napoleon_use_ivar = True
+napoleon_use_param = True  # Required for compatibility with sphinx-autodoc-typehints
 
 # linkcheck settings
 import multiprocessing

--- a/env/cpu/py3-master.yml
+++ b/env/cpu/py3-master.yml
@@ -6,7 +6,7 @@ dependencies:
   - perl
   - pylint=2.3.1
   - flake8
-  - sphinx=1.7.7
+  - sphinx=2.1.2
   - spacy>2
   - nltk
   - pytest=4.5.0
@@ -20,3 +20,4 @@ dependencies:
     - mxnet-mkl>=1.6.0b20190729
     - sacremoses
     - sentencepiece<0.2
+    - sphinx-autodoc-typehints==1.6.0

--- a/env/cpu/py3-master.yml
+++ b/env/cpu/py3-master.yml
@@ -20,4 +20,4 @@ dependencies:
     - mxnet-mkl>=1.6.0b20190729
     - sacremoses
     - sentencepiece<0.2
-    - sphinx-autodoc-typehints==1.6.0
+    - sphinx-autodoc-typehints==1.7.0

--- a/env/cpu/py3.yml
+++ b/env/cpu/py3.yml
@@ -6,7 +6,7 @@ dependencies:
   - perl
   - pylint=2.3.1
   - flake8
-  - sphinx=1.7.7
+  - sphinx=2.1.2
   - spacy>2
   - nltk
   - pytest=4.5.0
@@ -33,3 +33,4 @@ dependencies:
     - https://github.com/mli/mx-theme/tarball/v0.3.9
     - seaborn
     - jieba
+    - sphinx-autodoc-typehints==1.6.0

--- a/env/cpu/py3.yml
+++ b/env/cpu/py3.yml
@@ -33,4 +33,4 @@ dependencies:
     - https://github.com/mli/mx-theme/tarball/v0.3.9
     - seaborn
     - jieba
-    - sphinx-autodoc-typehints==1.6.0
+    - sphinx-autodoc-typehints==1.7.0

--- a/env/docker/py3.yml
+++ b/env/docker/py3.yml
@@ -6,7 +6,7 @@ dependencies:
   - perl
   - pylint=1.9.2
   - flake8
-  - sphinx=1.7.7
+  - sphinx=2.1.2
   - spacy>2
   - nltk
   - pytest=4.5.0

--- a/env/gpu/py3-master.yml
+++ b/env/gpu/py3-master.yml
@@ -6,7 +6,7 @@ dependencies:
   - perl
   - pylint=2.3.1
   - flake8
-  - sphinx=1.7.7
+  - sphinx=2.1.2
   - spacy>2
   - nltk
   - pytest=4.5.0
@@ -33,3 +33,4 @@ dependencies:
     - https://github.com/mli/mx-theme/tarball/v0.3.9
     - seaborn
     - jieba
+    - sphinx-autodoc-typehints==1.6.0

--- a/env/gpu/py3-master.yml
+++ b/env/gpu/py3-master.yml
@@ -33,4 +33,4 @@ dependencies:
     - https://github.com/mli/mx-theme/tarball/v0.3.9
     - seaborn
     - jieba
-    - sphinx-autodoc-typehints==1.6.0
+    - sphinx-autodoc-typehints==1.7.0

--- a/env/gpu/py3.yml
+++ b/env/gpu/py3.yml
@@ -6,7 +6,7 @@ dependencies:
   - perl
   - pylint=2.3.1
   - flake8
-  - sphinx=1.7.7
+  - sphinx=2.1.2
   - spacy>2
   - nltk
   - pytest=4.5.0
@@ -33,3 +33,4 @@ dependencies:
     - https://github.com/mli/mx-theme/tarball/v0.3.9
     - seaborn
     - jieba
+    - sphinx-autodoc-typehints==1.6.0

--- a/env/gpu/py3.yml
+++ b/env/gpu/py3.yml
@@ -33,4 +33,4 @@ dependencies:
     - https://github.com/mli/mx-theme/tarball/v0.3.9
     - seaborn
     - jieba
-    - sphinx-autodoc-typehints==1.6.0
+    - sphinx-autodoc-typehints==1.7.0

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -24,15 +24,15 @@ __all__ = ['Vocab']
 
 import collections
 import json
-import typing
 import uuid
 import warnings
+from typing import Dict, Hashable, List, Optional
 
 from mxnet import nd
 
 from .. import _constants as C
 from .. import embedding as emb
-from ..data.utils import DefaultLookupDict, Counter, count_tokens
+from ..data.utils import Counter, DefaultLookupDict, count_tokens
 
 UNK_IDX = 0
 
@@ -173,14 +173,13 @@ class Vocab:
 
     """
 
-    def __init__(self, counter: typing.Optional[Counter] = None,
-                 max_size: typing.Optional[int] = None, min_freq: int = 1,
-                 unknown_token: typing.Optional[typing.Hashable] = C.UNK_TOKEN,
-                 padding_token: typing.Optional[typing.Hashable] = C.PAD_TOKEN,
-                 bos_token: typing.Optional[typing.Hashable] = C.BOS_TOKEN,
-                 eos_token: typing.Optional[typing.Hashable] = C.EOS_TOKEN,
-                 reserved_tokens: typing.Optional[typing.List[typing.Hashable]] = None,
-                 token_to_idx: typing.Optional[typing.Dict[typing.Hashable, int]] = None, **kwargs):
+    def __init__(self, counter: Optional[Counter] = None, max_size: Optional[int] = None,
+                 min_freq: int = 1, unknown_token: Optional[Hashable] = C.UNK_TOKEN,
+                 padding_token: Optional[Hashable] = C.PAD_TOKEN,
+                 bos_token: Optional[Hashable] = C.BOS_TOKEN,
+                 eos_token: Optional[Hashable] = C.EOS_TOKEN,
+                 reserved_tokens: Optional[List[Hashable]] = None,
+                 token_to_idx: Optional[Dict[Hashable, int]] = None, **kwargs):
 
         # Sanity checks.
         assert min_freq > 0, '`min_freq` must be set to a positive value.'

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -20,21 +20,19 @@
 # pylint: disable=consider-iterating-dictionary
 
 """Vocabulary."""
-from __future__ import absolute_import
-from __future__ import print_function
-
 __all__ = ['Vocab']
 
 import collections
 import json
+import typing
 import uuid
 import warnings
 
 from mxnet import nd
 
-from ..data.utils import DefaultLookupDict, count_tokens
 from .. import _constants as C
 from .. import embedding as emb
+from ..data.utils import DefaultLookupDict, Counter, count_tokens
 
 UNK_IDX = 0
 
@@ -44,12 +42,12 @@ class Vocab:
 
     Parameters
     ----------
-    counter : Counter or None, default None
+    counter
         Counts text token frequencies in the text data. Its keys will be indexed according to
         frequency thresholds such as `max_size` and `min_freq`. Keys of `counter`,
         `unknown_token`, and values of `reserved_tokens` must be of the same hashable type.
         Examples: str, int, and tuple.
-    max_size : None or int, default None
+    max_size
         The maximum possible number of the most frequent tokens in the keys of `counter` that can be
         indexed. Note that this argument does not count any token from `reserved_tokens`. Suppose
         that there are different keys of `counter` whose frequency are the same, if indexing all of
@@ -57,25 +55,25 @@ class Vocab:
         their __cmp__() order until the frequency threshold is met. If this argument is None or
         larger than its largest possible value restricted by `counter` and `reserved_tokens`, this
         argument has no effect.
-    min_freq : int, default 1
+    min_freq
         The minimum frequency required for a token in the keys of `counter` to be indexed.
-    unknown_token : hashable object or None, default '<unk>'
+    unknown_token
         The representation for any unknown token. If `unknown_token` is not
         `None`, looking up any token that is not part of the vocabulary and
         thus considered unknown will return the index of `unknown_token`. If
         None, looking up an unknown token will result in `KeyError`.
-    padding_token : hashable object or None, default '<pad>'
+    padding_token
         The representation for the special token of padding token.
-    bos_token : hashable object or None, default '<bos>'
+    bos_token
         The representation for the special token of beginning-of-sequence token.
-    eos_token : hashable object or None, default '<eos>'
+    eos_token
         The representation for the special token of end-of-sequence token.
-    reserved_tokens : list of hashable objects or None, default None
+    reserved_tokens
         A list specifying additional tokens to be added to the vocabulary.
         `reserved_tokens` must not contain the value of `unknown_token` or
         duplicate tokens. It must neither contain special tokens specified via
         keyword arguments.
-    token_to_idx : dict mapping tokens (hashable objects) to int or None, default None
+    token_to_idx
         If not `None`, specifies the indices of tokens to be used by the
         vocabulary. Each token in `token_to_index` must be part of the Vocab
         and each index can only be associated with a single token.
@@ -175,9 +173,14 @@ class Vocab:
 
     """
 
-    def __init__(self, counter=None, max_size=None, min_freq=1, unknown_token=C.UNK_TOKEN,
-                 padding_token=C.PAD_TOKEN, bos_token=C.BOS_TOKEN, eos_token=C.EOS_TOKEN,
-                 reserved_tokens=None, token_to_idx=None, **kwargs):
+    def __init__(self, counter: typing.Optional[Counter] = None,
+                 max_size: typing.Optional[int] = None, min_freq: int = 1,
+                 unknown_token: typing.Optional[typing.Hashable] = C.UNK_TOKEN,
+                 padding_token: typing.Optional[typing.Hashable] = C.PAD_TOKEN,
+                 bos_token: typing.Optional[typing.Hashable] = C.BOS_TOKEN,
+                 eos_token: typing.Optional[typing.Hashable] = C.EOS_TOKEN,
+                 reserved_tokens: typing.Optional[typing.List[typing.Hashable]] = None,
+                 token_to_idx: typing.Optional[typing.Dict[typing.Hashable, int]] = None, **kwargs):
 
         # Sanity checks.
         assert min_freq > 0, '`min_freq` must be set to a positive value.'


### PR DESCRIPTION
## Description ##
This adds sphinx autodoc based on Python 3 typehints.

Impact: Auto-generate (missing) type annotations in the documentation based on machine-readable typehints. The auto-generated type annotations look as follows: http://gluon-nlp-staging.s3-accelerate.dualstack.amazonaws.com/PR-830/4/api/modules/vocab.html#gluonnlp.Vocab