### PR TITLE
[DEV] python version check at package import 

### DIFF
--- a/src/gluonnlp/_pyversion.py
+++ b/src/gluonnlp/_pyversion.py
@@ -16,31 +16,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Python version check"""
 
-# pylint: disable=wildcard-import
-"""NLP toolkit."""
+import sys
 
-from . import _pyversion
-from . import loss
-from . import data
-from . import embedding
-from . import model
-from . import metric
-from . import utils
-from . import vocab
-from . import optimizer
-from . import initializer
-from .vocab import Vocab
-
-__version__ = '0.8.0.dev'
-
-__all__ = ['data',
-           'model',
-           'embedding',
-           'Vocab',
-           'vocab',
-           'loss',
-           'initializer',
-           'optimizer',
-           'utils',
-           'metric']
+if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 5):
+    PY3STATEMENT = """GluonNLP project proudly dropped support of Python2.
+    The minimal Python requirement is Python 3.5
+    """
+    raise Exception(PY3STATEMENT)

--- a/src/gluonnlp/_pyversion.py
+++ b/src/gluonnlp/_pyversion.py
@@ -22,5 +22,7 @@ import sys
 
 if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 6):
     PY3STATEMENT = 'GluonNLP project proudly dropped support of Python2.' \
-                   'The minimal Python requirement is Python 3.6'
+                   'The minimal Python requirement is Python 3.6' \
+                   'The last version that supports Python2 is v0.7.1 ' \
+                   '(pip install gluonnlp==0.7.1).'
     raise Exception(PY3STATEMENT)

--- a/src/gluonnlp/_pyversion.py
+++ b/src/gluonnlp/_pyversion.py
@@ -21,7 +21,6 @@
 import sys
 
 if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 6):
-    PY3STATEMENT = """GluonNLP project proudly dropped support of Python2.
-    The minimal Python requirement is Python 3.6
-    """
+    PY3STATEMENT = 'GluonNLP project proudly dropped support of Python2.' \
+                   'The minimal Python requirement is Python 3.6'
     raise Exception(PY3STATEMENT)

--- a/src/gluonnlp/_pyversion.py
+++ b/src/gluonnlp/_pyversion.py
@@ -20,8 +20,8 @@
 
 import sys
 
-if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 5):
+if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 6):
     PY3STATEMENT = """GluonNLP project proudly dropped support of Python2.
-    The minimal Python requirement is Python 3.5
+    The minimal Python requirement is Python 3.6
     """
     raise Exception(PY3STATEMENT)

--- a/src/gluonnlp/_pyversion.py
+++ b/src/gluonnlp/_pyversion.py
@@ -21,8 +21,8 @@
 import sys
 
 if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 6):
-    PY3STATEMENT = 'GluonNLP project proudly dropped support of Python2.' \
-                   'The minimal Python requirement is Python 3.6' \
+    PY3STATEMENT = 'GluonNLP project proudly dropped support of Python2. ' \
+                   'The minimal Python requirement is Python 3.6. ' \
                    'The last version that supports Python2 is v0.7.1 ' \
                    '(pip install gluonnlp==0.7.1).'
     raise Exception(PY3STATEMENT)


### PR DESCRIPTION
## Description ##
Throw an exception instead of the following:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/haibilin/Library/Python/2.7/lib/python/site-packages/gluonnlp/__init__.py", line 24, in <module>
    from . import data
  File "/Users/haibilin/Library/Python/2.7/lib/python/site-packages/gluonnlp/data/__init__.py", line 23, in <module>
    from . import (batchify, candidate_sampler, conll, corpora, dataloader,
  File "/Users/haibilin/Library/Python/2.7/lib/python/site-packages/gluonnlp/data/corpora/__init__.py", line 23, in <module>
    from . import (google_billion_word, large_text_compression_benchmark, wikitext)
  File "/Users/haibilin/Library/Python/2.7/lib/python/site-packages/gluonnlp/data/corpora/google_billion_word.py", line 35, in <module>
    from ...vocab import Vocab
  File "/Users/haibilin/Library/Python/2.7/lib/python/site-packages/gluonnlp/vocab/__init__.py", line 23, in <module>
    from . import subwords, vocab, bert
  File "/Users/haibilin/Library/Python/2.7/lib/python/site-packages/gluonnlp/vocab/vocab.py", line 176
    def __init__(self, counter: Optional[Counter] = None, max_size: Optional[int] = None,
                              ^
SyntaxError: invalid syntax
```

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
