### PR TITLE
[DOC] Remove Py2 icon from Readme. Add 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ GluonNLP: Your Choice of Deep Learning for NLP
 
 .. raw:: html
 
-   <a href='http://ci.mxnet.io/job/gluon-nlp/job/master/'><img src='https://img.shields.io/badge/python-2.7%2C%203.6-blue.svg'></a>
+   <a href='http://ci.mxnet.io/job/gluon-nlp/job/master/'><img src='https://img.shields.io/badge/python-3.6%2C3.7-blue.svg'></a>
    <a href='https://codecov.io/gh/dmlc/gluon-nlp'><img src='https://codecov.io/gh/dmlc/gluon-nlp/branch/master/graph/badge.svg'></a>
    <a href='http://ci.mxnet.io/job/gluonnlp-py3-master-gpu-doc/job/master/'><img src='http://ci.mxnet.io/buildStatus/icon?job=gluonnlp-py3-master-gpu-doc%2Fmaster'></a>
    <a href='https://pypi.org/project/gluonnlp/#history'><img src='https://img.shields.io/pypi/v/gluonnlp.svg'></a>
@@ -43,7 +43,9 @@ News
 Installation
 ============
 
-Make sure you have Python 2.7 or Python 3.6 and recent version of MXNet.
+Make sure you have Python 3.6 or newer and a recent version of MXNet (our CI
+server runs the testsuite with Python 3.6).
+
 You can install ``MXNet`` and ``GluonNLP`` using pip.
 
 ``GluonNLP`` is based on the most recent version of ``MXNet``.


### PR DESCRIPTION
## Description ##
Remove Py2 icon from Readme. Add 3.7

## Comments ##
Our CI does not test 3.7. Code may be broken on 3.7, though it's unlikely. I use 3.7 locally and haven't experienced problems.