### PR TITLE
[CI] Use Cuda 10.1

### DIFF
--- a/env/gpu/py3-master.yml
+++ b/env/gpu/py3-master.yml
@@ -27,7 +27,7 @@ dependencies:
   - regex
   - pip:
     - pylint-quotes<0.2
-    - mxnet-cu92mkl>=1.5.0b20190407
+    - mxnet-cu101mkl>=1.5.0
     - sacremoses
     - sentencepiece<0.2
     - https://github.com/mli/mx-theme/tarball/v0.3.9

--- a/env/gpu/py3.yml
+++ b/env/gpu/py3.yml
@@ -27,7 +27,7 @@ dependencies:
   - regex
   - pip:
     - pylint-quotes==0.2.1
-    - mxnet-cu92mkl>=1.4.1
+    - mxnet-cu101mkl>=1.5.0
     - sacremoses
     - sentencepiece<0.2
     - https://github.com/mli/mx-theme/tarball/v0.3.9


### PR DESCRIPTION
## Description ##
Address "Upgrade advisory: this mxnet has been built against cuda library version 9020, which is older than the oldest version tested by CI (10000).  Set MXNET_CUDA_LIB_CHECKING=0 to quiet this warning" on our CI.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Use Cuda 10.1
