### PR TITLE
[COMMUNITY] adjust code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,4 +9,4 @@
 
 
 # Global owners
-*			@szha
+*			@dmlc/gluon-nlp-team


### PR DESCRIPTION
## Description ##
This PR updates the CODEOWNER file to include the @dmlc/gluon-nlp-team as the default reviewer of all files. This team consists of two child teams, @dmlc/gluon-nlp-committers and @dmlc/gluon-nlp-reviewers.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] update CODEOWNERS

## Comments ##
- This change affects the committers and reviewers of the GluonNLP project. If you have suggestions on how you'd like to engage in the code merging process, feel free to comment.
- Along with the change, we are reducing the required review count from 2 to 1, since GluonNLP now has a solid foundation and comprehensive coverage, which can enable us to move faster. 
