### PR TITLE
[DOC] more detailed doc for CorpusBPTTBatchify

### DIFF
--- a/src/gluonnlp/data/batchify/language_model.py
+++ b/src/gluonnlp/data/batchify/language_model.py
@@ -129,8 +129,9 @@ class CorpusBPTTBatchify:
         mxnet.gluon.data.Dataset
             Batches of numericalized samples such that the recurrent states
             from last batch connects with the current batch for each sample.
-            Each element of the Dataset is a tuple of data and label arrays for
-            BPTT. They are of shape (seq_len, batch_size) respectively.
+            Each element of the Dataset is a tuple of size 2, specifying the 
+            data and label for BPTT respectively. Both items are of the same 
+            shape (seq_len, batch_size).
         """
         if self._last_batch == 'keep':
             coded = self._vocab[list(corpus)]


### PR DESCRIPTION
## Description ##

The document for `CorpusBPTTBatchify` does not explicitly mention the size of the tuple which could be confusing to end users. This PR updates the documentation to provide more details on the data format.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [X] Code is well-documented

### Changes ###


## Comments ##
