### PR TITLE
Declare Python version requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     # Metadata
     name='gluonnlp',
     version=VERSION,
+    python_requires='>=3.6',
     author='Gluon NLP Toolkit Contributors',
     author_email='mxnet-gluon@amazon.com',
     url='https://github.com/dmlc/gluon-nlp',


### PR DESCRIPTION
## Description ##
This PR implements "fail early at install time" principle to make sure user's don't install GluonNLP with an unsupported version of Python. As of version 9.0.1 pip will honour the `python_requires` string.

https://github.com/dmlc/gluon-nlp/pull/918 adds a runtime exception if GluonNLP is loaded with unsupported Python version.

https://python3statement.org/practicalities/

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [X] Declare python version requirement with `python_requires` in setup.py