### PR TITLE
[DEV] Deprecate specifying Vocab padding, bos and eos_token as positional arguments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,8 @@ setup(
             'recommonmark',
             'sphinx-gallery',
             'sphinx_rtd_theme',
+            'mxtheme',
+            'sphinx-autodoc-typehints',
             'nbsphinx',
             'flaky',
         ],

--- a/src/gluonnlp/__init__.py
+++ b/src/gluonnlp/__init__.py
@@ -19,7 +19,6 @@
 """NLP toolkit."""
 
 import warnings
-warnings.filterwarnings(module='gluonnlp', action='default', category=DeprecationWarning)
 
 from . import loss
 from . import data
@@ -44,3 +43,5 @@ __all__ = ['data',
            'optimizer',
            'utils',
            'metric']
+
+warnings.filterwarnings(module='gluonnlp', action='default', category=DeprecationWarning)

--- a/src/gluonnlp/__init__.py
+++ b/src/gluonnlp/__init__.py
@@ -18,6 +18,9 @@
 # pylint: disable=wildcard-import
 """NLP toolkit."""
 
+import warnings
+warnings.filterwarnings(module='gluonnlp', action='default', category=DeprecationWarning)
+
 from . import loss
 from . import data
 from . import embedding

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -212,8 +212,8 @@ class Vocab:
         for depr_pos_arg, name, indicator, value in combs:
             if depr_pos_arg != indicator:
                 warnings.warn(
-                    'Specifying `{n}` as positional argument is deprecated and support will be removed. '
-                    'Please specify `{n}` as keyword argument instead, '
+                    'Specifying `{n}` as positional argument is deprecated and '
+                    'support will be removed. Please specify `{n}` as keyword argument instead, '
                     'for example `Vocab(counter, {n}={v})`'.format(n=name, v=depr_pos_arg),
                     DeprecationWarning)
                 # Store positional argument value in kwargs

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -90,26 +90,20 @@ class Vocab:
     Deprecated Parameters
     ---------------------
     deprecated_padding_token
-        The representation for the special token of padding token.
-        Default: '<pad>'
-        .. deprecated:: 0.9
-            Specifying padding_token as positional argument is deprecated and
-            support will be removed. Specify it as keyword argument instead
-            (see documentation of **kwargs above)
+        The representation for the special token of padding token. Default:
+        '<pad>'. Specifying padding_token as positional argument is deprecated
+        and support will be removed. Specify it as keyword argument instead
+        (see documentation of **kwargs above)
     deprecated_bos_token
-        The representation for the special token of beginning-of-sequence token.
-        Default: '<bos>'
-        .. deprecated:: 0.9
-            Specifying bos_token as positional argument is deprecated and
-            support will be removed. Specify it as keyword argument instead
-            (see documentation of **kwargs above)
+        The representation for the special token of beginning-of-sequence
+        token. Default: '<bos>'. Specifying bos_token as positional argument is
+        deprecated and support will be removed. Specify it as keyword argument
+        instead (see documentation of **kwargs above)
     deprecated_eos_token
         The representation for the special token of end-of-sequence token.
-        Default: '<eos>'
-        .. deprecated:: 0.9
-            Specifying eos_token as positional argument is deprecated and
-            support will be removed. Specify it as keyword argument instead
-            (see documentation of **kwargs above)
+        Default: '<eos>'. Specifying eos_token as positional argument is
+        deprecated and support will be removed. Specify it as keyword argument
+        instead (see documentation of **kwargs above)
 
     Attributes
     ----------

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -16,7 +16,6 @@
 # under the License.
 
 # pylint: disable=consider-iterating-dictionary
-
 """Vocabulary."""
 __all__ = ['Vocab']
 
@@ -33,6 +32,9 @@ from .. import embedding as emb
 from ..data.utils import Counter, DefaultLookupDict, count_tokens
 
 UNK_IDX = 0
+_DEPR_PAD = object()
+_DEPR_BOS = object()
+_DEPR_EOS = object()
 
 
 class Vocab:
@@ -60,12 +62,6 @@ class Vocab:
         `None`, looking up any token that is not part of the vocabulary and
         thus considered unknown will return the index of `unknown_token`. If
         None, looking up an unknown token will result in `KeyError`.
