### PR TITLE
[DOC] fix math formula in docs

### DIFF
--- a/src/gluonnlp/model/lstmpcellwithclip.py
+++ b/src/gluonnlp/model/lstmpcellwithclip.py
@@ -28,19 +28,20 @@ class LSTMPCellWithClip(LSTMPCell):
 
     .. math::
 
+        \DeclareMathOperator{\sigmoid}{sigmoid}
         \begin{array}{ll}
-        i_t = sigmoid(W_{ii} x_t + b_{ii} + W_{ri} r_{(t-1)} + b_{ri}) \\
-        f_t = sigmoid(W_{if} x_t + b_{if} + W_{rf} r_{(t-1)} + b_{rf}) \\
+        i_t = \sigmoid(W_{ii} x_t + b_{ii} + W_{ri} r_{(t-1)} + b_{ri}) \\
+        f_t = \sigmoid(W_{if} x_t + b_{if} + W_{rf} r_{(t-1)} + b_{rf}) \\
         g_t = \tanh(W_{ig} x_t + b_{ig} + W_{rc} r_{(t-1)} + b_{rg}) \\
-        o_t = sigmoid(W_{io} x_t + b_{io} + W_{ro} r_{(t-1)} + b_{ro}) \\
-        c_t = c_{clip}(f_t * c_{(t-1)} + i_t * g_t) \\
+        o_t = \sigmoid(W_{io} x_t + b_{io} + W_{ro} r_{(t-1)} + b_{ro}) \\
+        c_t = c_{\text{clip}}(f_t * c_{(t-1)} + i_t * g_t) \\
         h_t = o_t * \tanh(c_t) \\
-        r_t = p_{clip}(W_{hr} h_t)
+        r_t = p_{\text{clip}}(W_{hr} h_t)
         \end{array}
 
-    where :math:`c_{clip}` is the cell clip applied on the next cell;
+    where :math:`c_{\text{clip}}` is the cell clip applied on the next cell;
     :math:`r_t` is the projected recurrent activation at time `t`,
-    :math:`p_{clip}` means apply projection clip on he projected output.
+    :math:`p_{\text{clip}}` means apply projection clip on he projected output.
     math:`h_t` is the hidden state at time `t`, :math:`c_t` is the
     cell state at time `t`, :math:`x_t` is the input at time `t`, and :math:`i_t`,
     :math:`f_t`, :math:`g_t`, :math:`o_t` are the input, forget, cell, and
@@ -74,9 +75,9 @@ class LSTMPCellWithClip(LSTMPCell):
         Container for weight sharing between cells.
         Created if `None`.
     cell_clip : float
-        Clip cell state between [-cellclip, cell_clip] in LSTMPCellWithClip cell
+        Clip cell state between `[-cell_clip, cell_clip]` in LSTMPCellWithClip cell
     projection_clip : float
