### PR TITLE
[BUGFIX] Corrected np.random.randint upper limit in data.stream.py

### DIFF
--- a/src/gluonnlp/data/stream.py
+++ b/src/gluonnlp/data/stream.py
@@ -377,8 +377,8 @@ class PrefetchingStream(DataStream):
 
     def __iter__(self):
         seed = random.getrandbits(32)
-        np_seed = np.random.randint(0, 2**32)
-        mx_seed = int(mx.nd.random.uniform(0, 2**32).asscalar())
+        np_seed = np.random.randint(0, np.iinfo(np.int_).max)
+        mx_seed = int(mx.nd.random.uniform(0, np.iinfo(np.int_).max).asscalar())
         if self._multiprocessing:
             return _ProcessPrefetcher(self._stream, self._num_prefetch,
                                       seed=seed, np_seed=np_seed,

--- a/src/gluonnlp/data/stream.py
+++ b/src/gluonnlp/data/stream.py
@@ -377,8 +377,9 @@ class PrefetchingStream(DataStream):
 
     def __iter__(self):
         seed = random.getrandbits(32)
-        np_seed = np.random.randint(0, np.iinfo(np.int_).max)
-        mx_seed = int(mx.nd.random.uniform(0, np.iinfo(np.int_).max).asscalar())
+        # TODO should be possible to change to 64 bit in MXNet 1.6 (uses int64 by default?)
+        np_seed = np.random.randint(0, np.iinfo(np.int32).max)
+        mx_seed = int(mx.nd.random.uniform(0, np.iinfo(np.int32).max).asscalar())
         if self._multiprocessing:
             return _ProcessPrefetcher(self._stream, self._num_prefetch,
                                       seed=seed, np_seed=np_seed,


### PR DESCRIPTION
## Description ##
Since default np.int_  is int32 for Windows, an upper limit for random seed of 2**32 rises a `ValueError: high is out of bounds for int32`.
with `np.iinfo(np.int_).max`, np.random.randint is platform-independent

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- very small fix to allow Windows users to use module (otherwise random seed is bugged)

cc @dmlc/gluon-nlp-team
