### PR TITLE
[FEATURE] Add raw attention scores to the AttentionCell #951

### DIFF
--- a/src/gluonnlp/model/attention_cell.py
+++ b/src/gluonnlp/model/attention_cell.py
@@ -159,7 +159,7 @@ class AttentionCell(HybridBlock):
             Shape (batch_size, query_length, context_vec_dim)
         att_weights : Symbol or NDArray
             Attention weights. Shape (batch_size, query_length, memory_length)
-        [att_scores]: Symbol or NDArray
+        att_scores: Symbol or NDArray
             Attention scores. Shape (batch_size, query_length, memory_length)
         """
         return super(AttentionCell, self).__call__(query, key, value, mask)

--- a/src/gluonnlp/model/attention_cell.py
+++ b/src/gluonnlp/model/attention_cell.py
@@ -71,7 +71,7 @@ class AttentionCell(HybridBlock):
 
         cell = AttentionCell()
         out = cell(query, key, value, mask)
-    
+
     Parameters
     ----------
     prefix : str or None, default None
@@ -220,8 +220,8 @@ class MultiHeadAttentionCell(AttentionCell):
     def __init__(self, base_cell, query_units, key_units, value_units, num_heads, use_bias=True,
                  weight_initializer=None, bias_initializer='zeros', prefix=None, params=None,
                  return_attention_scores=False):
-        super(MultiHeadAttentionCell, self).__init__(prefix=prefix, params=params,
-                                                     return_attention_scores=return_attention_scores)
+        super(MultiHeadAttentionCell, self).__init__(
+            prefix=prefix, params=params, return_attention_scores=return_attention_scores)
         self._base_cell = base_cell
         self._num_heads = num_heads
         self._use_bias = use_bias
@@ -461,8 +461,8 @@ class DotProductAttentionCell(AttentionCell):
     def __init__(self, units=None, luong_style=False, scaled=True, normalized=False, use_bias=True,
                  dropout=0.0, weight_initializer=None, bias_initializer='zeros',
                  prefix=None, params=None, return_attention_scores=False):
-        super(DotProductAttentionCell, self).__init__(prefix=prefix, params=params,
-                                                      return_attention_scores=return_attention_scores)
+        super(DotProductAttentionCell, self).__init__(
+            prefix=prefix, params=params, return_attention_scores=return_attention_scores)
         self._units = units
         self._scaled = scaled
         self._normalized = normalized


### PR DESCRIPTION
## Description ##
For implementing a pointer mechanism in sequence to sequence models it is very practical to re-use attention cells. For example see the Attention-Based Copy Mechanism described in Jia, Robin, and Percy Liang. "Data recombination for neural semantic parsing." arXiv preprint arXiv:1606.03622 (2016).
The proposal is to additionally return the raw attention scores in the AttentionCell.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

## Comments ##
- The change is a backward compatible

cc @dmlc/gluon-nlp-team
