### PR TITLE
fix broken multi-head attention cell

### DIFF
--- a/src/gluonnlp/model/attention_cell.py
+++ b/src/gluonnlp/model/attention_cell.py
@@ -220,7 +220,7 @@ class MultiHeadAttentionCell(AttentionCell):
             with self.name_scope():
                 setattr(
                     self, 'proj_{}'.format(name),
-                    nn.Dense(units=self._query_units, use_bias=self._use_bias, flatten=False,
+                    nn.Dense(units=unit, use_bias=self._use_bias, flatten=False,
                              weight_initializer=weight_initializer,
                              bias_initializer=bias_initializer, prefix='{}_'.format(name)))
 


### PR DESCRIPTION
## Description ##
Otherwise it will throw an error "AttributeError: 'MultiHeadAttentionCell' object has no attribute '_query_units'" while training transformer.
@eric-haibin-lin 

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
