### PR TITLE
[FEATURE] Padding seq length to multiple of 8 in BERT model

### DIFF
--- a/scripts/bert/pretraining_utils.py
+++ b/scripts/bert/pretraining_utils.py
@@ -241,13 +241,13 @@ class BERTDataLoaderFn(DataLoaderFn):
         self._use_avg_len = use_avg_len
         self._num_ctxes = num_ctxes
         pad_val = vocab[vocab.padding_token]
-        self._batchify_fn = Tuple(Pad(pad_val=pad_val), # input_id
-                                  Pad(pad_val=pad_val), # masked_id
-                                  Pad(pad_val=0),       # masked_position
-                                  Pad(pad_val=0),       # masked_weight
-                                  Stack(),              # next_sentence_label
-                                  Pad(pad_val=0),       # segment_id
-                                  Stack())              # valid_length
+        self._batchify_fn = Tuple(Pad(pad_val=pad_val, round_to=8), # input_id
+                                  Pad(pad_val=pad_val),             # masked_id
+                                  Pad(pad_val=0),                   # masked_position
+                                  Pad(pad_val=0),                   # masked_weight
+                                  Stack(),                          # next_sentence_label
+                                  Pad(pad_val=0, round_to=8),       # segment_id
+                                  Stack())                          # valid_length
 
     def __call__(self, dataset, sampler):
         if self._use_avg_len:

--- a/src/gluonnlp/data/batchify/batchify.py
+++ b/src/gluonnlp/data/batchify/batchify.py
@@ -176,6 +176,8 @@ class Pad:
         Whether to return the valid length in the output.
     dtype : str or numpy.dtype, default None
         The value type of the output. If it is set to None, the input data type is used.
+    round_to : int, default None
+        If specified, the padded dimension will be rounded to be multiple of this argument.
 
     Examples
     --------

--- a/src/gluonnlp/data/batchify/batchify.py
+++ b/src/gluonnlp/data/batchify/batchify.py
@@ -21,12 +21,13 @@ into batches for fast processing."""
 __all__ = ['Stack', 'Pad', 'Tuple', 'List']
 
 import warnings
+import math
 
 import numpy as np
 import mxnet as mx
 
 
-def _pad_arrs_to_max_length(arrs, pad_axis, pad_val, use_shared_mem, dtype):
+def _pad_arrs_to_max_length(arrs, pad_axis, pad_val, use_shared_mem, dtype, round_to=None):
     """Inner Implementation of the Pad batchify
 
     Parameters
@@ -51,6 +52,8 @@ def _pad_arrs_to_max_length(arrs, pad_axis, pad_val, use_shared_mem, dtype):
 
     original_length = [ele.shape[pad_axis] for ele in arrs]
     max_size = max(original_length)
+    if round_to is not None:
+        max_size = round_to * math.ceil(max_size / round_to)
 
     ret_shape = list(arrs[0].shape)
     ret_shape[pad_axis] = max_size
@@ -213,7 +216,7 @@ class Pad:
       [ 1  2 -1 -1]]]
     <NDArray 2x2x4 @cpu_shared(0)>
     """
-    def __init__(self, axis=0, pad_val=None, ret_length=False, dtype=None):
+    def __init__(self, axis=0, pad_val=None, ret_length=False, dtype=None, round_to=None):
         self._axis = axis
         assert isinstance(axis, int), 'axis must be an integer! ' \
                                       'Received axis=%s, type=%s.' % (str(axis),
@@ -222,6 +225,7 @@ class Pad:
         self._ret_length = ret_length
         self._dtype = dtype
         self._warned = False
+        self._round_to = round_to
 
         if pad_val is None:
             warnings.warn(
@@ -266,7 +270,8 @@ class Pad:
         if isinstance(data[0], (mx.nd.NDArray, np.ndarray, list)):
             padded_arr, original_length = _pad_arrs_to_max_length(data, self._axis,
                                                                   self._pad_val, True,
-                                                                  self._dtype)
+                                                                  self._dtype,
+                                                                  round_to=self._round_to)
             if self._ret_length:
                 return padded_arr, original_length
             else:

--- a/tests/unittest/batchify/test_batchify.py
+++ b/tests/unittest/batchify/test_batchify.py
@@ -15,6 +15,8 @@ def test_list():
 def test_pad():
     padded = batchify.Pad(pad_val=-1)([mx.nd.array([]), mx.nd.arange(1)]).asnumpy().flatten().tolist()
     assert padded == [-1.0, 0.0]
+    padded = batchify.Pad(pad_val=-1, round_to=2)([mx.nd.array([]), mx.nd.arange(1)]).asnumpy().flatten().tolist()
+    assert padded == [-1.0, -1.0, 0.0, -1.0]
 
 
 @pytest.mark.parametrize('odtype', [np.uint8, np.int32, np.int64,


### PR DESCRIPTION
## Description ##
This PR adds an option to Pad batchify option to round the resulting size. It is especially important in FP16 training, like BERT training, as TensorCore algorithms may only be invoked when the sequence length is a multiple of 8.

@eric-haibin-lin FYI

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented