### PR TITLE
[BUGFIX] Remove incorrect vocab.padding_token requirement in CorpusBPTTBatchify

### DIFF
--- a/src/gluonnlp/data/batchify/language_model.py
+++ b/src/gluonnlp/data/batchify/language_model.py
@@ -105,7 +105,6 @@ class CorpusBPTTBatchify:
         self._seq_len = seq_len
         self._batch_size = batch_size
         self._last_batch = last_batch
-        self._padding_idx = vocab[vocab.padding_token]
 
         if last_batch not in ['keep', 'discard']:
             raise ValueError(
@@ -224,8 +223,7 @@ class StreamBPTTBatchify:
         self._sampler = sampler
         self._last_batch = last_batch
         if not self._vocab.padding_token:
-            raise ValueError('Padding token must be specified in vocab for BPTT.')
-        self._padding_idx = vocab[vocab.padding_token]
+            raise ValueError('Padding token must be specified in vocab for StreamBPTTBatchify.')
 
         if last_batch not in ['keep', 'discard']:
             raise ValueError(


### PR DESCRIPTION
## Description ##
Remove incorrect vocab.padding_token requirement in CorpusBPTTBatchify.

This was not noticed before as `vocab[vocab.padding_token]` only fails if `vocab.padding_token is None and vocab.unknown_token is None`. It seems all experiments so far used an `unknown_token`.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Remove incorrect vocab.padding_token requirement for last_batch='discard' in CorpusBPTTBatchify