### PR TITLE
[CI] Correct propagation of error codes in GluonNLP-py3-master-gpu-doc

### DIFF
--- a/ci/batch/docker/gluon_nlp_job.sh
+++ b/ci/batch/docker/gluon_nlp_job.sh
@@ -29,7 +29,7 @@ python -m nltk.downloader all
 pip install awscli
 
 cd $WORK_DIR
-/bin/bash -c "$COMMAND"
+/bin/bash -o pipefail -c "$COMMAND"
 COMMAND_EXIT_CODE=$?
 if [[ -f $SAVED_OUTPUT ]]; then
   aws s3 cp $SAVED_OUTPUT s3://gluon-nlp-staging/$SAVE_PATH;


### PR DESCRIPTION
Set `-o pipefail` for gluon_nlp_job.sh

I'll have to rebuild the docker container after this change.

cc @dmlc/gluon-nlp-team
