### PR TITLE
[DOC] Fix wrong documentation for BERT custom vocab

### DIFF
--- a/scripts/bert/index.rst
+++ b/scripts/bert/index.rst
@@ -162,7 +162,7 @@ You can `train <//github.com/google/sentencepiece/tree/v0.1.82/python#model-trai
 .. code-block:: python
 
     import sentencepiece as spm
-    spm.SentencePieceTrainer.Train('--input=a.txt,b.txt --unk_id=0 --pad_id=1 --model_prefix=my_vocab --vocab_size=30000 --model_type BPE')
+    spm.SentencePieceTrainer.Train('--input=a.txt,b.txt --unk_id=0 --pad_id=3 --model_prefix=my_vocab --vocab_size=30000 --model_type=BPE')
 
 To use sentencepiece vocab for pre-training, please set --sentencepiece=my_vocab.model when using run_pretraining_hvd.py.
 


### PR DESCRIPTION
## Description ##
as title. 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
