### PR TITLE
[DOC] Fix a typo in attention_cell's docstring

### DIFF
--- a/src/gluonnlp/model/attention_cell.py
+++ b/src/gluonnlp/model/attention_cell.py
@@ -410,7 +410,7 @@ class DotProductAttentionCell(AttentionCell):
             If the units is None,
                 score = <h_q, h_k>
             Else if the units is not None and luong_style is False:
-                score = <W_q h_q, W_k, h_k>
+                score = <W_q h_q, W_k h_k>
             Else if the units is not None and luong_style is True:
                 score = <W h_q, h_k>
 


### PR DESCRIPTION
## Description ##
Remove a typo comma in `DotProductAttentionCell`'s docstring.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- Remove a typo comma in `DotProductAttentionCell`'s docstring.
