### PR TITLE
[BUGFIX] Make EmbeddingCenterContextBatchify returned dtype robust to empty sentences

### DIFF
--- a/src/gluonnlp/data/batchify/embedding.py
+++ b/src/gluonnlp/data/batchify/embedding.py
@@ -133,10 +133,11 @@ class _EmbeddingCenterContextBatchify(DataStream):
                 'with numba, but numba is not installed. '
                 'Consider "pip install numba" for significant speed-ups.')
 
-        if isinstance(self._sentences[0][0], str):
+        firstelement = next(itertools.chain.from_iterable(self._sentences))
+        if isinstance(firstelement, str):
             sentences = [np.asarray(s, dtype='O') for s in self._sentences]
         else:
-            dtype = type(next(itertools.chain.from_iterable(self._sentences)))
+            dtype = type(firstelement)
             sentences = [np.asarray(s, dtype=dtype) for s in self._sentences]
 
         if self._shuffle:

--- a/src/gluonnlp/data/batchify/embedding.py
+++ b/src/gluonnlp/data/batchify/embedding.py
@@ -135,7 +135,8 @@ class _EmbeddingCenterContextBatchify(DataStream):
         if isinstance(self._sentences[0][0], str):
             sentences = [np.asarray(s, dtype='O') for s in self._sentences]
         else:
-            sentences = [np.asarray(s) for s in self._sentences]
+            dtype = type(self._sentences[0][0])
+            sentences = [np.asarray(s, dtype=dtype) for s in self._sentences]
 
         if self._shuffle:
             random.shuffle(sentences)

--- a/src/gluonnlp/data/batchify/embedding.py
+++ b/src/gluonnlp/data/batchify/embedding.py
@@ -18,6 +18,7 @@
 
 __all__ = ['EmbeddingCenterContextBatchify']
 
+import itertools
 import logging
 import random
 
@@ -135,7 +136,7 @@ class _EmbeddingCenterContextBatchify(DataStream):
         if isinstance(self._sentences[0][0], str):
             sentences = [np.asarray(s, dtype='O') for s in self._sentences]
         else:
-            dtype = type(self._sentences[0][0])
+            dtype = type(next(itertools.chain.from_iterable(self._sentences)))
             sentences = [np.asarray(s, dtype=dtype) for s in self._sentences]
 
         if self._shuffle:

--- a/tests/unittest/batchify/test_batchify_embedding.py
+++ b/tests/unittest/batchify/test_batchify_embedding.py
@@ -80,3 +80,23 @@ def test_center_context_batchify(cbow, dtype, weight_dtype, index_dtype):
         assert contexts_data.tolist() == [1, 1, 1]
         assert contexts_row.tolist() == [0, 1, 2]
         assert contexts_col.tolist() == [dtype_fn(i) for i in [1, 0, 2]]
+
+@pytest.mark.parametrize('cbow', [True, False])
+@pytest.mark.parametrize('dtype', [np.float64, np.float32, np.float16, np.float64, np.int64, str])
+@pytest.mark.parametrize('weight_dtype', [np.float64, np.float32, np.float16])
+@pytest.mark.parametrize('index_dtype', [np.int64, np.int32])
+def test_center_context_batchify_robustness(cbow, dtype, weight_dtype, index_dtype):
+    batchify = nlp.data.batchify.EmbeddingCenterContextBatchify(
+        batch_size=3, window_size=1, cbow=cbow, weight_dtype=weight_dtype,
+        index_dtype=index_dtype)
+
+    if dtype != str:
+        samples = batchify([np.arange(5, dtype=dtype), []])
+    else:
+        samples = batchify([[str(i) for i in range(5)], []])
+    center, context = next(iter(samples))
+    (contexts_data, contexts_row, contexts_col) = context
+    assert center.dtype == dtype if dtype != str else center.dtype == 'O'
+    assert contexts_data.dtype == weight_dtype
+    assert contexts_row.dtype == index_dtype
+    assert contexts_col.dtype == dtype if dtype != str else center.dtype == 'O'

--- a/tests/unittest/batchify/test_batchify_embedding.py
+++ b/tests/unittest/batchify/test_batchify_embedding.py
@@ -85,15 +85,18 @@ def test_center_context_batchify(cbow, dtype, weight_dtype, index_dtype):
 @pytest.mark.parametrize('dtype', [np.float64, np.float32, np.float16, np.float64, np.int64, str])
 @pytest.mark.parametrize('weight_dtype', [np.float64, np.float32, np.float16])
 @pytest.mark.parametrize('index_dtype', [np.int64, np.int32])
-def test_center_context_batchify_robustness(cbow, dtype, weight_dtype, index_dtype):
+@pytest.mark.parametrize('emptyatbegin', [True, False])
+def test_center_context_batchify_robustness(cbow, dtype, weight_dtype, index_dtype, emptyatbegin):
     batchify = nlp.data.batchify.EmbeddingCenterContextBatchify(
         batch_size=3, window_size=1, cbow=cbow, weight_dtype=weight_dtype,
         index_dtype=index_dtype)
 
     if dtype != str:
-        samples = batchify([np.arange(5, dtype=dtype), []])
+        samples = np.arange(5, dtype=dtype)
     else:
-        samples = batchify([[str(i) for i in range(5)], []])
+        samples = [str(i) for i in range(5)]
+    samples = [[], samples] if emptyatbegin else [samples, []]
+    samples = batchify(samples)
     center, context = next(iter(samples))
     (contexts_data, contexts_row, contexts_col) = context
     assert center.dtype == dtype if dtype != str else center.dtype == 'O'


### PR DESCRIPTION
## Description ##
np.asarray([]) defaults to float32 dtype. Thus an input of [[1,2,3,...], []]
would yield returnvalue of float32 dtype instead of expected int64 dtype.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Make EmbeddingCenterContextBatchify returned dtype robust to empty sentences

cc @dmlc/gluon-nlp-team