-    padding_token
-        The representation for the special token of padding token.
-    bos_token
-        The representation for the special token of beginning-of-sequence token.
-    eos_token
-        The representation for the special token of end-of-sequence token.
     reserved_tokens
         A list specifying additional tokens to be added to the vocabulary.
         `reserved_tokens` must not contain the value of `unknown_token` or
@@ -90,6 +86,30 @@ class Vocab:
         just as if it was listed in the `reserved_tokens` argument. The
         specified tokens are listed together with reserved tokens in the
         `reserved_tokens` attribute of the vocabulary object.
+
+    Deprecated Parameters
+    ---------------------
+    deprecated_padding_token
+        The representation for the special token of padding token.
+        Default: '<pad>'
+        .. deprecated:: 0.9
+            Specifying padding_token as positional argument is deprecated and
+            support will be removed. Specify it as keyword argument instead
+            (see documentation of **kwargs above)
+    deprecated_bos_token
+        The representation for the special token of beginning-of-sequence token.
+        Default: '<bos>'
+        .. deprecated:: 0.9
+            Specifying bos_token as positional argument is deprecated and
+            support will be removed. Specify it as keyword argument instead
+            (see documentation of **kwargs above)
+    deprecated_eos_token
+        The representation for the special token of end-of-sequence token.
+        Default: '<eos>'
+        .. deprecated:: 0.9
+            Specifying eos_token as positional argument is deprecated and
+            support will be removed. Specify it as keyword argument instead
+            (see documentation of **kwargs above)
 
     Attributes
     ----------
@@ -173,14 +193,33 @@ class Vocab:
 
     def __init__(self, counter: Optional[Counter] = None, max_size: Optional[int] = None,
                  min_freq: int = 1, unknown_token: Optional[Hashable] = C.UNK_TOKEN,
+                 deprecated_padding_token: Optional[Hashable] = _DEPR_PAD,
+                 deprecated_bos_token: Optional[Hashable] = _DEPR_BOS,
+                 deprecated_eos_token: Optional[Hashable] = _DEPR_EOS,
+                 reserved_tokens: Optional[List[Hashable]] = None,
+                 token_to_idx: Optional[Dict[Hashable, int]] = None, *,
                  padding_token: Optional[Hashable] = C.PAD_TOKEN,
                  bos_token: Optional[Hashable] = C.BOS_TOKEN,
-                 eos_token: Optional[Hashable] = C.EOS_TOKEN,
-                 reserved_tokens: Optional[List[Hashable]] = None,
-                 token_to_idx: Optional[Dict[Hashable, int]] = None, **kwargs):
+                 eos_token: Optional[Hashable] = C.EOS_TOKEN, **kwargs):
 
         # Sanity checks.
         assert min_freq > 0, '`min_freq` must be set to a positive value.'
+
+        # Deprecation checks and warnings
+        combs = ((deprecated_padding_token, 'padding_token', _DEPR_PAD, padding_token),
+                 (deprecated_bos_token, 'bos_token', _DEPR_BOS, bos_token),
+                 (deprecated_eos_token, 'eos_token', _DEPR_EOS, eos_token))
+        for depr_pos_arg, name, indicator, value in combs:
+            if depr_pos_arg != indicator:
+                warnings.warn(
+                    'Specifying `{n}` as positional argument is deprecated and support will be removed. '
+                    'Please specify `{n}` as keyword argument instead, '
+                    'for example `Vocab(counter, {n}={v})`'.format(n=name, v=depr_pos_arg),
+                    DeprecationWarning)
+                # Store positional argument value in kwargs
+                kwargs[name] = depr_pos_arg
+            elif name not in kwargs:  # Store keyword argument value in kwargs
+                kwargs[name] = value
 
         # Set up idx_to_token and token_to_idx based on presence of unknown token
         self._unknown_token = unknown_token
@@ -189,10 +228,6 @@ class Vocab:
             self._token_to_idx = DefaultLookupDict(UNK_IDX)
         else:
             self._token_to_idx = {}
