### PR TITLE
Fix #905

### DIFF
--- a/scripts/tests/test_scripts.py
+++ b/scripts/tests/test_scripts.py
@@ -69,7 +69,8 @@ def test_glove():
 @pytest.mark.gpu
 @pytest.mark.integration
 @pytest.mark.parametrize('fasttextloadngrams', [True, False])
-def test_embedding_evaluate_pretrained(fasttextloadngrams):
+@pytest.mark.parametrize('maxvocabsize', [None, 50000])
+def test_embedding_evaluate_pretrained(fasttextloadngrams, maxvocabsize):
     cmd = [
         sys.executable, './scripts/word_embeddings/evaluate_pretrained.py',
         '--embedding-name', 'fasttext', '--embedding-source', 'wiki.simple',
@@ -79,6 +80,8 @@ def test_embedding_evaluate_pretrained(fasttextloadngrams):
     cmd += ['--analogy-datasets', 'GoogleAnalogyTestSet']
     if fasttextloadngrams:
         cmd.append('--fasttext-load-ngrams')
+    if maxvocabsize:
+        cmd += ['--analogy-max-vocab-size', str(maxvocabsize)]
 
     subprocess.check_call(cmd)
     time.sleep(5)

--- a/scripts/tests/test_scripts.py
+++ b/scripts/tests/test_scripts.py
@@ -101,11 +101,11 @@ def test_embedding_evaluate_from_path(evaluateanalogies, maxvocabsize):
         sys.executable, './scripts/word_embeddings/evaluate_pretrained.py',
         '--embedding-path', path, '--gpu', '0']
     if evaluateanalogies:
-        cmd += ['--similarity-datasets=']
+        cmd += ['--similarity-datasets']
         cmd += ['--analogy-datasets', 'GoogleAnalogyTestSet']
     else:
         cmd += ['--similarity-datasets', 'WordSim353']
-        cmd += ['--analogy-datasets=']
+        cmd += ['--analogy-datasets']
     if maxvocabsize is not None:
         cmd += ['--analogy-max-vocab-size', str(maxvocabsize)]
     subprocess.check_call(cmd)

--- a/scripts/word_embeddings/evaluate_pretrained.py
+++ b/scripts/word_embeddings/evaluate_pretrained.py
@@ -140,23 +140,25 @@ def load_embedding_from_path(args):
                     args.embedding_path)
         idx_to_token = sorted(model._token_to_idx, key=model._token_to_idx.get)
 
-        embedding = nlp.embedding.TokenEmbedding(
-            unknown_token=None, unknown_lookup=model, allow_extend=True)
-
         # Analogy task is open-vocabulary, so must keep all known words.
         # But if not evaluating analogy, no need to precompute now as all
         # words for closed vocabulary task can be obtained via the unknown
         # lookup
         if not args.analogy_datasets:
-            idx_to_token = []
-        elif args.analogy_datasets and args.analogy_max_vocab_size:
-            idx_to_token = idx_to_token[:args.analogy_max_vocab_size]
-
-        embedding['<unk>'] = mx.nd.zeros(model.weight.shape[1])
-        if idx_to_token:
+            # TODO(leezu): use shape (0, model.weight.shape[1]) once np shape
+            # is supported by TokenEmbedding
+            idx_to_token = ['<unk>']
+            idx_to_vec = mx.nd.zeros((1,  model.weight.shape[1]))
+        else:
+            if args.analogy_max_vocab_size:
+                idx_to_token = idx_to_token[:args.analogy_max_vocab_size]
             with utils.print_time('compute vectors for {} known '
                                   'words.'.format(len(idx_to_token))):
-                embedding[idx_to_token] = model[idx_to_token]
+                idx_to_vec = model[idx_to_token]
+
+        embedding = nlp.embedding.TokenEmbedding(
+            unknown_token=None, idx_to_token=idx_to_token,
+            idx_to_vec=idx_to_vec, unknown_lookup=model)
     else:
         embedding = nlp.embedding.TokenEmbedding.from_file(args.embedding_path)
 

--- a/scripts/word_embeddings/evaluate_pretrained.py
+++ b/scripts/word_embeddings/evaluate_pretrained.py
@@ -183,7 +183,8 @@ def enforce_max_size(token_embedding, size):
         token_embedding = nlp.embedding.TokenEmbedding(
             unknown_token=token_embedding.unknown_token,
             idx_to_token=token_embedding._idx_to_token[:size],
-            idx_to_vec=token_embedding._idx_to_vec[:size])
+            idx_to_vec=token_embedding._idx_to_vec[:size],
+            unknown_lookup=token_embedding.unknown_lookup)
     return token_embedding
 
 
@@ -206,6 +207,8 @@ if __name__ == '__main__':
 
     token_embedding_ = enforce_max_size(
         token_embedding_, args_.analogy_max_vocab_size)
+    if args_.fasttext_load_ngrams:
+        assert token_embedding_.unknown_lookup is not None
     known_tokens = set(token_embedding_.idx_to_token)
 
     if args_.similarity_datasets:

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -400,6 +400,8 @@ class Vocab:
             'unknown_token set.'
 
         new_vec_len = sum(embs.idx_to_vec.shape[1] for embs in embeddings)
+        # TODO(leezu): Remove once np shape is used by default
+        assert len(self), "Empty vocab not yet supported"
         new_idx_to_vec = nd.zeros(shape=(len(self), new_vec_len))
 
         col_start = 0

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -401,7 +401,7 @@ class Vocab:
 
         new_vec_len = sum(embs.idx_to_vec.shape[1] for embs in embeddings)
         # TODO(leezu): Remove once np shape is used by default
-        assert len(self), "Empty vocab not yet supported"
+        assert len(self), 'Empty vocab not yet supported'
         new_idx_to_vec = nd.zeros(shape=(len(self), new_vec_len))
 
         col_start = 0


### PR DESCRIPTION
## Description ##
`enforce_max_size` function incorrectly overwrote an internal TokenEmbedding datastructure, breaking the use of `unknown_token`'s embedding for `'<pad>'`. When this script was written, modifying TokenEmbedding's internals was required. Based on https://github.com/dmlc/gluon-nlp/pull/750 we can now use proper API to make the required changes.

In general however, `vocab = nlp.Vocab(nlp.data.count_tokens(tokens))` can be replaced with vocab = `nlp.Vocab(nlp.data.count_tokens(tokens), unknown_token=token_embedding_.unknown_token, padding_token=None, bos_token=None, eos_token=None)`. I'm opening a PR for these two changes.

Unfortunately this error slipped through the tests. I'm also extending the testcase.

Fixes #905

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix `word_embeddings/evaluate_pretrained.py` script when `--analogy-max-vocab-size` is used