### PR TITLE
[DOC] Enhance error message when vocab is not found

### DIFF
--- a/src/gluonnlp/data/utils.py
+++ b/src/gluonnlp/data/utils.py
@@ -277,7 +277,10 @@ def train_valid_split(dataset, valid_ratio=0.05):
 
 def short_hash(name):
     if name not in _vocab_sha1:
-        raise ValueError('Vocabulary for {name} is not available.'.format(name=name))
+        vocabs = list(_vocab_sha1.keys())
+        raise ValueError('Vocabulary for {name} is not available. '
+                         'Hosted vocabularies include: {vocabs}'.format(name=name,
+                                                                        vocabs=vocabs))
     return _vocab_sha1[name][:8]
 
 


### PR DESCRIPTION
## Description ##
Sometimes users have typos in their `dataset_name` argument for `model.get_model`. Report existing vocabularies when a vocab is not found. 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
