### PR TITLE
[FEATURE] [WIP] Use softmax with length in attention cells

### DIFF
--- a/src/gluonnlp/model/attention_cell.py
+++ b/src/gluonnlp/model/attention_cell.py
@@ -29,7 +29,7 @@ from mxnet.gluon.block import HybridBlock
 from mxnet.gluon import nn
 from .block import L2Normalization
 
-def _masked_softmax(F, att_score, mask, dtype):
+def _masked_softmax(F, att_score, mask):
     """Ignore the masked elements when calculating the softmax
 
     Parameters
@@ -62,12 +62,7 @@ class AttentionCell(HybridBlock):
 
     """
     def __init__(self, prefix=None, params=None):
-        self._dtype = np.float32
         super(AttentionCell, self).__init__(prefix=prefix, params=params)
-
-    def cast(self, dtype):
-        self._dtype = dtype
-        super(AttentionCell, self).cast(dtype)
 
     def _compute_weight(self, F, query, key, mask=None):
         """Compute attention weights based on the query and the keys
@@ -356,7 +351,7 @@ class MLPAttentionCell(AttentionCell):
                                    F.expand_dims(mapped_key, axis=1))
         mid_feat = self._act(mid_feat)
         att_score = self._attention_score(mid_feat).reshape(shape=(0, 0, 0))
-        att_weights = self._dropout_layer(_masked_softmax(F, att_score, mask, self._dtype))
+        att_weights = self._dropout_layer(_masked_softmax(F, att_score, mask))
         return att_weights
 
 
@@ -463,5 +458,5 @@ class DotProductAttentionCell(AttentionCell):
 
         att_score = F.batch_dot(query, key, transpose_b=True)
 
-        att_weights = self._dropout_layer(_masked_softmax(F, att_score, mask, self._dtype))
+        att_weights = self._dropout_layer(_masked_softmax(F, att_score, mask))
         return att_weights

--- a/src/gluonnlp/model/attention_cell.py
+++ b/src/gluonnlp/model/attention_cell.py
@@ -23,7 +23,6 @@ from __future__ import print_function
 __all__ = ['AttentionCell', 'MultiHeadAttentionCell', 'MLPAttentionCell', 'DotProductAttentionCell']
 
 import math
-import numpy as np
 import mxnet as mx
 from mxnet.gluon.block import HybridBlock
 from mxnet.gluon import nn

--- a/src/gluonnlp/model/transformer.py
+++ b/src/gluonnlp/model/transformer.py
@@ -1025,12 +1025,12 @@ class TransformerDecoder(HybridBlock, Seq2SeqDecoder):
         """
         batch_size = inputs.shape[0]
         length = inputs.shape[1]
-        mask = mx.nd.arange(1, length+1, ctx=inputs.context, dtype=inputs.dtype)
+        valid_length_cast = mx.nd.cast(valid_length, dtype='int32')
+        arange = mx.nd.arange(1, length+1, ctx=inputs.context, dtype='int32')
         if valid_length is not None:
-            mask = mx.nd.broadcast_lesser_equal(mask.reshape(1, -1),
-                                                valid_length.reshape(-1, 1))
-            mask = mask * mx.nd.broadcast_minimum(mask.reshape(1, -1),
-                                                  valid_length.reshape(-1, 1))
+            mask = mx.nd.broadcast_lesser_equal(arange.reshape(1, -1),
+                                                valid_length_cast.reshape(-1, 1))
+            mask = mask * arange.reshape(1, -1)
         else:
             mask = mx.nd.broadcast_axes(mx.nd.expand_dims(mask, axis=0), axis=0, size=batch_size)
         states = [None] + states
@@ -1099,7 +1099,7 @@ class TransformerDecoder(HybridBlock, Seq2SeqDecoder):
             states[-1] = augmented_mem_mask
         if mask is None:
             mask = mx.nd.arange(1, step_input.shape[1]+1, ctx=step_input.context,
-                                dtype=step_input.dtype)
+                                dtype='int32')
             mask = mx.nd.broadcast_axes(mx.nd.expand_dims(mask, axis=0),
                                         axis=0, size=step_input.shape[0])
         steps = mx.nd.arange(step_input.shape[1], ctx=step_input.context)

--- a/src/gluonnlp/model/transformer.py
+++ b/src/gluonnlp/model/transformer.py
@@ -989,10 +989,7 @@ class TransformerDecoder(HybridBlock, Seq2SeqDecoder):
         """
         mem_value = encoder_outputs
         decoder_states = [mem_value]
-        mem_length = mem_value.shape[1]
         if encoder_valid_length is not None:
-            dtype = encoder_valid_length.dtype
-            ctx = encoder_valid_length.context
             mem_masks = mx.nd.cast(encoder_valid_length, dtype='int32')
             decoder_states.append(mem_masks)
         self._encoder_valid_length = encoder_valid_length


### PR DESCRIPTION
## Description ##
MXNet added support for softmax with length parameter (https://github.com/apache/incubator-mxnet/pull/15169) and this PR attempts to use it in attention cells. Work done by me and @blchu.

@eric-haibin-lin Could you help in making sure this works for all models (we tested just BERT and Transformer decoder)?

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented