### PR TITLE
[DOC] Add missing docs for nlp.utils

### DIFF
--- a/docs/api/modules/index.rst
+++ b/docs/api/modules/index.rst
@@ -13,3 +13,4 @@ Package Reference
    loss
    initializer
    optimizer
+   utils

--- a/docs/api/modules/utils.rst
+++ b/docs/api/modules/utils.rst
@@ -1,5 +1,5 @@
 gluonnlp.utils
-=============
+==============
 
 GluonNLP Toolkit provides tools for easily setting up task specific loss.
 

--- a/docs/api/modules/utils.rst
+++ b/docs/api/modules/utils.rst
@@ -1,0 +1,45 @@
+gluonnlp.utils
+=============
+
+GluonNLP Toolkit provides tools for easily setting up task specific loss.
+
+.. currentmodule:: gluonnlp.utils
+
+
+File Handling
+-------------
+
+.. autosummary::
+    :nosignatures:
+
+    glob
+    mkdir
+
+
+Parameter and Training
+----------------------
+
+.. autosummary::
+    :nosignatures:
+
+    clip_grad_global_norm
+
+
+Serialization and Deserialization
+---------------------------------
+
+.. autosummary::
+    :nosignatures:
+
+    load_parameters
+    load_states
+    save_parameters
+    save_states
+
+
+API Reference
+-------------
+
+.. automodule:: gluonnlp.utils
+   :members:
+   :imported-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -211,7 +211,7 @@ htmlhelp_basename = project + 'doc'
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/{.major}'.format(sys.version_info), None),
-    'mxnet': ('https://mxnet.apache.org/', None),
+    'mxnet': ('https://beta.mxnet.io/', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('http://matplotlib.org/', None),


### PR DESCRIPTION
## Description ##
The website API doc does not include nlp.utils APIs. 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
