### PR TITLE
[BUGFIX] fix argument `analogy-max-vocab-size`

### DIFF
--- a/scripts/word_embeddings/run_all.sh
+++ b/scripts/word_embeddings/run_all.sh
@@ -22,19 +22,19 @@ set -e
 for i in glove.42B.300d glove.6B.100d glove.6B.200d glove.6B.300d glove.6B.50d glove.840B.300d glove.twitter.27B.100d glove.twitter.27B.200d glove.twitter.27B.25d glove.twitter.27B.50d
 do
     echo "Running $i"
-    python evaluate_pretrained.py --gpu 0  --embedding-name glove --embedding-source $i --logdir results --max-vocab-size 300000 --analogy-datasets GoogleAnalogyTestSet BiggerAnalogyTestSet
+    python evaluate_pretrained.py --gpu 0  --embedding-name glove --embedding-source $i --logdir results --analogy-max-vocab-size 300000 --analogy-datasets GoogleAnalogyTestSet BiggerAnalogyTestSet
 done
 
 # Fasttext
 for i in crawl-300d-2M wiki-news-300d-1M wiki-news-300d-1M-subword
 do
     echo "Running $i"
-    python evaluate_pretrained.py --gpu 0  --embedding-name fasttext --embedding-source $i --logdir results --max-vocab-size 300000 --analogy-datasets GoogleAnalogyTestSet BiggerAnalogyTestSet
+    python evaluate_pretrained.py --gpu 0  --embedding-name fasttext --embedding-source $i --logdir results --analogy-max-vocab-size 300000 --analogy-datasets GoogleAnalogyTestSet BiggerAnalogyTestSet
 done
 
 # Fasttext with subwords
 for i in wiki.en wiki.simple
 do
     echo "Running $i"
-    python evaluate_pretrained.py --gpu 0  --embedding-name fasttext --fasttext-load-ngrams --embedding-source $i --logdir results --max-vocab-size 300000 --analogy-datasets GoogleAnalogyTestSet BiggerAnalogyTestSet
+    python evaluate_pretrained.py --gpu 0  --embedding-name fasttext --fasttext-load-ngrams --embedding-source $i --logdir results --analogy-max-vocab-size 300000 --analogy-datasets GoogleAnalogyTestSet BiggerAnalogyTestSet
 done


### PR DESCRIPTION
## Description ##

Use the correct argument analog-max-vocab-size as indicated [here](https://github.com/dmlc/gluon-nlp/blob/master/scripts/word_embeddings/evaluate_pretrained.py#L66).

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###


## Comments ##