-
-        kwargs['padding_token'] = padding_token
-        kwargs['bos_token'] = bos_token
-        kwargs['eos_token'] = eos_token
 
         # Handle special tokens
         special_tokens = []

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -75,7 +75,7 @@ class Vocab:
         example, it is valid to only set the `unknown_token` index to 10
         (instead of the default of 0) with `token_to_idx = {'<unk>': 10}`,
         assuming that there are at least 10 tokens in the vocabulary.
-    ``**kwargs``
+    `**kwargs`
         Keyword arguments of the format `xxx_token` can be used to specify
         further special tokens that will be exposed as attribute of the
         vocabulary and associated with an index.
@@ -93,17 +93,17 @@ class Vocab:
         The representation for the special token of padding token. Default:
         '<pad>'. Specifying padding_token as positional argument is deprecated
         and support will be removed. Specify it as keyword argument instead
-        (see documentation of **kwargs above)
+        (see documentation of `**kwargs` above)
     deprecated_bos_token
         The representation for the special token of beginning-of-sequence
         token. Default: '<bos>'. Specifying bos_token as positional argument is
         deprecated and support will be removed. Specify it as keyword argument
-        instead (see documentation of **kwargs above)
+        instead (see documentation of `**kwargs` above)
     deprecated_eos_token
         The representation for the special token of end-of-sequence token.
         Default: '<eos>'. Specifying eos_token as positional argument is
         deprecated and support will be removed. Specify it as keyword argument
-        instead (see documentation of **kwargs above)
+        instead (see documentation of `**kwargs` above)
 
     Attributes
     ----------

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -75,7 +75,7 @@ class Vocab:
         example, it is valid to only set the `unknown_token` index to 10
         (instead of the default of 0) with `token_to_idx = {'<unk>': 10}`,
         assuming that there are at least 10 tokens in the vocabulary.
-    **kwargs
+    ``**kwargs``
         Keyword arguments of the format `xxx_token` can be used to specify
         further special tokens that will be exposed as attribute of the
         vocabulary and associated with an index.

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -86,9 +86,6 @@ class Vocab:
         just as if it was listed in the `reserved_tokens` argument. The
         specified tokens are listed together with reserved tokens in the
         `reserved_tokens` attribute of the vocabulary object.
-
-    Deprecated Parameters
-    ---------------------
     deprecated_padding_token
         The representation for the special token of padding token. Default:
         '<pad>'. Specifying padding_token as positional argument is deprecated

--- a/tests/unittest/test_datasets.py
+++ b/tests/unittest/test_datasets.py
@@ -268,8 +268,9 @@ def test_simlex999():
 @flaky(max_runs=2, min_passes=1)
 @pytest.mark.serial
 @pytest.mark.remote_required
-@pytest.mark.skipif(datetime.date.today() < datetime.date(2019, 10, 14),
-                    reason="simverb temporarily unavailable.")
+@pytest.mark.skipif(datetime.date.today() < datetime.date(2019, 10, 21),
+                    reason="simverb temporarily unavailable"
+                    "contacted author on 10/14")
 def test_simverb3500():
     data = nlp.data.SimVerb3500()
     assert len(data) == 3500


### PR DESCRIPTION
## Description ##
Deprecate specification as positional arguments in preparation for dropping explicit padding_token, bos_token and eos_token arguments in favor of the general kwargs handling of https://github.com/dmlc/gluon-nlp/pull/732.

``` python
nlp.Vocab({'a':10}, None, 1, '<unk>', 'PAD')  # deprecated and will be unsupported
nlp.Vocab({'a':10}, None, 1, '<unk>', padding_token='PAD')  # recommended use
``` 

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Deprecate specifying Vocab padding, bos and eos_token as positional arguments

## Comments ##
- We need to consider if we want to deprecate the current default values of padding, bos and eos_token as well in the future. Ie. if `Vocab(counter)` should still create `Vocab(size=5, unk="<unk>", reserved="['<pad>', '<bos>', '<eos>']")` or maybe `Vocab(size=2, unk="<unk>", reserved="[]")` The advantage is that there is nothing special about these 3 special tokens compared to other application specific special tokens; removing the default values simplifies our API. The disadvantage is that such change would affect the vast majority of users and most lines of code that instantiates Vocab. (Note, this is not part of this PR).

cc @dmlc/gluon-nlp-team
