### PR TITLE
[Refactor] TransformerDecoder

### DIFF
--- a/docs/examples/machine_translation/gnmt.md
+++ b/docs/examples/machine_translation/gnmt.md
@@ -337,12 +337,12 @@ feed the encoder and decoder to the `NMTModel` to construct the GNMT model.
 `model.hybridize` allows computation to be done using the symbolic backend. To understand what it means to be "hybridized," please refer to [this](https://mxnet.incubator.apache.org/versions/master/tutorials/gluon/hybrid.html) page on MXNet hybridization and its advantages.
 
 ```{.python .input}
-encoder, decoder = nmt.gnmt.get_gnmt_encoder_decoder(hidden_size=num_hidden,
-                                                     dropout=dropout,
-                                                     num_layers=num_layers,
-                                                     num_bi_layers=num_bi_layers)
+encoder, decoder, one_step_ahead_decoder = nmt.gnmt.get_gnmt_encoder_decoder(
+    hidden_size=num_hidden, dropout=dropout, num_layers=num_layers,
+    num_bi_layers=num_bi_layers)
 model = nlp.model.translation.NMTModel(src_vocab=src_vocab, tgt_vocab=tgt_vocab, encoder=encoder,
-                                       decoder=decoder, embed_size=num_hidden, prefix='gnmt_')
+                                       decoder=decoder, one_step_ahead_decoder=one_step_ahead_decoder,
+                                       embed_size=num_hidden, prefix='gnmt_')
 model.initialize(init=mx.init.Uniform(0.1), ctx=ctx)
 static_alloc = True
 model.hybridize(static_alloc=static_alloc)

--- a/scripts/machine_translation/gnmt.py
+++ b/scripts/machine_translation/gnmt.py
@@ -22,7 +22,7 @@ from mxnet.base import _as_list
 from mxnet.gluon import nn, rnn
 from mxnet.gluon.block import HybridBlock
 from gluonnlp.model.seq2seq_encoder_decoder import Seq2SeqEncoder, Seq2SeqDecoder, \
-     _get_attention_cell, _get_cell_type, _nested_sequence_last
+     Seq2SeqOneStepDecoder, _get_attention_cell, _get_cell_type, _nested_sequence_last
 
 
 class GNMTEncoder(Seq2SeqEncoder):
@@ -158,48 +158,14 @@ class GNMTEncoder(Seq2SeqEncoder):
         return [outputs, new_states], []
 
 
-class GNMTDecoder(HybridBlock, Seq2SeqDecoder):
-    """Structure of the RNN Encoder similar to that used in the
-    Google Neural Machine Translation paper.
-
-    We use gnmt_v2 strategy in tensorflow/nmt
-
-    Parameters
-    ----------
-    cell_type : str or type
-    attention_cell : AttentionCell or str
-        Arguments of the attention cell.
-        Can be 'scaled_luong', 'normed_mlp', 'dot'
-    num_layers : int
-    hidden_size : int
-    dropout : float
-    use_residual : bool
-    output_attention: bool
-        Whether to output the attention weights
-    i2h_weight_initializer : str or Initializer
-        Initializer for the input weights matrix, used for the linear
-        transformation of the inputs.
-    h2h_weight_initializer : str or Initializer
-        Initializer for the recurrent weights matrix, used for the linear
-        transformation of the recurrent state.
-    i2h_bias_initializer : str or Initializer
-        Initializer for the bias vector.
-    h2h_bias_initializer : str or Initializer
-        Initializer for the bias vector.
-    prefix : str, default 'rnn_'
-        Prefix for name of `Block`s
-        (and name of weight if params is `None`).
-    params : Parameter or None
-        Container for weight sharing between cells.
-        Created if `None`.
-    """
+class _BaseGNMTDecoder(HybridBlock):
     def __init__(self, cell_type='lstm', attention_cell='scaled_luong',
                  num_layers=2, hidden_size=128,
                  dropout=0.0, use_residual=True, output_attention=False,
                  i2h_weight_initializer=None, h2h_weight_initializer=None,
                  i2h_bias_initializer='zeros', h2h_bias_initializer='zeros',
                  prefix=None, params=None):
-        super(GNMTDecoder, self).__init__(prefix=prefix, params=params)
+        super().__init__(prefix=prefix, params=params)
         self._cell_type = _get_cell_type(cell_type)
         self._num_layers = num_layers
         self._hidden_size = hidden_size
@@ -249,59 +215,7 @@ class GNMTDecoder(HybridBlock, Seq2SeqDecoder):
             decoder_states.append(mem_masks)
         return decoder_states
 
-    def decode_seq(self, inputs, states, valid_length=None):
-        """Decode the decoder inputs. This function is only used for training.
-
-        Parameters
-        ----------
-        inputs : NDArray, Shape (batch_size, length, C_in)
-        states : list of NDArrays or None
-            Initial states. The list of initial decoder states
-        valid_length : NDArray or None
-            Valid lengths of each sequence. This is usually used when part of sequence has
-            been padded. Shape (batch_size,)
-
-        Returns
-        -------
-        output : NDArray, Shape (batch_size, length, C_out)
-        states : list
-            The decoder states, includes:
-
-            - rnn_states : NDArray
-            - attention_vec : NDArray
-            - mem_value : NDArray
-            - mem_masks : NDArray, optional
-        additional_outputs : list
-            Either be an empty list or contains the attention weights in this step.
-            The attention weights will have shape (batch_size, length, mem_length) or
-            (batch_size, num_heads, length, mem_length)
-        """
-        length = inputs.shape[1]
-        output = []
-        additional_outputs = []
-        inputs = _as_list(mx.nd.split(inputs, num_outputs=length, axis=1, squeeze_axis=True))
-        rnn_states_l = []
-        attention_output_l = []
-        fixed_states = states[2:]
-        for i in range(length):
-            ele_output, states, ele_additional_outputs = self.forward(inputs[i], states)
-            rnn_states_l.append(states[0])
-            attention_output_l.append(states[1])
-            output.append(ele_output)
-            additional_outputs.extend(ele_additional_outputs)
-        output = mx.nd.stack(*output, axis=1)
-        if valid_length is not None:
-            states = [_nested_sequence_last(rnn_states_l, valid_length),
-                      _nested_sequence_last(attention_output_l, valid_length)] + fixed_states
-            output = mx.nd.SequenceMask(output,
-                                        sequence_length=valid_length,
-                                        use_sequence_length=True,
-                                        axis=1)
-        if self._output_attention:
-            additional_outputs = [mx.nd.concat(*additional_outputs, dim=-2)]
-        return output, states, additional_outputs
-
-    def __call__(self, step_input, states): #pylint: disable=arguments-differ
+    def forward(self, step_input, states):  # pylint: disable=arguments-differ
         """One-step-ahead decoding of the GNMT decoder.
 
         Parameters
@@ -326,11 +240,7 @@ class GNMTDecoder(HybridBlock, Seq2SeqDecoder):
             The attention weights will have shape (batch_size, 1, mem_length) or
             (batch_size, num_heads, 1, mem_length)
         """
-        return super(GNMTDecoder, self).__call__(step_input, states)
-
-    def forward(self, step_input, states):  #pylint: disable=arguments-differ, missing-docstring
-        step_output, new_states, step_additional_outputs =\
-            super(GNMTDecoder, self).forward(step_input, states)
+        step_output, new_states, step_additional_outputs = super().forward(step_input, states)
         # In hybrid_forward, only the rnn_states and attention_vec are calculated.
         # We directly append the mem_value and mem_masks in the forward() function.
         # We apply this trick because the memory value/mask can be directly appended to the next
@@ -402,6 +312,148 @@ class GNMTDecoder(HybridBlock, Seq2SeqDecoder):
         return rnn_out, new_states, step_additional_outputs
 
 
+class GNMTOneStepDecoder(_BaseGNMTDecoder, Seq2SeqOneStepDecoder):
+    """RNN Encoder similar to that used in the Google Neural Machine Translation paper.
+
+    One-step ahead decoder used during inference.
+
+    We use gnmt_v2 strategy in tensorflow/nmt
+
+    Parameters
+    ----------
+    cell_type : str or type
+        Can be "lstm", "gru" or constructor functions that can be directly called,
+         like rnn.LSTMCell
+    attention_cell : AttentionCell or str
+        Arguments of the attention cell.
+        Can be 'scaled_luong', 'normed_mlp', 'dot'
+    num_layers : int
+        Total number of layers
+    hidden_size : int
+        Number of hidden units
+    dropout : float
+        The dropout rate
+    use_residual : bool
+        Whether to use residual connection. Residual connection will be added in the
+        uni-directional RNN layers
+    output_attention: bool
+        Whether to output the attention weights
+    i2h_weight_initializer : str or Initializer
+        Initializer for the input weights matrix, used for the linear
+        transformation of the inputs.
+    h2h_weight_initializer : str or Initializer
+        Initializer for the recurrent weights matrix, used for the linear
+        transformation of the recurrent state.
+    i2h_bias_initializer : str or Initializer
+        Initializer for the bias vector.
+    h2h_bias_initializer : str or Initializer
+        Initializer for the bias vector.
+    prefix : str, default 'rnn_'
+        Prefix for name of `Block`s
+        (and name of weight if params is `None`).
+    params : Parameter or None
+        Container for weight sharing between cells.
+        Created if `None`.
+    """
+
+
+class GNMTDecoder(_BaseGNMTDecoder, Seq2SeqDecoder):
+    """RNN Encoder similar to that used in the Google Neural Machine Translation paper.
+
+    Multi-step decoder used during training with teacher forcing.
+
+    We use gnmt_v2 strategy in tensorflow/nmt
+
+    Parameters
+    ----------
+    cell_type : str or type
+        Can be "lstm", "gru" or constructor functions that can be directly called,
+         like rnn.LSTMCell
+    attention_cell : AttentionCell or str
+        Arguments of the attention cell.
+        Can be 'scaled_luong', 'normed_mlp', 'dot'
+    num_layers : int
+        Total number of layers
+    hidden_size : int
+        Number of hidden units
+    dropout : float
+        The dropout rate
+    use_residual : bool
+        Whether to use residual connection. Residual connection will be added in the
+        uni-directional RNN layers
+    output_attention: bool
+        Whether to output the attention weights
+    i2h_weight_initializer : str or Initializer
+        Initializer for the input weights matrix, used for the linear
+        transformation of the inputs.
+    h2h_weight_initializer : str or Initializer
+        Initializer for the recurrent weights matrix, used for the linear
+        transformation of the recurrent state.
+    i2h_bias_initializer : str or Initializer
+        Initializer for the bias vector.
+    h2h_bias_initializer : str or Initializer
+        Initializer for the bias vector.
+    prefix : str, default 'rnn_'
+        Prefix for name of `Block`s
+        (and name of weight if params is `None`).
+    params : Parameter or None
+        Container for weight sharing between cells.
+        Created if `None`.
+    """
+
+    def forward(self, inputs, states, valid_length=None):  # pylint: disable=arguments-differ
+        """Decode the decoder inputs. This function is only used for training.
+
+        Parameters
+        ----------
+        inputs : NDArray, Shape (batch_size, length, C_in)
+        states : list of NDArrays or None
+            Initial states. The list of initial decoder states
+        valid_length : NDArray or None
+            Valid lengths of each sequence. This is usually used when part of sequence has
+            been padded. Shape (batch_size,)
+
+        Returns
+        -------
+        output : NDArray, Shape (batch_size, length, C_out)
+        states : list
+            The decoder states, includes:
+
+            - rnn_states : NDArray
+            - attention_vec : NDArray
+            - mem_value : NDArray
+            - mem_masks : NDArray, optional
+        additional_outputs : list
+            Either be an empty list or contains the attention weights in this step.
+            The attention weights will have shape (batch_size, length, mem_length) or
+            (batch_size, num_heads, length, mem_length)
+        """
+        length = inputs.shape[1]
+        output = []
+        additional_outputs = []
+        inputs = _as_list(mx.nd.split(inputs, num_outputs=length, axis=1, squeeze_axis=True))
+        rnn_states_l = []
+        attention_output_l = []
+        fixed_states = states[2:]
+        for i in range(length):
+            ele_output, states, ele_additional_outputs = super().forward(inputs[i], states)
+            rnn_states_l.append(states[0])
+            attention_output_l.append(states[1])
+            output.append(ele_output)
+            additional_outputs.extend(ele_additional_outputs)
+        output = mx.nd.stack(*output, axis=1)
+        if valid_length is not None:
+            states = [_nested_sequence_last(rnn_states_l, valid_length),
+                      _nested_sequence_last(attention_output_l, valid_length)] + fixed_states
+            output = mx.nd.SequenceMask(output,
+                                        sequence_length=valid_length,
+                                        use_sequence_length=True,
+                                        axis=1)
+        if self._output_attention:
+            additional_outputs = [mx.nd.concat(*additional_outputs, dim=-2)]
+        return output, states, additional_outputs
+
+
 def get_gnmt_encoder_decoder(cell_type='lstm', attention_cell='scaled_luong', num_layers=2,
                              num_bi_layers=1, hidden_size=128, dropout=0.0, use_residual=False,
                              i2h_weight_initializer=None, h2h_weight_initializer=None,
@@ -435,19 +487,24 @@ def get_gnmt_encoder_decoder(cell_type='lstm', attention_cell='scaled_luong', nu
     decoder : GNMTDecoder
     """
     encoder = GNMTEncoder(cell_type=cell_type, num_layers=num_layers, num_bi_layers=num_bi_layers,
-                          hidden_size=hidden_size, dropout=dropout,
-                          use_residual=use_residual,
+                          hidden_size=hidden_size, dropout=dropout, use_residual=use_residual,
                           i2h_weight_initializer=i2h_weight_initializer,
                           h2h_weight_initializer=h2h_weight_initializer,
                           i2h_bias_initializer=i2h_bias_initializer,
-                          h2h_bias_initializer=h2h_bias_initializer,
-                          prefix=prefix + 'enc_', params=params)
+                          h2h_bias_initializer=h2h_bias_initializer, prefix=prefix + 'enc_',
+                          params=params)
     decoder = GNMTDecoder(cell_type=cell_type, attention_cell=attention_cell, num_layers=num_layers,
-                          hidden_size=hidden_size, dropout=dropout,
-                          use_residual=use_residual,
+                          hidden_size=hidden_size, dropout=dropout, use_residual=use_residual,
                           i2h_weight_initializer=i2h_weight_initializer,
                           h2h_weight_initializer=h2h_weight_initializer,
                           i2h_bias_initializer=i2h_bias_initializer,
-                          h2h_bias_initializer=h2h_bias_initializer,
-                          prefix=prefix + 'dec_', params=params)
-    return encoder, decoder
+                          h2h_bias_initializer=h2h_bias_initializer, prefix=prefix + 'dec_',
+                          params=params)
+    one_step_ahead_decoder = GNMTOneStepDecoder(
+        cell_type=cell_type, attention_cell=attention_cell, num_layers=num_layers,
+        hidden_size=hidden_size, dropout=dropout, use_residual=use_residual,
+        i2h_weight_initializer=i2h_weight_initializer,
+        h2h_weight_initializer=h2h_weight_initializer, i2h_bias_initializer=i2h_bias_initializer,
+        h2h_bias_initializer=h2h_bias_initializer, prefix=prefix + 'dec_',
+        params=decoder.collect_params())
+    return encoder, decoder, one_step_ahead_decoder

--- a/scripts/machine_translation/gnmt.py
+++ b/scripts/machine_translation/gnmt.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Encoder and decoder usded in sequence-to-sequence learning."""
-__all__ = ['GNMTEncoder', 'GNMTDecoder', 'get_gnmt_encoder_decoder']
+__all__ = ['GNMTEncoder', 'GNMTDecoder', 'GNMTOneStepDecoder', 'get_gnmt_encoder_decoder']
 
 import mxnet as mx
 from mxnet.base import _as_list

--- a/scripts/machine_translation/inference_transformer.py
+++ b/scripts/machine_translation/inference_transformer.py
@@ -154,17 +154,14 @@ if args.tgt_max_len > 0:
 else:
     tgt_max_len = max_len[1]
 
-encoder, decoder = get_transformer_encoder_decoder(units=args.num_units,
-                                                   hidden_size=args.hidden_size,
-                                                   dropout=args.dropout,
-                                                   num_layers=args.num_layers,
-                                                   num_heads=args.num_heads,
-                                                   max_src_length=max(src_max_len, 500),
-                                                   max_tgt_length=max(tgt_max_len, 500),
-                                                   scaled=args.scaled)
+encoder, decoder, one_step_ahead_decoder = get_transformer_encoder_decoder(
+    units=args.num_units, hidden_size=args.hidden_size, dropout=args.dropout,
+    num_layers=args.num_layers, num_heads=args.num_heads, max_src_length=max(src_max_len, 500),
+    max_tgt_length=max(tgt_max_len, 500), scaled=args.scaled)
 model = NMTModel(src_vocab=src_vocab, tgt_vocab=tgt_vocab, encoder=encoder, decoder=decoder,
-                 share_embed=args.dataset != 'TOY', embed_size=args.num_units,
-                 tie_weights=args.dataset != 'TOY', embed_initializer=None, prefix='transformer_')
+                 one_step_ahead_decoder=one_step_ahead_decoder, share_embed=args.dataset != 'TOY',
+                 embed_size=args.num_units, tie_weights=args.dataset != 'TOY',
+                 embed_initializer=None, prefix='transformer_')
 
 param_name = args.model_parameter
 if (not os.path.exists(param_name)):

--- a/scripts/machine_translation/train_gnmt.py
+++ b/scripts/machine_translation/train_gnmt.py
@@ -122,12 +122,12 @@ if args.gpu is None:
 else:
     ctx = mx.gpu(args.gpu)
 
-encoder, decoder = get_gnmt_encoder_decoder(hidden_size=args.num_hidden,
-                                            dropout=args.dropout,
-                                            num_layers=args.num_layers,
-                                            num_bi_layers=args.num_bi_layers)
+encoder, decoder, one_step_ahead_decoder = get_gnmt_encoder_decoder(
+    hidden_size=args.num_hidden, dropout=args.dropout, num_layers=args.num_layers,
+    num_bi_layers=args.num_bi_layers)
 model = NMTModel(src_vocab=src_vocab, tgt_vocab=tgt_vocab, encoder=encoder, decoder=decoder,
-                 embed_size=args.num_hidden, prefix='gnmt_')
+                 one_step_ahead_decoder=one_step_ahead_decoder, embed_size=args.num_hidden,
+                 prefix='gnmt_')
 model.initialize(init=mx.init.Uniform(0.1), ctx=ctx)
 static_alloc = True
 model.hybridize(static_alloc=static_alloc)
@@ -175,8 +175,8 @@ def evaluate(data_loader):
         avg_loss += loss * (tgt_seq.shape[1] - 1)
         avg_loss_denom += (tgt_seq.shape[1] - 1)
         # Translate
-        samples, _, sample_valid_length =\
-            translator.translate(src_seq=src_seq, src_valid_length=src_valid_length)
+        samples, _, sample_valid_length = translator.translate(
+            src_seq=src_seq, src_valid_length=src_valid_length)
         max_score_sample = samples[:, 0, :].asnumpy()
         sample_valid_length = sample_valid_length[:, 0].asnumpy()
         for i in range(max_score_sample.shape[0]):

--- a/scripts/machine_translation/train_transformer.py
+++ b/scripts/machine_translation/train_transformer.py
@@ -33,25 +33,25 @@ This example shows how to implement the Transformer model with Gluon NLP Toolkit
 # pylint:disable=redefined-outer-name,logging-format-interpolation
 
 import argparse
-import time
-import random
-import os
 import logging
 import math
+import os
+import random
+import time
+
 import numpy as np
 import mxnet as mx
 from mxnet import gluon
+
 import gluonnlp as nlp
-
-from gluonnlp.loss import MaskedSoftmaxCELoss, LabelSmoothing
+from gluonnlp.loss import LabelSmoothing, MaskedSoftmaxCELoss
+from gluonnlp.model.transformer import ParallelTransformer, get_transformer_encoder_decoder
 from gluonnlp.model.translation import NMTModel
-from gluonnlp.model.transformer import get_transformer_encoder_decoder, ParallelTransformer
 from gluonnlp.utils.parallel import Parallel
-from translation import BeamSearchTranslator
-
-from utils import logging_config
-from bleu import _bpe_to_words, compute_bleu
 import dataprocessor
+from bleu import _bpe_to_words, compute_bleu
+from translation import BeamSearchTranslator
+from utils import logging_config
 
 np.random.seed(100)
 random.seed(100)
@@ -174,15 +174,12 @@ if args.tgt_max_len > 0:
     tgt_max_len = args.tgt_max_len
 else:
     tgt_max_len = max_len[1]
-encoder, decoder = get_transformer_encoder_decoder(units=args.num_units,
-                                                   hidden_size=args.hidden_size,
-                                                   dropout=args.dropout,
-                                                   num_layers=args.num_layers,
-                                                   num_heads=args.num_heads,
-                                                   max_src_length=max(src_max_len, 500),
-                                                   max_tgt_length=max(tgt_max_len, 500),
-                                                   scaled=args.scaled)
+encoder, decoder, one_step_ahead_decoder = get_transformer_encoder_decoder(
+    units=args.num_units, hidden_size=args.hidden_size, dropout=args.dropout,
+    num_layers=args.num_layers, num_heads=args.num_heads, max_src_length=max(src_max_len, 500),
+    max_tgt_length=max(tgt_max_len, 500), scaled=args.scaled)
 model = NMTModel(src_vocab=src_vocab, tgt_vocab=tgt_vocab, encoder=encoder, decoder=decoder,
+                 one_step_ahead_decoder=one_step_ahead_decoder,
                  share_embed=args.dataset not in ('TOY', 'IWSLT2015'), embed_size=args.num_units,
                  tie_weights=args.dataset not in ('TOY', 'IWSLT2015'), embed_initializer=None,
                  prefix='transformer_')

--- a/scripts/tests/test_encoder_decoder.py
+++ b/scripts/tests/test_encoder_decoder.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pytest
+
 import numpy as np
 import mxnet as mx
 from mxnet.test_utils import assert_almost_equal
@@ -75,9 +77,7 @@ def test_gnmt_encoder_decoder():
                     decoder_states = decoder.init_state_from_encoder(encoder_outputs, src_valid_length_nd)
 
                     # Test multi step forwarding
-                    output, new_states, additional_outputs = decoder.decode_seq(tgt_seq_nd,
-                                                                                decoder_states,
-                                                                                tgt_valid_length_nd)
+                    output, new_states, additional_outputs = decoder(tgt_seq_nd, decoder_states, tgt_valid_length_nd)
                     assert(output.shape == (batch_size, tgt_seq_length, num_hidden))
                     output_npy = output.asnumpy()
                     for i in range(batch_size):
@@ -136,51 +136,53 @@ def test_transformer_encoder():
                         else:
                             assert(len(additional_outputs) == 0)
 
-def test_transformer_encoder_decoder():
+@pytest.mark.parametrize('output_attention', [False, True])
+@pytest.mark.parametrize('use_residual', [False, True])
+@pytest.mark.parametrize('batch_size', [4])
+@pytest.mark.parametrize('src_tgt_seq_len', [(5, 10), (10, 5)])
+def test_transformer_encoder_decoder(output_attention, use_residual, batch_size, src_tgt_seq_len):
     ctx = mx.current_context()
     units = 16
     encoder = TransformerEncoder(num_layers=3, units=units, hidden_size=32, num_heads=8, max_length=10,
                                  dropout=0.0, use_residual=True, prefix='transformer_encoder_')
     encoder.initialize(ctx=ctx)
     encoder.hybridize()
-    for output_attention in [True, False]:
-        for use_residual in [True, False]:
-            decoder = TransformerDecoder(num_layers=3, units=units, hidden_size=32, num_heads=8, max_length=10, dropout=0.0,
-                                         output_attention=output_attention, use_residual=use_residual, prefix='transformer_decoder_')
-            decoder.initialize(ctx=ctx)
-            decoder.hybridize()
-            for batch_size in [4]:
-                for src_seq_length, tgt_seq_length in [(5, 10), (10, 5)]:
-                    src_seq_nd = mx.nd.random.normal(0, 1, shape=(batch_size, src_seq_length, units), ctx=ctx)
-                    tgt_seq_nd = mx.nd.random.normal(0, 1, shape=(batch_size, tgt_seq_length, units), ctx=ctx)
-                    src_valid_length_nd = mx.nd.array(np.random.randint(1, src_seq_length, size=(batch_size,)), ctx=ctx)
-                    tgt_valid_length_nd = mx.nd.array(np.random.randint(1, tgt_seq_length, size=(batch_size,)), ctx=ctx)
-                    src_valid_length_npy = src_valid_length_nd.asnumpy()
-                    tgt_valid_length_npy = tgt_valid_length_nd.asnumpy()
-                    encoder_outputs, _ = encoder(src_seq_nd, valid_length=src_valid_length_nd)
-                    decoder_states = decoder.init_state_from_encoder(encoder_outputs, src_valid_length_nd)
+    decoder = TransformerDecoder(num_layers=3, units=units, hidden_size=32,
+                                 num_heads=8, max_length=10, dropout=0.0,
+                                 output_attention=output_attention,
+                                 use_residual=use_residual,
+                                 prefix='transformer_decoder_')
+    decoder.initialize(ctx=ctx)
+    decoder.hybridize()
 
-                    # Test multi step forwarding
-                    output, new_states, additional_outputs = decoder.decode_seq(tgt_seq_nd,
-                                                                                decoder_states,
-                                                                                tgt_valid_length_nd)
-                    assert(output.shape == (batch_size, tgt_seq_length, units))
-                    output_npy = output.asnumpy()
-                    for i in range(batch_size):
-                        tgt_v_len = int(tgt_valid_length_npy[i])
-                        if tgt_v_len < tgt_seq_length - 1:
-                            assert((output_npy[i, tgt_v_len:, :] == 0).all())
-                    if output_attention:
-                        assert(len(additional_outputs) == 3)
-                        attention_out = additional_outputs[0][1].asnumpy()
-                        assert(attention_out.shape == (batch_size, 8, tgt_seq_length, src_seq_length))
-                        for i in range(batch_size):
-                            mem_v_len = int(src_valid_length_npy[i])
-                            if mem_v_len < src_seq_length - 1:
-                                assert((attention_out[i, :, :, mem_v_len:] == 0).all())
-                            if mem_v_len > 0:
-                                assert_almost_equal(attention_out[i, :, :, :].sum(axis=-1),
-                                                    np.ones(attention_out.shape[1:3]))
-                    else:
-                        assert(len(additional_outputs) == 0)
+    src_seq_length, tgt_seq_length = src_tgt_seq_len
+    src_seq_nd = mx.nd.random.normal(0, 1, shape=(batch_size, src_seq_length, units), ctx=ctx)
+    tgt_seq_nd = mx.nd.random.normal(0, 1, shape=(batch_size, tgt_seq_length, units), ctx=ctx)
+    src_valid_length_nd = mx.nd.array(np.random.randint(1, src_seq_length, size=(batch_size,)), ctx=ctx)
+    tgt_valid_length_nd = mx.nd.array(np.random.randint(1, tgt_seq_length, size=(batch_size,)), ctx=ctx)
+    src_valid_length_npy = src_valid_length_nd.asnumpy()
+    tgt_valid_length_npy = tgt_valid_length_nd.asnumpy()
+    encoder_outputs, _ = encoder(src_seq_nd, valid_length=src_valid_length_nd)
+    decoder_states = decoder.init_state_from_encoder(encoder_outputs, src_valid_length_nd)
 
+    # Test multi step forwarding
+    output, new_states, additional_outputs = decoder(tgt_seq_nd, decoder_states, tgt_valid_length_nd)
+    assert(output.shape == (batch_size, tgt_seq_length, units))
+    output_npy = output.asnumpy()
+    for i in range(batch_size):
+        tgt_v_len = int(tgt_valid_length_npy[i])
+        if tgt_v_len < tgt_seq_length - 1:
+            assert((output_npy[i, tgt_v_len:, :] == 0).all())
+    if output_attention:
+        assert(len(additional_outputs) == 3)
+        attention_out = additional_outputs[0][1].asnumpy()
+        assert(attention_out.shape == (batch_size, 8, tgt_seq_length, src_seq_length))
+        for i in range(batch_size):
+            mem_v_len = int(src_valid_length_npy[i])
+            if mem_v_len < src_seq_length - 1:
+                assert((attention_out[i, :, :, mem_v_len:] == 0).all())
+            if mem_v_len > 0:
+                assert_almost_equal(attention_out[i, :, :, :].sum(axis=-1),
+                                    np.ones(attention_out.shape[1:3]))
+    else:
+        assert(len(additional_outputs) == 0)

--- a/src/gluonnlp/model/seq2seq_encoder_decoder.py
+++ b/src/gluonnlp/model/seq2seq_encoder_decoder.py
@@ -18,11 +18,13 @@
 __all__ = ['Seq2SeqEncoder']
 
 from functools import partial
+
 import mxnet as mx
 from mxnet.gluon import rnn
 from mxnet.gluon.block import Block
-from gluonnlp.model import AttentionCell, MLPAttentionCell, DotProductAttentionCell, \
-    MultiHeadAttentionCell
+
+from .attention_cell import (AttentionCell, DotProductAttentionCell,
+                             MLPAttentionCell, MultiHeadAttentionCell)
 
 
 def _get_cell_type(cell_type):
@@ -153,9 +155,11 @@ class Seq2SeqEncoder(Block):
 
 
 class Seq2SeqDecoder(Block):
-    r"""Base class of the decoders in sequence to sequence learning models.
+    """Base class of the decoders in sequence to sequence learning models.
 
-    In the forward function, it generates the one-step-ahead decoding output.
+    Given the inputs and the context computed by the encoder, generate the new
+    states. This is usually used in the training phase where we set the inputs
+    to be the target sequence.
 
     """
     def init_state_from_encoder(self, encoder_outputs, encoder_valid_length=None):
@@ -172,8 +176,8 @@ class Seq2SeqDecoder(Block):
         """
         raise NotImplementedError
 
-    def decode_seq(self, inputs, states, valid_length=None):
-        r"""Given the inputs and the context computed by the encoder,
+    def forward(self, step_input, states, valid_length=None):  #pylint: disable=arguments-differ
+        """Given the inputs and the context computed by the encoder,
         generate the new states. This is usually used in the training phase where we set the inputs
         to be the target sequence.
 
@@ -196,8 +200,29 @@ class Seq2SeqDecoder(Block):
         """
         raise NotImplementedError
 
-    def __call__(self, step_input, states):  #pylint: disable=arguments-differ
-        r"""One-step decoding of the input
+
+class Seq2SeqOneStepDecoder(Block):
+    r"""Base class of the decoders in sequence to sequence learning models.
+
+    In the forward function, it generates the one-step-ahead decoding output.
+
+    """
+    def init_state_from_encoder(self, encoder_outputs, encoder_valid_length=None):
+        r"""Generates the initial decoder states based on the encoder outputs.
+
+        Parameters
+        ----------
+        encoder_outputs : list of NDArrays
+        encoder_valid_length : NDArray or None
+
+        Returns
+        -------
+        decoder_states : list
+        """
+        raise NotImplementedError
+
+    def forward(self, step_input, states):  #pylint: disable=arguments-differ
+        """One-step decoding of the input
 
         Parameters
         ----------
@@ -213,7 +238,4 @@ class Seq2SeqDecoder(Block):
         step_additional_outputs : list
             Additional outputs of the step, e.g, the attention weights
         """
-        return super(Seq2SeqDecoder, self).__call__(step_input, states)
-
-    def forward(self, step_input, states):  #pylint: disable=arguments-differ
         raise NotImplementedError

--- a/src/gluonnlp/model/seq2seq_encoder_decoder.py
+++ b/src/gluonnlp/model/seq2seq_encoder_decoder.py
@@ -130,6 +130,7 @@ def _nested_sequence_last(data, valid_length):
 class Seq2SeqEncoder(Block):
     r"""Base class of the encoders in sequence to sequence learning models.
     """
+
     def __call__(self, inputs, valid_length=None, states=None):  #pylint: disable=arguments-differ
         """Encode the input sequence.
 
@@ -155,13 +156,14 @@ class Seq2SeqEncoder(Block):
 
 
 class Seq2SeqDecoder(Block):
-    """Base class of the decoders in sequence to sequence learning models.
+    """Base class of the decoders for sequence to sequence learning models.
 
     Given the inputs and the context computed by the encoder, generate the new
-    states. This is usually used in the training phase where we set the inputs
-    to be the target sequence.
+    states. Used in the training phase where we set the inputs to be the target
+    sequence.
 
     """
+
     def init_state_from_encoder(self, encoder_outputs, encoder_valid_length=None):
         r"""Generates the initial decoder states based on the encoder outputs.
 
@@ -177,9 +179,10 @@ class Seq2SeqDecoder(Block):
         raise NotImplementedError
 
     def forward(self, step_input, states, valid_length=None):  #pylint: disable=arguments-differ
-        """Given the inputs and the context computed by the encoder,
-        generate the new states. This is usually used in the training phase where we set the inputs
-        to be the target sequence.
+        """Given the inputs and the context computed by the encoder, generate the new states.
+
+        Used in the training phase where we set the inputs to be the target
+        sequence.
 
         Parameters
         ----------
@@ -197,6 +200,7 @@ class Seq2SeqDecoder(Block):
             The new states of the decoder
         additional_outputs : list
             Additional outputs of the decoder, e.g, the attention weights
+
         """
         raise NotImplementedError
 
@@ -207,6 +211,7 @@ class Seq2SeqOneStepDecoder(Block):
     In the forward function, it generates the one-step-ahead decoding output.
 
     """
+
     def init_state_from_encoder(self, encoder_outputs, encoder_valid_length=None):
         r"""Generates the initial decoder states based on the encoder outputs.
 

--- a/src/gluonnlp/model/train/__init__.py
+++ b/src/gluonnlp/model/train/__init__.py
@@ -26,8 +26,7 @@ from .cache import *
 from .embedding import *
 from .language_model import *
 
-__all__ = language_model.__all__ + cache.__all__ + embedding.__all__ + \
-    ['get_cache_model']
+__all__ = language_model.__all__ + cache.__all__ + embedding.__all__ + ['get_cache_model']
 
 
 def get_cache_model(name, dataset_name='wikitext-2', window=2000,

--- a/src/gluonnlp/model/translation.py
+++ b/src/gluonnlp/model/translation.py
@@ -37,9 +37,11 @@ class NMTModel(Block):
     encoder : Seq2SeqEncoder
         Encoder that encodes the input sentence.
     decoder : Seq2SeqDecoder
-        Decoder that generates the predictions based on the output of the encoder.
+        Decoder used during training phase. The decoder generates predictions
+        based on the output of the encoder.
     one_step_ahead_decoder : Seq2SeqOneStepDecoder
-        Decoder that generates the one-step ahead prediction based on the output of the encoder.
+        One-step ahead decoder used during inference phase. The decoder
+        generates predictions based on the output of the encoder.
     embed_size : int or None, default None
         Size of the embedding vectors. It is used to generate the source and target embeddings
         if src_embed and tgt_embed are None.

--- a/src/gluonnlp/model/translation.py
+++ b/src/gluonnlp/model/translation.py
@@ -38,6 +38,8 @@ class NMTModel(Block):
         Encoder that encodes the input sentence.
     decoder : Seq2SeqDecoder
         Decoder that generates the predictions based on the output of the encoder.
+    one_step_ahead_decoder : Seq2SeqOneStepDecoder
+        Decoder that generates the one-step ahead prediction based on the output of the encoder.
     embed_size : int or None, default None
         Size of the embedding vectors. It is used to generate the source and target embeddings
         if src_embed and tgt_embed are None.
@@ -63,7 +65,7 @@ class NMTModel(Block):
     params : ParameterDict or None
         See document of `Block`.
     """
-    def __init__(self, src_vocab, tgt_vocab, encoder, decoder,
+    def __init__(self, src_vocab, tgt_vocab, encoder, decoder, one_step_ahead_decoder,
                  embed_size=None, embed_dropout=0.0, embed_initializer=mx.init.Uniform(0.1),
                  src_embed=None, tgt_embed=None, share_embed=False, tie_weights=False,
                  tgt_proj=None, prefix=None, params=None):
@@ -72,6 +74,7 @@ class NMTModel(Block):
         self.src_vocab = src_vocab
         self.encoder = encoder
         self.decoder = decoder
+        self.one_step_ahead_decoder = one_step_ahead_decoder
         self._shared_embed = share_embed
         if embed_dropout is None:
             embed_dropout = 0.0
@@ -158,10 +161,8 @@ class NMTModel(Block):
         additional_outputs : list
             Additional outputs of the decoder, e.g, the attention weights
         """
-        outputs, states, additional_outputs =\
-            self.decoder.decode_seq(inputs=self.tgt_embed(inputs),
-                                    states=states,
-                                    valid_length=valid_length)
+        outputs, states, additional_outputs = self.decoder(self.tgt_embed(inputs), states,
+                                                           valid_length)
         outputs = self.tgt_proj(outputs)
         return outputs, states, additional_outputs
 
@@ -183,7 +184,7 @@ class NMTModel(Block):
             Additional outputs of the step, e.g, the attention weights
         """
         step_output, states, step_additional_outputs =\
-            self.decoder(self.tgt_embed(step_input), states)
+            self.one_step_ahead_decoder(self.tgt_embed(step_input), states)
         step_output = self.tgt_proj(step_output)
         return step_output, states, step_additional_outputs
 

--- a/tests/unittest/test_models.py
+++ b/tests/unittest/test_models.py
@@ -73,30 +73,27 @@ def test_big_text_models(wikitext2_val_and_counter):
 
 @pytest.mark.serial
 @pytest.mark.remote_required
-def test_transformer_models():
-    models = ['transformer_en_de_512']
-    pretrained_to_test = {'transformer_en_de_512': 'WMT2014'}
-    dropout_rates = [0.1, 0.0]
+@pytest.mark.parametrize('dropout_rate', [0.1, 0.0])
+@pytest.mark.parametrize('model_dataset', [('transformer_en_de_512', 'WMT2014')])
+def test_transformer_models(dropout_rate, model_dataset):
+    model_name, pretrained_dataset = model_dataset
     src = mx.nd.ones((2, 10))
     tgt = mx.nd.ones((2, 8))
     valid_len = mx.nd.ones((2,))
-    for model_name in models:
-        for rate in dropout_rates:
-            eprint('testing forward for %s, dropout rate %f' % (model_name, rate))
-            pretrained_dataset = pretrained_to_test.get(model_name)
-            with warnings.catch_warnings():  # TODO https://github.com/dmlc/gluon-nlp/issues/978
-                warnings.simplefilter("ignore")
-                model, _, _ = nlp.model.get_model(model_name, dataset_name=pretrained_dataset,
-                                                  pretrained=pretrained_dataset is not None,
-                                                  dropout=rate)
+    eprint('testing forward for %s, dropout rate %f' % (model_name, dropout_rate))
+    with warnings.catch_warnings():  # TODO https://github.com/dmlc/gluon-nlp/issues/978
+        warnings.simplefilter("ignore")
+        model, _, _ = nlp.model.get_model(model_name, dataset_name=pretrained_dataset,
+                                          pretrained=pretrained_dataset is not None,
+                                          dropout=dropout_rate)
 
-            print(model)
-            if not pretrained_dataset:
-                model.initialize()
-            output, state = model(src, tgt, src_valid_length=valid_len, tgt_valid_length=valid_len)
-            output.wait_to_read()
-            del model
-            mx.nd.waitall()
+    print(model)
+    if not pretrained_dataset:
+        model.initialize()
+    output, state = model(src, tgt, src_valid_length=valid_len, tgt_valid_length=valid_len)
+    output.wait_to_read()
+    del model
+    mx.nd.waitall()
 
 
 @pytest.mark.serial


### PR DESCRIPTION
## Description ##
In the current Gluon API, each HybridBlock has to serve one puropse and can only
define a single callable interface. Previous Seq2SeqDecoder interface required
each Seq2SeqDecoder Block to perform two functionalities (multi-step ahead and
single-step ahead decoding). This means neither of the two functionalities can
in practice be hybridized completely. Thus use two separate Blocks for the two
functionalities. They may share parameters.

Update the NMTModel API accordingly.

Further refactor TransformerDecoder to make it completely hybridizable.
TransformerOneStepDecoder still relies on a small hack but can be hybridized
completely when we enable numpy shape semantics.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Refactor TransformerDecoder

## Comments ##


cc @dmlc/gluon-nlp-team