-        Clip projection between [-projection_clip, projection_clip] in LSTMPCellWithClip cell
+        Clip projection between `[-projection_clip, projection_clip]` in LSTMPCellWithClip cell
     """
     def __init__(self, hidden_size, projection_size,
                  i2h_weight_initializer=None, h2h_weight_initializer=None,

--- a/src/gluonnlp/model/lstmpcellwithclip.py
+++ b/src/gluonnlp/model/lstmpcellwithclip.py
@@ -28,15 +28,16 @@ class LSTMPCellWithClip(LSTMPCell):
 
     .. math::
 
-    \begin{array}{ll}
-    i_t = sigmoid(W_{ii} x_t + b_{ii} + W_{ri} r_{(t-1)} + b_{ri}) \\
-    f_t = sigmoid(W_{if} x_t + b_{if} + W_{rf} r_{(t-1)} + b_{rf}) \\
-    g_t = \tanh(W_{ig} x_t + b_{ig} + W_{rc} r_{(t-1)} + b_{rg}) \\
-    o_t = sigmoid(W_{io} x_t + b_{io} + W_{ro} r_{(t-1)} + b_{ro}) \\
-    c_t = c_clip(f_t * c_{(t-1)} + i_t * g_t) \\
-    h_t = o_t * \tanh(c_t) \\
-    r_t = p_clip(W_{hr} h_t)
-    \end{array}
+        \begin{array}{ll}
+        i_t = sigmoid(W_{ii} x_t + b_{ii} + W_{ri} r_{(t-1)} + b_{ri}) \\
+        f_t = sigmoid(W_{if} x_t + b_{if} + W_{rf} r_{(t-1)} + b_{rf}) \\
+        g_t = \tanh(W_{ig} x_t + b_{ig} + W_{rc} r_{(t-1)} + b_{rg}) \\
+        o_t = sigmoid(W_{io} x_t + b_{io} + W_{ro} r_{(t-1)} + b_{ro}) \\
+        c_t = c_clip(f_t * c_{(t-1)} + i_t * g_t) \\
+        h_t = o_t * \tanh(c_t) \\
+        r_t = p_clip(W_{hr} h_t)
+        \end{array}
+
     where :math:`c_clip` is the cell clip applied on the next cell;
     :math:`r_t` is the projected recurrent activation at time `t`,
     :math:`p_clip` means apply projection clip on he projected output.

--- a/src/gluonnlp/model/lstmpcellwithclip.py
+++ b/src/gluonnlp/model/lstmpcellwithclip.py
@@ -33,14 +33,14 @@ class LSTMPCellWithClip(LSTMPCell):
         f_t = sigmoid(W_{if} x_t + b_{if} + W_{rf} r_{(t-1)} + b_{rf}) \\
         g_t = \tanh(W_{ig} x_t + b_{ig} + W_{rc} r_{(t-1)} + b_{rg}) \\
         o_t = sigmoid(W_{io} x_t + b_{io} + W_{ro} r_{(t-1)} + b_{ro}) \\
-        c_t = c_clip(f_t * c_{(t-1)} + i_t * g_t) \\
+        c_t = c_{clip}(f_t * c_{(t-1)} + i_t * g_t) \\
         h_t = o_t * \tanh(c_t) \\
-        r_t = p_clip(W_{hr} h_t)
+        r_t = p_{clip}(W_{hr} h_t)
         \end{array}
 
-    where :math:`c_clip` is the cell clip applied on the next cell;
+    where :math:`c_{clip}` is the cell clip applied on the next cell;
     :math:`r_t` is the projected recurrent activation at time `t`,
-    :math:`p_clip` means apply projection clip on he projected output.
+    :math:`p_{clip}` means apply projection clip on he projected output.
     math:`h_t` is the hidden state at time `t`, :math:`c_t` is the
     cell state at time `t`, :math:`x_t` is the input at time `t`, and :math:`i_t`,
     :math:`f_t`, :math:`g_t`, :math:`o_t` are the input, forget, cell, and

--- a/src/gluonnlp/model/lstmpcellwithclip.py
+++ b/src/gluonnlp/model/lstmpcellwithclip.py
@@ -31,7 +31,7 @@ class LSTMPCellWithClip(LSTMPCell):
     \begin{array}{ll}
     i_t = sigmoid(W_{ii} x_t + b_{ii} + W_{ri} r_{(t-1)} + b_{ri}) \\
     f_t = sigmoid(W_{if} x_t + b_{if} + W_{rf} r_{(t-1)} + b_{rf}) \\
-    g_t = \tanh(W_{ig} x_t + b_{ig} + W_{rc} r_{(t-1)} + b_{rg}}) \\
+    g_t = \tanh(W_{ig} x_t + b_{ig} + W_{rc} r_{(t-1)} + b_{rg}) \\
     o_t = sigmoid(W_{io} x_t + b_{io} + W_{ro} r_{(t-1)} + b_{ro}) \\
     c_t = c_clip(f_t * c_{(t-1)} + i_t * g_t) \\
     h_t = o_t * \tanh(c_t) \\


### PR DESCRIPTION
## Description ##

Fix the math formula in docs for `gluonnlp.model.LSTMPCellWithClip`. There is an extra `}` that caused formula not displaying as expected. Attached with documentation website screenshot to show the problem.

<img width="862" alt="before" src="https://user-images.githubusercontent.com/3293332/64462789-7eb61c00-d0b6-11e9-94c2-02b7ce2c2e34.png">


## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
