### PR TITLE
[DOC] Fix Machine Translation with Transformers example

### DIFF
--- a/docs/examples/machine_translation/transformer.md
+++ b/docs/examples/machine_translation/transformer.md
@@ -6,6 +6,7 @@ In this notebook, we will show how to use Transformer introduced in [1] and eval
 
 We start with some usual preparation such as importing libraries and setting the environment.
 
+
 ### Load MXNet and GluonNLP
 
 ```{.python .input}

--- a/docs/examples/machine_translation/transformer.md
+++ b/docs/examples/machine_translation/transformer.md
@@ -224,7 +224,7 @@ import utils
 
 print('Translate the following English sentence into German:')
 
-sample_src_seq = 'We love language.'
+sample_src_seq = 'We love language .'
 
 print('[\'' + sample_src_seq + '\']')
 


### PR DESCRIPTION
## Description ##
`language.` is not tokenized correctly and causes mistranslation.
