### PR TITLE
[Tests] Declare pytest seed marker in pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    seed: set the python, numpy and mxnet random seeds to a specified value for test reproducibility
     serial: mark a test that requires more resources to run that are thus only suitable for serial run.
     remote_required: mark a test that requires internet access.
     gpu: mark a test that requires GPU.


### PR DESCRIPTION
## Description ##
Pytest raises warnings for undeclared markers.

     pytest.warning_types.PytestUnknownMarkWarning: Unknown pytest.mark.seed - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

Warnings are treated as errors when running with `pytest -Werror`

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Declare pytest seed marker in pytest.ini

cc @dmlc/gluon-nlp-team