### PR TITLE
[CI] Test warnings

### DIFF
--- a/docs/api/notes/data_api.rst
+++ b/docs/api/notes/data_api.rst
@@ -158,7 +158,7 @@ lengths in the minibatch, which allows the fast tensor manipulation in GPU.
 
 .. code:: python
 
-   >>> batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(axis=0),
+   >>> batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(axis=0, pad_val=0),
    >>>                                       nlp.data.batchify.Stack())
 
 :class:`~gluonnlp.data.batchify.Tuple` wraps multiple batchify functions and applies each input function on each input field,

--- a/docs/examples/machine_translation/gnmt.md
+++ b/docs/examples/machine_translation/gnmt.md
@@ -277,12 +277,12 @@ is to construct the sampler and `DataLoader`. The first step is to use the `batc
 function, which pads and stacks sequences to form mini-batches.
 
 ```{.python .input}
-train_batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(),
-                                            nlp.data.batchify.Pad(),
+train_batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(pad_val=0),
+                                            nlp.data.batchify.Pad(pad_val=0),
                                             nlp.data.batchify.Stack(dtype='float32'),
                                             nlp.data.batchify.Stack(dtype='float32'))
-test_batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(),
-                                           nlp.data.batchify.Pad(),
+test_batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(pad_val=0),
+                                           nlp.data.batchify.Pad(pad_val=0),
                                            nlp.data.batchify.Stack(dtype='float32'),
                                            nlp.data.batchify.Stack(dtype='float32'),
                                            nlp.data.batchify.Stack())

--- a/docs/examples/machine_translation/transformer.md
+++ b/docs/examples/machine_translation/transformer.md
@@ -121,8 +121,8 @@ Now, we have obtained the transformed datasets. The next step is to construct th
 
 ```{.python .input}
 wmt_test_batchify_fn = nlp.data.batchify.Tuple(
-    nlp.data.batchify.Pad(),
-    nlp.data.batchify.Pad(),
+    nlp.data.batchify.Pad(pad_val=0),
+    nlp.data.batchify.Pad(pad_val=0),
     nlp.data.batchify.Stack(dtype='float32'),
     nlp.data.batchify.Stack(dtype='float32'),
     nlp.data.batchify.Stack())

--- a/docs/examples/sentence_embedding/elmo_sentence_representation.md
+++ b/docs/examples/sentence_embedding/elmo_sentence_representation.md
@@ -109,7 +109,7 @@ For more advanced usage examples of the DataLoader object, check out the
 
 ```{.python .input}
 batch_size = 2
-dataset_batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(),
+dataset_batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(pad_val=0),
                                               nlp.data.batchify.Stack())
 data_loader = gluon.data.DataLoader(dataset,
                                     batch_size=batch_size,

--- a/docs/examples/sentence_embedding/self_attentive_sentence_embedding.md
+++ b/docs/examples/sentence_embedding/self_attentive_sentence_embedding.md
@@ -172,7 +172,7 @@ def get_dataloader():
 
     # Construct the DataLoader Pad data, stack label and lengths
     batchify_fn = nlp.data.batchify.Tuple(
-        nlp.data.batchify.Pad(axis=0),
+        nlp.data.batchify.Pad(axis=0, pad_val=0),
         nlp.data.batchify.Stack())
 
     # In this example, we use a FixedBucketSampler,

--- a/docs/examples/sentiment_analysis/sentiment_analysis.md
+++ b/docs/examples/sentiment_analysis/sentiment_analysis.md
@@ -195,7 +195,7 @@ def get_dataloader():
 
     # Pad data, stack label and lengths
     batchify_fn = nlp.data.batchify.Tuple(
-        nlp.data.batchify.Pad(axis=0, ret_length=True),
+        nlp.data.batchify.Pad(axis=0, pad_val=0, ret_length=True),
         nlp.data.batchify.Stack(dtype='float32'))
     batch_sampler = nlp.data.sampler.FixedBucketSampler(
         train_data_lengths,

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,6 @@ markers =
 
 env =
     MXNET_HOME=tests/data
+
+filterwarnings =
+    error

--- a/scripts/bert/finetune_icsl.py
+++ b/scripts/bert/finetune_icsl.py
@@ -328,10 +328,10 @@ def train(args):
     dev_data_bert = dev_data.transform(idsl_transform, lazy=False)
     test_data_bert = test_data.transform(idsl_transform, lazy=False)
     # Construct the DataLoader
-    batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(pad_val=0),    # Subword ID
-                                          nlp.data.batchify.Pad(pad_val=0),    # Subword Mask
-                                          nlp.data.batchify.Pad(pad_val=0),    # Beginning of subword
-                                          nlp.data.batchify.Pad(pad_val=0),    # Tag IDs
+    batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(pad_val=0),  # Subword ID
+                                          nlp.data.batchify.Pad(pad_val=0),  # Subword Mask
+                                          nlp.data.batchify.Pad(pad_val=0),  # Beginning of subword
+                                          nlp.data.batchify.Pad(pad_val=0),  # Tag IDs
                                           nlp.data.batchify.Stack(),  # Intent Label
                                           nlp.data.batchify.Stack())  # Valid Length
     train_batch_sampler = nlp.data.sampler.SortedBucketSampler(

--- a/scripts/bert/finetune_icsl.py
+++ b/scripts/bert/finetune_icsl.py
@@ -328,10 +328,10 @@ def train(args):
     dev_data_bert = dev_data.transform(idsl_transform, lazy=False)
     test_data_bert = test_data.transform(idsl_transform, lazy=False)
     # Construct the DataLoader
-    batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(),    # Subword ID
-                                          nlp.data.batchify.Pad(),    # Subword Mask
-                                          nlp.data.batchify.Pad(),    # Beginning of subword
-                                          nlp.data.batchify.Pad(),    # Tag IDs
+    batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(pad_val=0),    # Subword ID
+                                          nlp.data.batchify.Pad(pad_val=0),    # Subword Mask
+                                          nlp.data.batchify.Pad(pad_val=0),    # Beginning of subword
+                                          nlp.data.batchify.Pad(pad_val=0),    # Tag IDs
                                           nlp.data.batchify.Stack(),  # Intent Label
                                           nlp.data.batchify.Stack())  # Valid Length
     train_batch_sampler = nlp.data.sampler.SortedBucketSampler(

--- a/scripts/machine_translation/dataprocessor.py
+++ b/scripts/machine_translation/dataprocessor.py
@@ -217,12 +217,12 @@ def get_dataloader(data_set, args, dataset_type,
     data_lengths = get_data_lengths(data_set)
 
     if dataset_type == 'train':
-        train_batchify_fn = btf.Tuple(btf.Pad(), btf.Pad(),
+        train_batchify_fn = btf.Tuple(btf.Pad(pad_val=0), btf.Pad(pad_val=0),
                                       btf.Stack(dtype='float32'), btf.Stack(dtype='float32'))
 
     else:
         data_lengths = list(map(lambda x: x[-1], data_lengths))
-        test_batchify_fn = btf.Tuple(btf.Pad(), btf.Pad(),
+        test_batchify_fn = btf.Tuple(btf.Pad(pad_val=0), btf.Pad(pad_val=0),
                                      btf.Stack(dtype='float32'), btf.Stack(dtype='float32'),
                                      btf.Stack())
 

--- a/scripts/machine_translation/dataset.py
+++ b/scripts/machine_translation/dataset.py
@@ -23,10 +23,8 @@ __all__ = ['TOY']
 import os
 from gluonnlp.base import get_home_dir
 from gluonnlp.data.translation import _TranslationDataset, _get_pair_key
-from gluonnlp.data.registry import register
 
 
-@register(segment=['train', 'val', 'test'])
 class TOY(_TranslationDataset):
     """A Small Translation Dataset for Testing Scripts.
 

--- a/scripts/natural_language_inference/dataset.py
+++ b/scripts/natural_language_inference/dataset.py
@@ -66,7 +66,7 @@ def prepare_data_loader(args, dataset, vocab, test=False):
                                 lazy=False)
 
     # Batching
-    batchify_fn = btf.Tuple(btf.Pad(), btf.Pad(), btf.Stack(dtype='int32'))
+    batchify_fn = btf.Tuple(btf.Pad(pad_val=0), btf.Pad(pad_val=0), btf.Stack(dtype='int32'))
     data_lengths = [max(len(d[0]), len(d[1])) for d in dataset]
     batch_sampler = nlp.data.FixedBucketSampler(lengths=data_lengths,
                                                 batch_size=args.batch_size,

--- a/scripts/sentiment_analysis/finetune_lm.py
+++ b/scripts/sentiment_analysis/finetune_lm.py
@@ -182,7 +182,7 @@ valid_dataset, valid_data_lengths = preprocess_dataset(valid_dataset)
 test_dataset, test_data_lengths = preprocess_dataset(test_dataset)
 
 # Construct the DataLoader. Pad data and stack label
-batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(axis=0, ret_length=True),
+batchify_fn = nlp.data.batchify.Tuple(nlp.data.batchify.Pad(axis=0, pad_val=0, ret_length=True),
                                       nlp.data.batchify.Stack(dtype='float32'))
 if args.bucket_type is None:
     print('Bucketing strategy is not used!')

--- a/scripts/tests/test_dataprocessor.py
+++ b/scripts/tests/test_dataprocessor.py
@@ -39,18 +39,16 @@ def test_toy():
     assert len(train_en_de) == 30
     assert len(val_en_de) == 30
     assert len(test_en_de) == 30
-    with warnings.catch_warnings(record=True) as w:  # TODO https://github.com/dmlc/gluon-nlp/issues/978
+    with warnings.catch_warnings():  # TODO https://github.com/dmlc/gluon-nlp/issues/978
+        warnings.simplefilter("ignore")
         en_vocab, de_vocab = train_en_de.src_vocab, train_en_de.tgt_vocab
-        assert len(w) == 1
-        assert 'corrupted index in the deserialize vocabulary' in str(w[-1].message)
     assert len(en_vocab) == 358
     assert len(de_vocab) == 381
     train_de_en = TOY(segment='train', src_lang='de', tgt_lang='en',
                       root='tests/data/translation_test')
-    with warnings.catch_warnings(record=True) as w:  # TODO https://github.com/dmlc/gluon-nlp/issues/978
+    with warnings.catch_warnings():  # TODO https://github.com/dmlc/gluon-nlp/issues/978
+        warnings.simplefilter("ignore")
         de_vocab, en_vocab = train_de_en.src_vocab, train_de_en.tgt_vocab
-        assert len(w) == 1
-        assert 'corrupted index in the deserialize vocabulary' in str(w[-1].message)
     assert len(en_vocab) == 358
     assert len(de_vocab) == 381
     for i in range(10):
@@ -71,10 +69,9 @@ def test_translation_preprocess():
         data_val = TOY('val', src_lang=src_lang, tgt_lang=tgt_lang)
 
         # TODO https://github.com/dmlc/gluon-nlp/issues/978
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
             src_vocab, tgt_vocab = data_train.src_vocab, data_train.tgt_vocab
-            assert len(w) == 1
-            assert 'corrupted index in the deserialize vocabulary' in str(w[-1].message)
         data_val_processed = process_dataset(data_val, src_vocab, tgt_vocab,
                                              src_max_len, tgt_max_len)
         for (src, tgt), (preprocessed_src, preprocessed_tgt) in zip(data_val, data_val_processed):

--- a/scripts/tests/test_dataprocessor.py
+++ b/scripts/tests/test_dataprocessor.py
@@ -17,11 +17,12 @@
 
 """Test DataProcessor."""
 
-
 import sys
 import os
-import pytest
+import warnings
 import time
+
+import pytest
 
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'machine_translation'))
 
@@ -38,12 +39,18 @@ def test_toy():
     assert len(train_en_de) == 30
     assert len(val_en_de) == 30
     assert len(test_en_de) == 30
-    en_vocab, de_vocab = train_en_de.src_vocab, train_en_de.tgt_vocab
+    with warnings.catch_warnings(record=True) as w:  # TODO https://github.com/dmlc/gluon-nlp/issues/978
+        en_vocab, de_vocab = train_en_de.src_vocab, train_en_de.tgt_vocab
+        assert len(w) == 1
+        assert 'corrupted index in the deserialize vocabulary' in str(w[-1].message)
     assert len(en_vocab) == 358
     assert len(de_vocab) == 381
     train_de_en = TOY(segment='train', src_lang='de', tgt_lang='en',
                       root='tests/data/translation_test')
-    de_vocab, en_vocab = train_de_en.src_vocab, train_de_en.tgt_vocab
+    with warnings.catch_warnings(record=True) as w:  # TODO https://github.com/dmlc/gluon-nlp/issues/978
+        de_vocab, en_vocab = train_de_en.src_vocab, train_de_en.tgt_vocab
+        assert len(w) == 1
+        assert 'corrupted index in the deserialize vocabulary' in str(w[-1].message)
     assert len(en_vocab) == 358
     assert len(de_vocab) == 381
     for i in range(10):
@@ -62,7 +69,12 @@ def test_translation_preprocess():
     for (src_max_len, tgt_max_len) in max_lens:
         data_train = TOY('train', src_lang=src_lang, tgt_lang=tgt_lang)
         data_val = TOY('val', src_lang=src_lang, tgt_lang=tgt_lang)
-        src_vocab, tgt_vocab = data_train.src_vocab, data_train.tgt_vocab
+
+        # TODO https://github.com/dmlc/gluon-nlp/issues/978
+        with warnings.catch_warnings(record=True) as w:
+            src_vocab, tgt_vocab = data_train.src_vocab, data_train.tgt_vocab
+            assert len(w) == 1
+            assert 'corrupted index in the deserialize vocabulary' in str(w[-1].message)
         data_val_processed = process_dataset(data_val, src_vocab, tgt_vocab,
                                              src_max_len, tgt_max_len)
         for (src, tgt), (preprocessed_src, preprocessed_tgt) in zip(data_val, data_val_processed):

--- a/scripts/tests/test_encoder_decoder.py
+++ b/scripts/tests/test_encoder_decoder.py
@@ -24,7 +24,7 @@ from gluonnlp.model.transformer import TransformerDecoder
 
 
 def test_gnmt_encoder():
-    ctx = mx.Context.current_context()
+    ctx = mx.current_context()
     for cell_type in ["lstm", "gru", "relu_rnn", "tanh_rnn"]:
         for num_layers, num_bi_layers in [(2, 1), (3, 0)]:
             for use_residual in [False, True]:
@@ -51,7 +51,7 @@ def test_gnmt_encoder():
 
 
 def test_gnmt_encoder_decoder():
-    ctx = mx.Context.current_context()
+    ctx = mx.current_context()
     num_hidden = 8
     encoder = GNMTEncoder(cell_type="lstm", num_layers=3, num_bi_layers=1, hidden_size=num_hidden,
                           dropout=0.0, use_residual=True, prefix='gnmt_encoder_')
@@ -99,7 +99,7 @@ def test_gnmt_encoder_decoder():
                         assert(len(additional_outputs) == 0)
 
 def test_transformer_encoder():
-    ctx = mx.Context.current_context()
+    ctx = mx.current_context()
     for num_layers in range(1, 3):
         for output_attention in [True, False]:
             for use_residual in [False, True]:
@@ -137,7 +137,7 @@ def test_transformer_encoder():
                             assert(len(additional_outputs) == 0)
 
 def test_transformer_encoder_decoder():
-    ctx = mx.Context.current_context()
+    ctx = mx.current_context()
     units = 16
     encoder = TransformerEncoder(num_layers=3, units=units, hidden_size=32, num_heads=8, max_length=10,
                                  dropout=0.0, use_residual=True, prefix='transformer_encoder_')

--- a/scripts/tests/test_encoder_decoder.py
+++ b/scripts/tests/test_encoder_decoder.py
@@ -24,7 +24,7 @@ from gluonnlp.model.transformer import TransformerDecoder
 
 
 def test_gnmt_encoder():
-    ctx = mx.Context.default_ctx
+    ctx = mx.Context.current_context()
     for cell_type in ["lstm", "gru", "relu_rnn", "tanh_rnn"]:
         for num_layers, num_bi_layers in [(2, 1), (3, 0)]:
             for use_residual in [False, True]:
@@ -51,7 +51,7 @@ def test_gnmt_encoder():
 
 
 def test_gnmt_encoder_decoder():
-    ctx = mx.Context.default_ctx
+    ctx = mx.Context.current_context()
     num_hidden = 8
     encoder = GNMTEncoder(cell_type="lstm", num_layers=3, num_bi_layers=1, hidden_size=num_hidden,
                           dropout=0.0, use_residual=True, prefix='gnmt_encoder_')
@@ -99,7 +99,7 @@ def test_gnmt_encoder_decoder():
                         assert(len(additional_outputs) == 0)
 
 def test_transformer_encoder():
-    ctx = mx.Context.default_ctx
+    ctx = mx.Context.current_context()
     for num_layers in range(1, 3):
         for output_attention in [True, False]:
             for use_residual in [False, True]:
@@ -137,7 +137,7 @@ def test_transformer_encoder():
                             assert(len(additional_outputs) == 0)
 
 def test_transformer_encoder_decoder():
-    ctx = mx.Context.default_ctx
+    ctx = mx.Context.current_context()
     units = 16
     encoder = TransformerEncoder(num_layers=3, units=units, hidden_size=32, num_heads=8, max_length=10,
                                  dropout=0.0, use_residual=True, prefix='transformer_encoder_')

--- a/scripts/text_classification/fasttext_word_ngram.py
+++ b/scripts/text_classification/fasttext_word_ngram.py
@@ -285,7 +285,7 @@ def get_dataloader(train_dataset, train_data_lengths,
     """ Construct the DataLoader. Pad data, stack label and lengths"""
     bucket_num, bucket_ratio = 20, 0.2
     batchify_fn = gluonnlp.data.batchify.Tuple(
-        gluonnlp.data.batchify.Pad(axis=0, ret_length=True),
+        gluonnlp.data.batchify.Pad(axis=0, pad_val=0, ret_length=True),
         gluonnlp.data.batchify.Stack(dtype='float32'))
     batch_sampler = gluonnlp.data.sampler.FixedBucketSampler(
         train_data_lengths,

--- a/scripts/word_embeddings/model.py
+++ b/scripts/word_embeddings/model.py
@@ -85,8 +85,7 @@ class Net(mx.gluon.HybridBlock):
                 dtype=dtype)
 
             self.negatives_sampler = nlp.data.UnigramCandidateSampler(
-                weights=negatives_weights**smoothing, shape=(batch_size, ),
-                dtype='int64')
+                weights=negatives_weights**smoothing, dtype='int64')
 
     def __getitem__(self, tokens):
         return self.embedding[tokens]

--- a/src/gluonnlp/data/batchify/batchify.py
+++ b/src/gluonnlp/data/batchify/batchify.py
@@ -187,7 +187,7 @@ class Pad:
     >>> a = [1, 2, 3, 4]
     >>> b = [4, 5, 6]
     >>> c = [8, 2]
-    >>> bf.Pad()([a, b, c])
+    >>> bf.Pad(pad_val=0)([a, b, c])
     <BLANKLINE>
     [[1. 2. 3. 4.]
      [4. 5. 6. 0.]
@@ -197,7 +197,7 @@ class Pad:
     >>> a = [1, 2, 3, 4]
     >>> b = [4, 5, 6]
     >>> c = [8, 2]
-    >>> batch, length = bf.Pad(ret_length=True)([a, b, c])
+    >>> batch, length = bf.Pad(pad_val=0, ret_length=True)([a, b, c])
     >>> batch
     <BLANKLINE>
     [[1. 2. 3. 4.]
@@ -306,7 +306,7 @@ class Tuple:
     >>> a = ([1, 2, 3, 4], 0)
     >>> b = ([5, 7], 1)
     >>> c = ([1, 2, 3, 4, 5, 6, 7], 0)
-    >>> f1, f2 = bf.Tuple(bf.Pad(), bf.Stack())([a, b])
+    >>> f1, f2 = bf.Tuple(bf.Pad(pad_val=0), bf.Stack())([a, b])
     >>> f1
     <BLANKLINE>
     [[1. 2. 3. 4.]
@@ -404,7 +404,7 @@ class Dict:
     >>> a = {'data': [1, 2, 3, 4], 'label': 0}
     >>> b = {'data': [5, 7], 'label': 1}
     >>> c = {'data': [1, 2, 3, 4, 5, 6, 7], 'label': 0}
-    >>> batchify_fn = Dict({'data': Pad(), 'label': Stack()})
+    >>> batchify_fn = Dict({'data': Pad(pad_val=0), 'label': Stack()})
     >>> sample = batchify_fn([a, b, c])
     >>> sample['data']
     <BLANKLINE>
@@ -474,7 +474,7 @@ class NamedTuple:
     >>> a = SampleData([1, 2, 3, 4], 0)
     >>> b = SampleData([5, 7], 1)
     >>> c = SampleData([1, 2, 3, 4, 5, 6, 7], 0)
-    >>> batchify_fn = NamedTuple(SampleData, {'data': Pad(), 'label': Stack()})
+    >>> batchify_fn = NamedTuple(SampleData, {'data': Pad(pad_val=0), 'label': Stack()})
     >>> sample = batchify_fn([a, b, c])
     >>> sample
     SampleData(data=
@@ -491,7 +491,7 @@ class NamedTuple:
      [1. 2. 3. 4. 5. 6. 7.]]
     <NDArray 3x7 @cpu_shared(0)>
     >>> # Let's consider to use a list
-    >>> batchify_fn = NamedTuple(SampleData, [Pad(), Stack()])
+    >>> batchify_fn = NamedTuple(SampleData, [Pad(pad_val=0), Stack()])
     >>> batchify_fn([a, b, c])
     SampleData(data=
     [[1. 2. 3. 4. 0. 0. 0.]

--- a/src/gluonnlp/data/candidate_sampler.py
+++ b/src/gluonnlp/data/candidate_sampler.py
@@ -36,10 +36,6 @@ class UnigramCandidateSampler(mx.gluon.HybridBlock):
     weights : mx.nd.NDArray
         Unnormalized class probabilities. Samples are drawn and returned on the
         same context as weights.context.
-    shape : int or tuple of int
-        Shape of data to be sampled.
-        TODO: Specifying the shape is only a workaround until random_like
-        operators are available in mxnet
     dtype : str or np.dtype, default 'float32'
         Data type of the candidates. Make sure that the dtype precision is
         large enough to represent the size of your weights array precisely. For
@@ -49,7 +45,6 @@ class UnigramCandidateSampler(mx.gluon.HybridBlock):
 
     def __init__(self, weights, shape, dtype='float32'):
         super(UnigramCandidateSampler, self).__init__()
-        self._shape = shape
         self._dtype = dtype
         self.N = weights.size
 
@@ -108,8 +103,6 @@ class UnigramCandidateSampler(mx.gluon.HybridBlock):
         ----------
         candidates_like: mxnet.nd.NDArray or mxnet.sym.Symbol
             This input specifies the shape of the to be sampled candidates. #
-            TODO shape selection is not yet supported. Shape must be specified
-            in the constructor.
 
         Returns
         -------
@@ -118,15 +111,13 @@ class UnigramCandidateSampler(mx.gluon.HybridBlock):
             are sampled based on the weights specified on creation of the
             UnigramCandidateSampler.
         """
-        flat_shape = functools.reduce(operator.mul, self._shape)
-        idx = F.random.uniform(low=0, high=self.N, shape=flat_shape,
-                               dtype='float64').floor()
+        candidates_flat = candidates_like.reshape((-1, ))
+        idx = F.random.uniform_like(candidates_flat, low=0, high=self.N, dtype='float64').floor()
         prob = F.gather_nd(prob, idx.reshape((1, -1)))
         alias = F.gather_nd(alias, idx.reshape((1, -1)))
-        where = F.random.uniform(shape=flat_shape,
-                                 dtype='float64') < prob
+        where = F.random.uniform_like(candidates_flat, dtype='float64') < prob
         hit = idx * where
         alt = alias * (1 - where)
-        candidates = (hit + alt).reshape(self._shape)
+        candidates = (hit + alt).reshape_like(candidates_like)
 
         return candidates.astype(self._dtype)

--- a/src/gluonnlp/data/candidate_sampler.py
+++ b/src/gluonnlp/data/candidate_sampler.py
@@ -108,11 +108,11 @@ class UnigramCandidateSampler(mx.gluon.HybridBlock):
             are sampled based on the weights specified on creation of the
             UnigramCandidateSampler.
         """
-        candidates_flat = candidates_like.reshape((-1, ))
-        idx = F.random.uniform_like(candidates_flat, low=0, high=self.N, dtype='float64').floor()
+        candidates_flat = candidates_like.reshape((-1, )).astype('float64')
+        idx = F.random.uniform_like(candidates_flat, low=0, high=self.N).floor()
         prob = F.gather_nd(prob, idx.reshape((1, -1)))
         alias = F.gather_nd(alias, idx.reshape((1, -1)))
-        where = F.random.uniform_like(candidates_flat, dtype='float64') < prob
+        where = F.random.uniform_like(candidates_flat) < prob
         hit = idx * where
         alt = alias * (1 - where)
         candidates = (hit + alt).reshape_like(candidates_like)

--- a/src/gluonnlp/data/candidate_sampler.py
+++ b/src/gluonnlp/data/candidate_sampler.py
@@ -18,9 +18,6 @@
 
 __all__ = ['UnigramCandidateSampler']
 
-import functools
-import operator
-
 import mxnet as mx
 import numpy as np
 
@@ -43,7 +40,7 @@ class UnigramCandidateSampler(mx.gluon.HybridBlock):
 
     """
 
-    def __init__(self, weights, shape, dtype='float32'):
+    def __init__(self, weights, dtype='float32'):
         super(UnigramCandidateSampler, self).__init__()
         self._dtype = dtype
         self.N = weights.size

--- a/src/gluonnlp/data/glue.py
+++ b/src/gluonnlp/data/glue.py
@@ -276,7 +276,10 @@ class GlueQQP(_GlueDataset):
 
     Examples
     --------
-    >>> qqp_dev = gluonnlp.data.GlueQQP('dev', root='./datasets/qqp')
+    >>> with warnings.catch_warnings():
+    >>>     # Ignore warnings triggered by invalid entries in GlueQQP dev set
+    >>>     warnings.simplefilter("ignore")
+    >>>     qqp_dev = gluonnlp.data.GlueQQP('dev', root='./datasets/qqp')
     -etc-
     >>> len(qqp_dev)
     40430

--- a/src/gluonnlp/data/glue.py
+++ b/src/gluonnlp/data/glue.py
@@ -277,7 +277,7 @@ class GlueQQP(_GlueDataset):
     Examples
     --------
     >>> import warnings
-    ... with warnings.catch_warnings():
+    >>> with warnings.catch_warnings():
     ...     # Ignore warnings triggered by invalid entries in GlueQQP dev set
     ...     warnings.simplefilter("ignore")
     ...     qqp_dev = gluonnlp.data.GlueQQP('dev', root='./datasets/qqp')

--- a/src/gluonnlp/data/glue.py
+++ b/src/gluonnlp/data/glue.py
@@ -277,9 +277,9 @@ class GlueQQP(_GlueDataset):
     Examples
     --------
     >>> with warnings.catch_warnings():
-    >>>     # Ignore warnings triggered by invalid entries in GlueQQP dev set
-    >>>     warnings.simplefilter("ignore")
-    >>>     qqp_dev = gluonnlp.data.GlueQQP('dev', root='./datasets/qqp')
+    ...     # Ignore warnings triggered by invalid entries in GlueQQP dev set
+    ...     warnings.simplefilter("ignore")
+    ...     qqp_dev = gluonnlp.data.GlueQQP('dev', root='./datasets/qqp')
     -etc-
     >>> len(qqp_dev)
     40430

--- a/src/gluonnlp/data/glue.py
+++ b/src/gluonnlp/data/glue.py
@@ -276,7 +276,8 @@ class GlueQQP(_GlueDataset):
 
     Examples
     --------
-    >>> with warnings.catch_warnings():
+    >>> import warnings
+    ... with warnings.catch_warnings():
     ...     # Ignore warnings triggered by invalid entries in GlueQQP dev set
     ...     warnings.simplefilter("ignore")
     ...     qqp_dev = gluonnlp.data.GlueQQP('dev', root='./datasets/qqp')

--- a/src/gluonnlp/data/transforms.py
+++ b/src/gluonnlp/data/transforms.py
@@ -1026,7 +1026,7 @@ class BERTSPTokenizer(BERTTokenizer):
         Examples
         --------
         >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-682b5d15.bpe'
-        >>> f = gluon.utils.download(url, overwrite=True)
+        >>> f = gluon.utils.download(url, sha1sum='682b5d159a036e984bd0053fa92162bbd926cab8')
         -etc-
         >>> bert_vocab = gluonnlp.vocab.BERTVocab.from_sentencepiece(f)
         >>> sp_tokenizer = BERTSPTokenizer(f, bert_vocab, lower=True)

--- a/src/gluonnlp/data/transforms.py
+++ b/src/gluonnlp/data/transforms.py
@@ -519,7 +519,8 @@ class SentencepieceTokenizer(_SentencepieceProcessor):
     Examples
     --------
     >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-0690baed.bpe'
-    >>> f = gluon.utils.download(url, overwrite=True)
+    >>> sha1 = '0690baed966b28dc38330b122d4d51b7e41b4efe'  # optionally specify expected hash
+    >>> f = gluon.utils.download(url, sha1_hash=sha1)
     -etc-
     >>> tokenizer = gluonnlp.data.SentencepieceTokenizer(f)
     >>> detokenizer = gluonnlp.data.SentencepieceDetokenizer(f)
@@ -569,7 +570,8 @@ class SentencepieceDetokenizer(_SentencepieceProcessor):
     Examples
     --------
     >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-0690baed.bpe'
-    >>> f = gluon.utils.download(url, overwrite=True)
+    >>> sha1 = '0690baed966b28dc38330b122d4d51b7e41b4efe'  # optionally specify expected hash
+    >>> f = gluon.utils.download(url, sha1_hash=sha1)
     -etc-
     >>> tokenizer = gluonnlp.data.SentencepieceTokenizer(f)
     >>> detokenizer = gluonnlp.data.SentencepieceDetokenizer(f)
@@ -958,7 +960,8 @@ class BERTSPTokenizer(BERTTokenizer):
     Examples
     --------
     >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-682b5d15.bpe'
-    >>> f = gluon.utils.download(url, overwrite=True)
+    >>> sha1 = '682b5d159a036e984bd0053fa92162bbd926cab8'  # optionally specify expected hash
+    >>> f = gluon.utils.download(url, sha1_hash=sha1)
     -etc-
     >>> bert_vocab = gluonnlp.vocab.BERTVocab.from_sentencepiece(f)
     >>> sp_tokenizer = BERTSPTokenizer(f, bert_vocab, lower=True)
@@ -1026,7 +1029,8 @@ class BERTSPTokenizer(BERTTokenizer):
         Examples
         --------
         >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-682b5d15.bpe'
-        >>> f = gluon.utils.download(url, sha1sum='682b5d159a036e984bd0053fa92162bbd926cab8')
+        >>> sha1 = '682b5d159a036e984bd0053fa92162bbd926cab8'  # optionally specify expected hash
+        >>> f = gluon.utils.download(url, sha1_hash=sha1)
         -etc-
         >>> bert_vocab = gluonnlp.vocab.BERTVocab.from_sentencepiece(f)
         >>> sp_tokenizer = BERTSPTokenizer(f, bert_vocab, lower=True)

--- a/src/gluonnlp/data/transforms.py
+++ b/src/gluonnlp/data/transforms.py
@@ -521,7 +521,6 @@ class SentencepieceTokenizer(_SentencepieceProcessor):
     >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-0690baed.bpe'
     >>> sha1 = '0690baed966b28dc38330b122d4d51b7e41b4efe'  # optionally specify expected hash
     >>> f = gluon.utils.download(url, sha1_hash=sha1)
-    -etc-
     >>> tokenizer = gluonnlp.data.SentencepieceTokenizer(f)
     >>> detokenizer = gluonnlp.data.SentencepieceDetokenizer(f)
     >>> sentence = 'This is a very awesome, life-changing sentence.'
@@ -572,7 +571,6 @@ class SentencepieceDetokenizer(_SentencepieceProcessor):
     >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-0690baed.bpe'
     >>> sha1 = '0690baed966b28dc38330b122d4d51b7e41b4efe'  # optionally specify expected hash
     >>> f = gluon.utils.download(url, sha1_hash=sha1)
-    -etc-
     >>> tokenizer = gluonnlp.data.SentencepieceTokenizer(f)
     >>> detokenizer = gluonnlp.data.SentencepieceDetokenizer(f)
     >>> sentence = 'This is a very awesome, life-changing sentence.'
@@ -962,7 +960,6 @@ class BERTSPTokenizer(BERTTokenizer):
     >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-682b5d15.bpe'
     >>> sha1 = '682b5d159a036e984bd0053fa92162bbd926cab8'  # optionally specify expected hash
     >>> f = gluon.utils.download(url, sha1_hash=sha1)
-    -etc-
     >>> bert_vocab = gluonnlp.vocab.BERTVocab.from_sentencepiece(f)
     >>> sp_tokenizer = BERTSPTokenizer(f, bert_vocab, lower=True)
     >>> sentence = 'Better is to bow than break.'
@@ -1031,7 +1028,6 @@ class BERTSPTokenizer(BERTTokenizer):
         >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-682b5d15.bpe'
         >>> sha1 = '682b5d159a036e984bd0053fa92162bbd926cab8'  # optionally specify expected hash
         >>> f = gluon.utils.download(url, sha1_hash=sha1)
-        -etc-
         >>> bert_vocab = gluonnlp.vocab.BERTVocab.from_sentencepiece(f)
         >>> sp_tokenizer = BERTSPTokenizer(f, bert_vocab, lower=True)
         >>> sp_tokenizer('Better is to bow than break.')

--- a/src/gluonnlp/data/transforms.py
+++ b/src/gluonnlp/data/transforms.py
@@ -521,6 +521,7 @@ class SentencepieceTokenizer(_SentencepieceProcessor):
     >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-0690baed.bpe'
     >>> sha1 = '0690baed966b28dc38330b122d4d51b7e41b4efe'  # optionally specify expected hash
     >>> f = gluon.utils.download(url, sha1_hash=sha1)
+    -etc-
     >>> tokenizer = gluonnlp.data.SentencepieceTokenizer(f)
     >>> detokenizer = gluonnlp.data.SentencepieceDetokenizer(f)
     >>> sentence = 'This is a very awesome, life-changing sentence.'
@@ -960,6 +961,7 @@ class BERTSPTokenizer(BERTTokenizer):
     >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-682b5d15.bpe'
     >>> sha1 = '682b5d159a036e984bd0053fa92162bbd926cab8'  # optionally specify expected hash
     >>> f = gluon.utils.download(url, sha1_hash=sha1)
+    -etc-
     >>> bert_vocab = gluonnlp.vocab.BERTVocab.from_sentencepiece(f)
     >>> sp_tokenizer = BERTSPTokenizer(f, bert_vocab, lower=True)
     >>> sentence = 'Better is to bow than break.'

--- a/src/gluonnlp/data/transforms.py
+++ b/src/gluonnlp/data/transforms.py
@@ -519,8 +519,7 @@ class SentencepieceTokenizer(_SentencepieceProcessor):
     Examples
     --------
     >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-0690baed.bpe'
-    >>> sha1 = '0690baed966b28dc38330b122d4d51b7e41b4efe'  # optionally specify expected hash
-    >>> f = gluon.utils.download(url, sha1_hash=sha1)
+    >>> f = gluon.utils.download(url)
     -etc-
     >>> tokenizer = gluonnlp.data.SentencepieceTokenizer(f)
     >>> detokenizer = gluonnlp.data.SentencepieceDetokenizer(f)
@@ -529,6 +528,7 @@ class SentencepieceTokenizer(_SentencepieceProcessor):
     ['▁This', '▁is', '▁a', '▁very', '▁awesome', ',', '▁life', '-', 'ch', 'anging', '▁sentence', '.']
     >>> detokenizer(tokenizer(sentence))
     'This is a very awesome, life-changing sentence.'
+    >>> os.remove('test-0690baed.bpe')
 
     """
 
@@ -570,8 +570,8 @@ class SentencepieceDetokenizer(_SentencepieceProcessor):
     Examples
     --------
     >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-0690baed.bpe'
-    >>> sha1 = '0690baed966b28dc38330b122d4d51b7e41b4efe'  # optionally specify expected hash
-    >>> f = gluon.utils.download(url, sha1_hash=sha1)
+    >>> f = gluon.utils.download(url)
+    -etc-
     >>> tokenizer = gluonnlp.data.SentencepieceTokenizer(f)
     >>> detokenizer = gluonnlp.data.SentencepieceDetokenizer(f)
     >>> sentence = 'This is a very awesome, life-changing sentence.'
@@ -579,6 +579,7 @@ class SentencepieceDetokenizer(_SentencepieceProcessor):
     ['▁This', '▁is', '▁a', '▁very', '▁awesome', ',', '▁life', '-', 'ch', 'anging', '▁sentence', '.']
     >>> detokenizer(tokenizer(sentence))
     'This is a very awesome, life-changing sentence.'
+    >>> os.remove('test-0690baed.bpe')
 
     """
 
@@ -959,14 +960,14 @@ class BERTSPTokenizer(BERTTokenizer):
     Examples
     --------
     >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-682b5d15.bpe'
-    >>> sha1 = '682b5d159a036e984bd0053fa92162bbd926cab8'  # optionally specify expected hash
-    >>> f = gluon.utils.download(url, sha1_hash=sha1)
+    >>> f = gluon.utils.download(url)
     -etc-
     >>> bert_vocab = gluonnlp.vocab.BERTVocab.from_sentencepiece(f)
     >>> sp_tokenizer = BERTSPTokenizer(f, bert_vocab, lower=True)
     >>> sentence = 'Better is to bow than break.'
     >>> sp_tokenizer(sentence)
     ['▁better', '▁is', '▁to', '▁b', 'ow', '▁than', '▁brea', 'k', '▁', '.']
+    >>> os.remove('test-682b5d15.bpe')
     """
 
     _special_prefix = '▁'
@@ -1028,8 +1029,8 @@ class BERTSPTokenizer(BERTTokenizer):
         Examples
         --------
         >>> url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-682b5d15.bpe'
-        >>> sha1 = '682b5d159a036e984bd0053fa92162bbd926cab8'  # optionally specify expected hash
-        >>> f = gluon.utils.download(url, sha1_hash=sha1)
+        >>> f = gluon.utils.download(url)
+        -etc-
         >>> bert_vocab = gluonnlp.vocab.BERTVocab.from_sentencepiece(f)
         >>> sp_tokenizer = BERTSPTokenizer(f, bert_vocab, lower=True)
         >>> sp_tokenizer('Better is to bow than break.')
@@ -1038,6 +1039,7 @@ class BERTSPTokenizer(BERTTokenizer):
         True
         >>> sp_tokenizer.is_first_subword('ow')
         False
+        >>> os.remove('test-682b5d15.bpe')
         """
         return token.startswith(BERTSPTokenizer._special_prefix)
 

--- a/src/gluonnlp/data/word_embedding_evaluation.py
+++ b/src/gluonnlp/data/word_embedding_evaluation.py
@@ -624,7 +624,6 @@ class BakerVerb143(WordSimilarityEvaluationDataset):
         'verb_similarity dataset.txt':
         'd7e4820c7504cbae56898353e4d94e6408c330fc'
     }
-    _verify_ssl = False  # ie.technion.ac.il serves an invalid cert as of 2018-04-16
 
     min = 0
     max = 1

--- a/src/gluonnlp/embedding/token_embedding.py
+++ b/src/gluonnlp/embedding/token_embedding.py
@@ -1310,7 +1310,7 @@ class Word2Vec(TokenEmbedding):
                     warnings.warn('line {} in {}: failed to decode. Skipping.'
                                   .format(line_num, pretrained_file_path))
                     continue
-                elems = np.fromstring(f.read(binary_len), dtype=np.float32)
+                elems = np.frombuffer(f.read(binary_len), dtype=np.float32)
 
                 assert len(elems) > 1, 'line {} in {}: unexpected data format.'.format(
                     line_num, pretrained_file_path)

--- a/src/gluonnlp/embedding/token_embedding.py
+++ b/src/gluonnlp/embedding/token_embedding.py
@@ -690,25 +690,27 @@ class TokenEmbedding:
 
         if self.allow_extend:
             # Add new / previously unknown tokens
+            len_before = len(self._token_to_idx)
             for token in tokens:
-                if not token in self._token_to_idx:
+                if token not in self._token_to_idx:
                     idx = len(self._token_to_idx)
                     self._token_to_idx[token] = idx
                     self._idx_to_token.append(token)
 
-            num_extended = len(self._token_to_idx) - self.idx_to_vec.shape[0]
-            if num_extended == 1:
-                warnings.warn(
-                    'When adding new tokens via TokenEmbedding.__setitem__ '
-                    'the internal embedding matrix needs to be reallocated. '
-                    'Users are therefore encouraged to batch their updates '
-                    '(i.e. add multiple new tokens at a time).')
+            num_extended = len(self._token_to_idx) - len_before
+            if num_extended >= 1:
+                if num_extended == 1:
+                    warnings.warn(
+                        'When adding new tokens via TokenEmbedding.__setitem__ '
+                        'the internal embedding matrix needs to be reallocated. '
+                        'Users are therefore encouraged to batch their updates '
+                        '(i.e. add multiple new tokens at a time).')
 
-            # Extend shape of idx_to_vec
-            idx_to_vec = nd.zeros(shape=(len(self._token_to_idx),
-                                         self.idx_to_vec.shape[1]))
-            idx_to_vec[:self.idx_to_vec.shape[0]] = self._idx_to_vec
-            self._idx_to_vec = idx_to_vec
+                # Extend shape of idx_to_vec
+                idx_to_vec = nd.zeros(shape=(len(self._token_to_idx),
+                                             self.idx_to_vec.shape[1]))
+                idx_to_vec[:self.idx_to_vec.shape[0]] = self._idx_to_vec
+                self._idx_to_vec = idx_to_vec
 
         indices = []
         for token in tokens:

--- a/src/gluonnlp/vocab/subwords.py
+++ b/src/gluonnlp/vocab/subwords.py
@@ -224,14 +224,16 @@ class NGramHashes(SubwordFunction):
     @staticmethod
     def fasttext_hash_asbytes(ngram, encoding='utf-8'):
         ngram_enc = memoryview(ngram.encode(encoding))
-        return _fasttext_hash(ngram_enc)
+        with np.errstate(over='ignore'):  # overflow in uint_scalars is expected
+            return _fasttext_hash(ngram_enc)
 
     def _word_to_hashes(self, word):
         if word not in self.special_tokens:
             word_enc = bytearray(('<' + word + '>').encode('utf-8'))
-            hashes = _fasttext_ngram_hashes(
-                memoryview(word_enc), ns=self._ngrams,
-                bucket_size=self.num_subwords)
+            with np.errstate(over='ignore'):  # overflow in uint_scalars is expected
+                hashes = _fasttext_ngram_hashes(
+                    memoryview(word_enc), ns=self._ngrams,
+                    bucket_size=self.num_subwords)
         else:
             hashes = []
         return hashes

--- a/tests/unittest/batchify/test_batchify.py
+++ b/tests/unittest/batchify/test_batchify.py
@@ -187,8 +187,10 @@ def test_pad_wrap_batchify():
                                                for shape in shapes]
                             batchify_fn = batchify.Pad(axis=axis, pad_val=pad_val, ret_length=True, dtype=_dtype)
                             batch_data, valid_length = batchify_fn(random_data_npy)
-                            batch_data_use_mx, valid_length_use_mx = batchify_fn(
-                                [mx.nd.array(ele, dtype=dtype) for ele in random_data_npy])
+                            with pytest.warns(UserWarning):
+                                # UserWarning: Using Pad with NDArrays is discouraged for speed reasons.
+                                batch_data_use_mx, valid_length_use_mx = batchify_fn(
+                                    [mx.nd.array(ele, dtype=dtype) for ele in random_data_npy])
                             assert_allclose(valid_length_use_mx.asnumpy(), valid_length.asnumpy())
                             assert batch_data.dtype == batch_data_use_mx.dtype == _dtype
                             assert valid_length.dtype == valid_length_use_mx.dtype == np.int32

--- a/tests/unittest/batchify/test_batchify.py
+++ b/tests/unittest/batchify/test_batchify.py
@@ -64,9 +64,16 @@ def test_dict():
 
 
 def test_pad():
-    padded = batchify.Pad(pad_val=-1)([mx.nd.array([]), mx.nd.arange(1)]).asnumpy().flatten().tolist()
+    with pytest.warns(UserWarning):
+        # UserWarning: Using Pad with NDArrays is discouraged for speed reasons.
+        padded = batchify.Pad(pad_val=-1)([mx.nd.array([]),
+                                           mx.nd.arange(1)]).asnumpy().flatten().tolist()
     assert padded == [-1.0, 0.0]
-    padded = batchify.Pad(pad_val=-1, round_to=2)([mx.nd.array([]), mx.nd.arange(1)]).asnumpy().flatten().tolist()
+    with pytest.warns(UserWarning):
+        # UserWarning: Using Pad with NDArrays is discouraged for speed reasons.
+        padded = batchify.Pad(pad_val=-1,
+                              round_to=2)([mx.nd.array([]),
+                                           mx.nd.arange(1)]).asnumpy().flatten().tolist()
     assert padded == [-1.0, -1.0, 0.0, -1.0]
 
 
@@ -110,8 +117,10 @@ def test_pad_wrap_batchify():
                                                for shape in shapes]
                             batchify_fn = batchify.Pad(axis=axis, pad_val=pad_val, ret_length=True, dtype=_dtype)
                             batch_data, valid_length = batchify_fn(random_data_npy)
-                            batch_data_use_mx, valid_length_use_mx = batchify_fn(
-                                [mx.nd.array(ele, dtype=dtype) for ele in random_data_npy])
+                            with pytest.warns(UserWarning):
+                                # UserWarning: Using Pad with NDArrays is discouraged for speed reasons.
+                                batch_data_use_mx, valid_length_use_mx = batchify_fn(
+                                    [mx.nd.array(ele, dtype=dtype) for ele in random_data_npy])
                             assert_allclose(batch_data_use_mx.asnumpy(), batch_data.asnumpy())
                             assert_allclose(valid_length_use_mx.asnumpy(), valid_length.asnumpy())
                             assert batch_data.dtype == batch_data_use_mx.dtype == dtype

--- a/tests/unittest/batchify/test_batchify.py
+++ b/tests/unittest/batchify/test_batchify.py
@@ -12,28 +12,28 @@ def test_list():
     passthrough = batchify.List()(data)
     assert passthrough == data
 
-TestNamedTuple = namedtuple('TestNamedTuple', ['data', 'label'])
+MyNamedTuple = namedtuple('MyNamedTuple', ['data', 'label'])
 
 
 def test_named_tuple():
-    a = TestNamedTuple([1, 2, 3, 4], 0)
-    b = TestNamedTuple([5, 7], 1)
-    c = TestNamedTuple([1, 2, 3, 4, 5, 6, 7], 0)
+    a = MyNamedTuple([1, 2, 3, 4], 0)
+    b = MyNamedTuple([5, 7], 1)
+    c = MyNamedTuple([1, 2, 3, 4, 5, 6, 7], 0)
     with pytest.raises(ValueError):
-        wrong_batchify_fn = batchify.NamedTuple(TestNamedTuple, {'data0': batchify.Pad(), 'label': batchify.Stack()})
+        wrong_batchify_fn = batchify.NamedTuple(MyNamedTuple, {'data0': batchify.Pad(), 'label': batchify.Stack()})
     with pytest.raises(ValueError):
-        wrong_batchify_fn = batchify.NamedTuple(TestNamedTuple, [batchify.Pad(), batchify.Stack(), batchify.Stack()])
+        wrong_batchify_fn = batchify.NamedTuple(MyNamedTuple, [batchify.Pad(), batchify.Stack(), batchify.Stack()])
     with pytest.raises(ValueError):
-        wrong_batchify_fn = batchify.NamedTuple(TestNamedTuple, (batchify.Pad(),))
+        wrong_batchify_fn = batchify.NamedTuple(MyNamedTuple, (batchify.Pad(),))
     with pytest.raises(ValueError):
-        wrong_batchify_fn = batchify.NamedTuple(TestNamedTuple, [1, 2])
-    for batchify_fn in [batchify.NamedTuple(TestNamedTuple, {'data': batchify.Pad(), 'label': batchify.Stack()}),
-                        batchify.NamedTuple(TestNamedTuple, [batchify.Pad(), batchify.Stack()]),
-                        batchify.NamedTuple(TestNamedTuple, (batchify.Pad(), batchify.Stack()))]:
+        wrong_batchify_fn = batchify.NamedTuple(MyNamedTuple, [1, 2])
+    for batchify_fn in [batchify.NamedTuple(MyNamedTuple, {'data': batchify.Pad(), 'label': batchify.Stack()}),
+                        batchify.NamedTuple(MyNamedTuple, [batchify.Pad(), batchify.Stack()]),
+                        batchify.NamedTuple(MyNamedTuple, (batchify.Pad(), batchify.Stack()))]:
         sample = batchify_fn([a, b, c])
         gt_data = batchify.Pad()([a[0], b[0], c[0]])
         gt_label = batchify.Stack()([a[1], b[1], c[1]])
-        assert isinstance(sample, TestNamedTuple)
+        assert isinstance(sample, MyNamedTuple)
         assert_allclose(sample.data.asnumpy(), gt_data.asnumpy())
         assert_allclose(sample.label.asnumpy(), gt_label.asnumpy())
         with pytest.raises(ValueError):
@@ -47,7 +47,7 @@ def test_dict():
     with pytest.raises(ValueError):
         wrong_batchify_fn = batchify.Dict([batchify.Pad(), batchify.Stack()])
     with pytest.raises(ValueError):
-        wrong_batchify_fn = batchify.NamedTuple(TestNamedTuple, {'a': 1, 'b': 2})
+        wrong_batchify_fn = batchify.NamedTuple(MyNamedTuple, {'a': 1, 'b': 2})
     batchify_fn = batchify.Dict({'data': batchify.Pad(), 'label': batchify.Stack()})
     sample = batchify_fn([a, b, c])
     gt_data = batchify.Pad()([a['data'], b['data'], c['data']])

--- a/tests/unittest/batchify/test_batchify.py
+++ b/tests/unittest/batchify/test_batchify.py
@@ -20,18 +20,24 @@ def test_named_tuple():
     b = MyNamedTuple([5, 7], 1)
     c = MyNamedTuple([1, 2, 3, 4, 5, 6, 7], 0)
     with pytest.raises(ValueError):
-        wrong_batchify_fn = batchify.NamedTuple(MyNamedTuple, {'data0': batchify.Pad(), 'label': batchify.Stack()})
+        wrong_batchify_fn = batchify.NamedTuple(MyNamedTuple, {
+            'data0': batchify.Pad(pad_val=0),
+            'label': batchify.Stack()
+        })
     with pytest.raises(ValueError):
-        wrong_batchify_fn = batchify.NamedTuple(MyNamedTuple, [batchify.Pad(), batchify.Stack(), batchify.Stack()])
+        wrong_batchify_fn = batchify.NamedTuple(
+            MyNamedTuple,
+            [batchify.Pad(pad_val=0), batchify.Stack(),
+             batchify.Stack()])
     with pytest.raises(ValueError):
-        wrong_batchify_fn = batchify.NamedTuple(MyNamedTuple, (batchify.Pad(),))
+        wrong_batchify_fn = batchify.NamedTuple(MyNamedTuple, (batchify.Pad(pad_val=0), ))
     with pytest.raises(ValueError):
         wrong_batchify_fn = batchify.NamedTuple(MyNamedTuple, [1, 2])
-    for batchify_fn in [batchify.NamedTuple(MyNamedTuple, {'data': batchify.Pad(), 'label': batchify.Stack()}),
-                        batchify.NamedTuple(MyNamedTuple, [batchify.Pad(), batchify.Stack()]),
-                        batchify.NamedTuple(MyNamedTuple, (batchify.Pad(), batchify.Stack()))]:
+    for batchify_fn in [batchify.NamedTuple(MyNamedTuple, {'data': batchify.Pad(pad_val=0), 'label': batchify.Stack()}),
+                        batchify.NamedTuple(MyNamedTuple, [batchify.Pad(pad_val=0), batchify.Stack()]),
+                        batchify.NamedTuple(MyNamedTuple, (batchify.Pad(pad_val=0), batchify.Stack()))]:
         sample = batchify_fn([a, b, c])
-        gt_data = batchify.Pad()([a[0], b[0], c[0]])
+        gt_data = batchify.Pad(pad_val=0)([a[0], b[0], c[0]])
         gt_label = batchify.Stack()([a[1], b[1], c[1]])
         assert isinstance(sample, MyNamedTuple)
         assert_allclose(sample.data.asnumpy(), gt_data.asnumpy())
@@ -45,12 +51,12 @@ def test_dict():
     b = {'data': [5, 7], 'label': 1}
     c = {'data': [1, 2, 3, 4, 5, 6, 7], 'label': 0}
     with pytest.raises(ValueError):
-        wrong_batchify_fn = batchify.Dict([batchify.Pad(), batchify.Stack()])
+        wrong_batchify_fn = batchify.Dict([batchify.Pad(pad_val=0), batchify.Stack()])
     with pytest.raises(ValueError):
         wrong_batchify_fn = batchify.NamedTuple(MyNamedTuple, {'a': 1, 'b': 2})
-    batchify_fn = batchify.Dict({'data': batchify.Pad(), 'label': batchify.Stack()})
+    batchify_fn = batchify.Dict({'data': batchify.Pad(pad_val=0), 'label': batchify.Stack()})
     sample = batchify_fn([a, b, c])
-    gt_data = batchify.Pad()([a['data'], b['data'], c['data']])
+    gt_data = batchify.Pad(pad_val=0)([a['data'], b['data'], c['data']])
     gt_label = batchify.Stack()([a['label'], b['label'], c['label']])
     assert isinstance(sample, dict)
     assert_allclose(sample['data'].asnumpy(), gt_data.asnumpy())
@@ -175,4 +181,3 @@ def test_pad_wrap_batchify():
                             assert_allclose(valid_length_use_mx.asnumpy(), valid_length.asnumpy())
                             assert batch_data.dtype == batch_data_use_mx.dtype == _dtype
                             assert valid_length.dtype == valid_length_use_mx.dtype == np.int32
-

--- a/tests/unittest/batchify/test_batchify.py
+++ b/tests/unittest/batchify/test_batchify.py
@@ -150,9 +150,11 @@ def test_pad_wrap_batchify():
                                         batchify_fn.append(batchify.Stack(dtype=_dtype))
                                 batchify_fn = batchify.Tuple(batchify_fn)
                                 ret_use_npy = batchify_fn(random_data_npy)
-                                ret_use_mx = batchify_fn(
-                                    [tuple(mx.nd.array(ele[i], dtype=dtype) for i in range(TOTAL_ELE_NUM)) for ele in
-                                     random_data_npy])
+                                with pytest.warns(UserWarning):
+                                    # Using Pad with NDArrays is discouraged for speed reasons.
+                                    ret_use_mx = batchify_fn([tuple(mx.nd.array(ele[i], dtype=dtype)
+                                                                    for i in range(TOTAL_ELE_NUM))
+                                                              for ele in random_data_npy])
                                 for i in range(TOTAL_ELE_NUM):
                                     if i in pad_index:
                                         assert ret_use_npy[i][0].dtype == ret_use_mx[i][0].dtype == dtype

--- a/tests/unittest/test_candidate_sampler.py
+++ b/tests/unittest/test_candidate_sampler.py
@@ -8,7 +8,7 @@ from gluonnlp.data import candidate_sampler as cs
 @pytest.mark.seed(1)
 def test_unigram_candidate_sampler(hybridize):
     N = 1000
-    sampler = cs.UnigramCandidateSampler(mx.nd.arange(N), shape=(3, ))
+    sampler = cs.UnigramCandidateSampler(mx.nd.arange(N))
     sampler.initialize()
     if hybridize:
         sampler.hybridize()

--- a/tests/unittest/test_datasets.py
+++ b/tests/unittest/test_datasets.py
@@ -437,12 +437,16 @@ def test_iwlst2015():
     assert len(val_en_vi) == 1553
     assert len(test_en_vi) == 1268
 
-    en_vocab, vi_vocab = train_en_vi.src_vocab, train_en_vi.tgt_vocab
+    with warnings.catch_warnings():  # TODO https://github.com/dmlc/gluon-nlp/issues/978
+        warnings.simplefilter("ignore")
+        en_vocab, vi_vocab = train_en_vi.src_vocab, train_en_vi.tgt_vocab
     assert len(en_vocab) == 17191
     assert len(vi_vocab) == 7709
 
     train_vi_en = nlp.data.IWSLT2015(segment='train', src_lang='vi', tgt_lang='en')
-    vi_vocab, en_vocab = train_vi_en.src_vocab, train_vi_en.tgt_vocab
+    with warnings.catch_warnings():  # TODO https://github.com/dmlc/gluon-nlp/issues/978
+        warnings.simplefilter("ignore")
+        vi_vocab, en_vocab = train_vi_en.src_vocab, train_vi_en.tgt_vocab
     assert len(en_vocab) == 17191
     assert len(vi_vocab) == 7709
     for i in range(10):

--- a/tests/unittest/test_datasets.py
+++ b/tests/unittest/test_datasets.py
@@ -20,6 +20,7 @@ import datetime
 import os
 import io
 import random
+import warnings
 
 from flaky import flaky
 import mxnet as mx
@@ -476,7 +477,9 @@ def test_wmt2016bpe():
     newstest_2012_2015 = nlp.data.WMT2016BPE(segment=['newstest%d' %i for i in range(2012, 2016)],
                                              src_lang='en', tgt_lang='de')
     assert len(newstest_2012_2015) == 3003 + 3000 + 3003 + 2169
-    en_vocab, de_vocab = train.src_vocab, train.tgt_vocab
+    with warnings.catch_warnings():  # TODO https://github.com/dmlc/gluon-nlp/issues/978
+        warnings.simplefilter("ignore")
+        en_vocab, de_vocab = train.src_vocab, train.tgt_vocab
     assert len(en_vocab) == 36548
     assert len(de_vocab) == 36548
 
@@ -513,7 +516,9 @@ def test_wmt2014bpe():
     newstest_2009_2013 = nlp.data.WMT2014BPE(segment=['newstest%d' %i for i in range(2009, 2014)],
                                              src_lang='en', tgt_lang='de')
     assert len(newstest_2009_2013) == 2525 + 2489 + 3003 + 3003 + 3000
-    en_vocab, de_vocab = train.src_vocab, train.tgt_vocab
+    with warnings.catch_warnings():  # TODO https://github.com/dmlc/gluon-nlp/issues/978
+        warnings.simplefilter("ignore")
+        en_vocab, de_vocab = train.src_vocab, train.tgt_vocab
     assert len(en_vocab) == 36794
     assert len(de_vocab) == 36794
 
@@ -698,7 +703,10 @@ def test_numpy_dataset():
 @pytest.mark.serial
 @pytest.mark.remote_required
 def test_glue_data(cls, name, segment, length, fields):
-    dataset = cls(segment=segment)
+    with warnings.catch_warnings():
+        if cls is nlp.data.GlueQQP:  # QQP contains incomplete samples and raises warnings
+            warnings.simplefilter("ignore")
+        dataset = cls(segment=segment)
     assert len(dataset) == length, len(dataset)
 
     for i, x in enumerate(dataset):

--- a/tests/unittest/test_datasets.py
+++ b/tests/unittest/test_datasets.py
@@ -555,6 +555,7 @@ def test_load_dev_squad():
 ###############################################################################
 # Intent Classification and Slot Labeling
 ###############################################################################
+@pytest.mark.serial
 @pytest.mark.remote_required
 @pytest.mark.parametrize('dataset,segment,expected_samples', [
     ('atis', 'train', 4478),

--- a/tests/unittest/test_models.py
+++ b/tests/unittest/test_models.py
@@ -18,6 +18,7 @@
 
 import os
 import sys
+import warnings
 
 import mxnet as mx
 import pytest
@@ -83,9 +84,11 @@ def test_transformer_models():
         for rate in dropout_rates:
             eprint('testing forward for %s, dropout rate %f' % (model_name, rate))
             pretrained_dataset = pretrained_to_test.get(model_name)
-            model, _, _ = nlp.model.get_model(model_name, dataset_name=pretrained_dataset,
-                                              pretrained=pretrained_dataset is not None,
-                                              dropout=rate)
+            with warnings.catch_warnings():  # TODO https://github.com/dmlc/gluon-nlp/issues/978
+                warnings.simplefilter("ignore")
+                model, _, _ = nlp.model.get_model(model_name, dataset_name=pretrained_dataset,
+                                                  pretrained=pretrained_dataset is not None,
+                                                  dropout=rate)
 
             print(model)
             if not pretrained_dataset:

--- a/tests/unittest/test_models.py
+++ b/tests/unittest/test_models.py
@@ -504,7 +504,6 @@ def test_big_rnn_model_share_params():
     eval_model = nlp.model.language_model.BigRNN(vocab_size, 2, 3, 4, 5, 0.1, prefix='bigrnn',
                                                  params=model.collect_params())
     eval_model.hybridize()
-    eval_model.initialize(mx.init.Xavier(), ctx=ctx)
     pred, hidden = eval_model(x, hidden)
     assert pred.shape == (seq_len, batch_size, vocab_size)
     mx.nd.waitall()

--- a/tests/unittest/test_sampler.py
+++ b/tests/unittest/test_sampler.py
@@ -1,9 +1,11 @@
-import pytest
+import warnings
+
 import numpy as np
+import pytest
 from mxnet.gluon import data
+
 import gluonnlp as nlp
 from gluonnlp.data import sampler as s
-
 
 N = 1000
 def test_sorted_sampler():
@@ -27,13 +29,13 @@ def test_sorted_sampler():
 @pytest.mark.parametrize('num_shards', range(4))
 def test_fixed_bucket_sampler(seq_lengths, ratio, shuffle, num_buckets, bucket_scheme,
                               use_average_length, num_shards):
-    sampler = s.FixedBucketSampler(seq_lengths,
-                                   batch_size=8,
-                                   num_buckets=num_buckets,
-                                   ratio=ratio, shuffle=shuffle,
-                                   use_average_length=use_average_length,
-                                   bucket_scheme=bucket_scheme,
-                                   num_shards=num_shards)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sampler = s.FixedBucketSampler(seq_lengths, batch_size=8, num_buckets=num_buckets,
+                                       ratio=ratio, shuffle=shuffle,
+                                       use_average_length=use_average_length,
+                                       bucket_scheme=bucket_scheme, num_shards=num_shards)
+
     print(sampler.stats())
     total_sampled_ids = []
     for batch_sample_ids in sampler:
@@ -49,8 +51,10 @@ def test_fixed_bucket_sampler(seq_lengths, ratio, shuffle, num_buckets, bucket_s
 @pytest.mark.parametrize('shuffle', [False, True])
 def test_fixed_bucket_sampler_with_single_key(bucket_keys, ratio, shuffle):
     seq_lengths = [np.random.randint(10, 100) for _ in range(N)]
-    sampler = s.FixedBucketSampler(seq_lengths, batch_size=8, num_buckets=None,
-                                   bucket_keys=bucket_keys, ratio=ratio, shuffle=shuffle)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sampler = s.FixedBucketSampler(seq_lengths, batch_size=8, num_buckets=None,
+                                       bucket_keys=bucket_keys, ratio=ratio, shuffle=shuffle)
     print(sampler.stats())
     total_sampled_ids = []
     for batch_sample_ids in sampler:
@@ -64,8 +68,10 @@ def test_fixed_bucket_sampler_with_single_key(bucket_keys, ratio, shuffle):
 @pytest.mark.parametrize('shuffle', [False, True])
 def test_fixed_bucket_sampler_with_single_key(bucket_keys, ratio, shuffle):
     seq_lengths = [(np.random.randint(10, 100), np.random.randint(10, 100)) for _ in range(N)]
-    sampler = s.FixedBucketSampler(seq_lengths, batch_size=8, num_buckets=None,
-                                   bucket_keys=bucket_keys, ratio=ratio, shuffle=shuffle)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sampler = s.FixedBucketSampler(seq_lengths, batch_size=8, num_buckets=None,
+                                       bucket_keys=bucket_keys, ratio=ratio, shuffle=shuffle)
     print(sampler.stats())
     total_sampled_ids = []
     for batch_sample_ids in sampler:

--- a/tests/unittest/test_token_embedding.py
+++ b/tests/unittest/test_token_embedding.py
@@ -89,13 +89,18 @@ def test_token_embedding_constructor(unknown_token, init_unknown_vec, allow_exte
 
         if allow_extend:
             emb = TokenEmbedding()
-            emb[unknown_token] = mx.nd.zeros(embsize) - 1
+            if not unknown_token:
+                with pytest.warns(UserWarning):  # UserWarning: encouraged to batch updates
+                    emb[unknown_token] = mx.nd.zeros(embsize) - 1
+            else:
+                emb[unknown_token] = mx.nd.zeros(embsize) - 1
             assert emb.idx_to_vec.shape[1] == embsize
             test_serialization(emb)
 
             emb = TokenEmbedding()
             with pytest.warns(UserWarning):  # UserWarning: encouraged to batch updates
-                emb['<some_token>'] = mx.nd.zeros(embsize) - 1
+                val = mx.nd.zeros(embsize) - 1
+                emb['<some_token>'] = val
             assert emb.idx_to_vec.shape[0] == 2 if unknown_token else emb.idx_to_vec.shape[0] == 1
             assert (emb['<some_token>'].asnumpy() == (mx.nd.zeros(embsize) - 1).asnumpy()).all()
             test_serialization(emb)
@@ -115,12 +120,17 @@ def test_token_embedding_constructor(unknown_token, init_unknown_vec, allow_exte
 
         if allow_extend:
             emb = TokenEmbedding()
-            emb[unknown_token] = mx.nd.zeros(embsize) - 1
+            if not unknown_token:
+                with pytest.warns(UserWarning):  # UserWarning: encouraged to batch updates
+                    emb[unknown_token] = mx.nd.zeros(embsize) - 1
+            else:
+                emb[unknown_token] = mx.nd.zeros(embsize) - 1
             assert emb.idx_to_vec.shape[1] == embsize
             test_serialization(emb)
 
             emb = TokenEmbedding()
-            emb['<some_token>'] = mx.nd.zeros(embsize) - 1
+            with pytest.warns(UserWarning):  # UserWarning: encouraged to batch updates
+                emb['<some_token>'] = mx.nd.zeros(embsize) - 1
             assert (emb['<some_token>'].asnumpy() == (mx.nd.zeros(embsize) - 1).asnumpy()).all()
 
             if unknown_token and unknown_token not in idx_to_token:

--- a/tests/unittest/test_transforms.py
+++ b/tests/unittest/test_transforms.py
@@ -291,7 +291,7 @@ def test_bert_sentencepiece_sentences_transform():
     # token ids
     assert all(processed[0] == np.array(token_ids, dtype='int32'))
     # sequence length
-    assert np.asscalar(processed[1]) == len(tokens) + 2
+    assert processed[1].item() == len(tokens) + 2
     # segment id
     assert all(processed[2] == np.array([0] * max_len, dtype='int32'))
 

--- a/tests/unittest/test_transforms.py
+++ b/tests/unittest/test_transforms.py
@@ -253,7 +253,10 @@ def test_bert_sentences_transform():
 @pytest.mark.remote_required
 def test_bert_sentencepiece_sentences_transform():
     url = 'http://repo.mxnet.io/gluon/dataset/vocab/test-682b5d15.bpe'
-    f = download(url, overwrite=True)
+    with warnings.catch_warnings():
+        # UserWarning: File test-682b5d15.bpe exists in file system so the downloaded file is deleted
+        warnings.simplefilter("ignore")
+        f = download(url, overwrite=True)
     bert_vocab = BERTVocab.from_sentencepiece(f)
     bert_tokenizer = t.BERTSPTokenizer(f, bert_vocab, lower=True)
     assert bert_tokenizer.is_first_subword(u'▁this')

--- a/tests/unittest/test_utils.py
+++ b/tests/unittest/test_utils.py
@@ -134,6 +134,7 @@ def test_version():
     past_version = '0.1.2'
     with pytest.raises(AssertionError):
         nlp.utils.check_version(future_version, warning_only=False)
-    nlp.utils.check_version(future_version, warning_only=True)
+    with pytest.raises(UserWarning):
+        nlp.utils.check_version(future_version, warning_only=True)
     nlp.utils.check_version(past_version, warning_only=False)
     nlp.utils.check_version(past_version, warning_only=True)

--- a/tests/unittest/test_vocab_embed.py
+++ b/tests/unittest/test_vocab_embed.py
@@ -406,7 +406,8 @@ def test_token_embedding_from_file(tmpdir, allow_extend):
     my_embed['a'] = nd.array([1, 2, 3, 4, 5])
     assert_almost_equal(my_embed['a'].asnumpy(), np.array([1, 2, 3, 4, 5]))
     if allow_extend:
-        my_embed['unknown$$$'] = nd.array([0, 0, 0, 0, 0])
+        with pytest.warns(UserWarning):  # Should add multiple new tokens at a time
+            my_embed['unknown$$$'] = nd.array([0, 0, 0, 0, 0])
         assert_almost_equal(my_embed['unknown$$$'].asnumpy(), np.array([0, 0, 0, 0, 0]))
     else:
         with pytest.raises(KeyError):
@@ -893,9 +894,12 @@ def test_token_embedding_from_file_S3_with_custom_unknown_token(unknown_token):
 def test_token_embedding_from_S3_fasttext_with_ngrams(load_ngrams):
     embed = nlp.embedding.create('fasttext', source='wiki.simple',
                                  load_ngrams=load_ngrams, unknown_token=None)
-
     if load_ngrams:
-        embed['$$$unknownword$$$']
+        with warnings.catch_warnings():
+            #  'RuntimeWarning: overflow encountered in uint_scalars' is
+            #  expected when running without numba
+            warnings.simplefilter("ignore")
+            embed['$$$unknownword$$$']
     else:
         with pytest.raises(KeyError):
             embed['$$$unknownword$$$']
@@ -979,7 +983,8 @@ def test_token_embedding_unknown_lookup(setinconstructor, lookup,
         assert 'hello' not in token_embedding.token_to_idx
 
         if allow_extend:
-            token_embedding['hello'] = token_embedding.unknown_lookup['hello']
+            with pytest.warns(UserWarning):  # encouraged to batch their updates
+                token_embedding['hello'] = token_embedding.unknown_lookup['hello']
             assert 'hello' in token_embedding.token_to_idx
             assert np.all(np.isclose(1, token_embedding['hello'].asnumpy()))
 
@@ -1012,11 +1017,13 @@ def test_token_embedding_manual_extension(initializeidxtovecbyextending,
 
     # Uninitialized token_embedding._idx_to_vec based
     token_embedding = TokEmb()
-    token_embedding['hello'] = nd.zeros(shape=(1, 5))
+    with pytest.warns(UserWarning):  # encouraged to batch their updates
+        token_embedding['hello'] = nd.zeros(shape=(1, 5))
     assert np.all(np.isclose(0, token_embedding['hello'].asnumpy()))
 
     token_embedding = TokEmb()
-    token_embedding['hello'] = nd.zeros(shape=(5, ))
+    with pytest.warns(UserWarning):  # encouraged to batch their updates
+        token_embedding['hello'] = nd.zeros(shape=(5, ))
     assert np.all(np.isclose(0, token_embedding['hello'].asnumpy()))
 
     token_embedding = TokEmb()
@@ -1035,34 +1042,35 @@ def test_token_embedding_manual_extension(initializeidxtovecbyextending,
 @pytest.mark.serial
 @pytest.mark.remote_required
 def test_token_embedding_serialization():
-    @nlp.embedding.register
-    class Test(nlp.embedding.TokenEmbedding):
-        # 33 bytes.
-        source_file_hash = \
-                {'embedding_test': ('embedding_test.vec',
-                                    '29b9a6511cf4b5aae293c44a9ec1365b74f2a2f8')}
-        namespace = 'test'
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        # UserWarning: New token embedding test_vocab_embed.Test registered
+        # with name test isoverriding existing token embedding
+        # test_vocab_embed.Test
 
-        def __init__(self, embedding_root=os.path.join(get_home_dir(), 'embedding'), **kwargs):
-            source = 'embedding_test'
-            Test._check_source(self.source_file_hash, source)
+        @nlp.embedding.register
+        class Test(nlp.embedding.TokenEmbedding):
+            # 33 bytes.
+            source_file_hash = \
+                    {'embedding_test': ('embedding_test.vec',
+                                        '29b9a6511cf4b5aae293c44a9ec1365b74f2a2f8')}
+            namespace = 'test'
 
-            file_path = Test._get_file_path(self.source_file_hash,
-                                            embedding_root, source)
+            def __init__(self, embedding_root=os.path.join(get_home_dir(), 'embedding'), **kwargs):
+                source = 'embedding_test'
+                Test._check_source(self.source_file_hash, source)
 
-            unknown_token = kwargs.pop('unknown_token', '<unk>')
-            init_unknown_vec = kwargs.pop('init_unknown_vec', nd.zeros)
-            idx_to_token, idx_to_vec, unknown_token = self._load_embedding(
-                file_path,
-                elem_delim=' ',
-                unknown_token=unknown_token,
-                init_unknown_vec=init_unknown_vec)
+                file_path = Test._get_file_path(self.source_file_hash, embedding_root, source)
 
-            super(Test, self).__init__(unknown_token=unknown_token,
-                                       init_unknown_vec=None,
-                                       idx_to_token=idx_to_token,
-                                       idx_to_vec=idx_to_vec,
-                                       **kwargs)
+                unknown_token = kwargs.pop('unknown_token', '<unk>')
+                init_unknown_vec = kwargs.pop('init_unknown_vec', nd.zeros)
+                idx_to_token, idx_to_vec, unknown_token = self._load_embedding(
+                    file_path, elem_delim=' ', unknown_token=unknown_token,
+                    init_unknown_vec=init_unknown_vec)
+
+                super(Test,
+                      self).__init__(unknown_token=unknown_token, init_unknown_vec=None,
+                                     idx_to_token=idx_to_token, idx_to_vec=idx_to_vec, **kwargs)
 
 
     emb = nlp.embedding.create('test')
@@ -1191,15 +1199,18 @@ def test_subword_function_ngramhashes():
     sf = nlp.vocab.create_subword_function('NGramHashes', ngrams=[3, 4, 5, 6],
                                            num_subwords=num_subwords)
 
-    assert set([8, 195, 271, 500, 201, 445, 379, 831, 617, 851]) == set(sf(['test'])[0])
-    assert set([8, 195, 271, 500, 201, 445, 379, 831, 617, 851]) == set(sf([u'test'])[0])
-    assert set([429, 793, 101, 334, 295, 474, 145, 524, 388, 790]) == set(sf([u'τεστ'])[0])
-    assert 1669484008 == sf.fasttext_hash_asbytes('<te')
-    assert 1669484008 == sf.fasttext_hash_asbytes(u'<te')
-    assert 2688791429 == sf.fasttext_hash_asbytes(u'<τε')
-    assert 1669484008 % num_subwords == next(iter(sf.subwords_to_indices(['<te'])))
-    assert 1669484008 % num_subwords == next(iter(sf.subwords_to_indices([u'<te'])))
-    assert 2688791429 % num_subwords == next(iter(sf.subwords_to_indices([u'<τε'])))
+    with warnings.catch_warnings():  # 'RuntimeWarning: overflow encountered in
+                                     # uint_scalars' expected with numba
+        warnings.simplefilter("ignore")
+        assert set([8, 195, 271, 500, 201, 445, 379, 831, 617, 851]) == set(sf(['test'])[0])
+        assert set([8, 195, 271, 500, 201, 445, 379, 831, 617, 851]) == set(sf([u'test'])[0])
+        assert set([429, 793, 101, 334, 295, 474, 145, 524, 388, 790]) == set(sf([u'τεστ'])[0])
+        assert 1669484008 == sf.fasttext_hash_asbytes('<te')
+        assert 1669484008 == sf.fasttext_hash_asbytes(u'<te')
+        assert 2688791429 == sf.fasttext_hash_asbytes(u'<τε')
+        assert 1669484008 % num_subwords == next(iter(sf.subwords_to_indices(['<te'])))
+        assert 1669484008 % num_subwords == next(iter(sf.subwords_to_indices([u'<te'])))
+        assert 2688791429 % num_subwords == next(iter(sf.subwords_to_indices([u'<τε'])))
 
 
 @pytest.mark.parametrize('unknown_token', ['<unk>', None])
@@ -1419,7 +1430,8 @@ def test_vocab_duplicate_special_tokens(unknown_token, padding_token,
 
 def test_vocab_backwards_compatibility_prior_v0_7_corrupted_index_bug():
     with open('tests/data/vocab/backward_compat_0_7_corrupted_index', 'r') as f:
-        v = nlp.Vocab.from_json(f.read())
+        with pytest.warns(UserWarning):  # Detected a corrupted index in the deserialize vocabulary
+            v = nlp.Vocab.from_json(f.read())
 
     assert len(set(v.idx_to_token)) == len(v.token_to_idx)
     assert v['<unk>'] == 0
@@ -1429,7 +1441,7 @@ def test_vocab_backwards_compatibility_prior_v0_7_corrupted_index_bug():
 
     assert v.idx_to_token[0] == '<unk>'
     assert v.idx_to_token[1] == '<eos>'  # corruption preserved for backward
-                                         # compatibility
+    # compatibility
     assert v.idx_to_token[2] == '<bos>'
     assert v.idx_to_token[3] == '<eos>'
     assert v.idx_to_token[4] == 'token'

--- a/tests/unittest/test_vocab_embed.py
+++ b/tests/unittest/test_vocab_embed.py
@@ -19,6 +19,7 @@ import functools
 import os
 import random
 import re
+import warnings
 
 import numpy as np
 import pytest

--- a/tests/unittest/test_vocab_embed.py
+++ b/tests/unittest/test_vocab_embed.py
@@ -896,11 +896,7 @@ def test_token_embedding_from_S3_fasttext_with_ngrams(load_ngrams):
     embed = nlp.embedding.create('fasttext', source='wiki.simple',
                                  load_ngrams=load_ngrams, unknown_token=None)
     if load_ngrams:
-        with warnings.catch_warnings():
-            #  'RuntimeWarning: overflow encountered in uint_scalars' is
-            #  expected when running without numba
-            warnings.simplefilter("ignore")
-            embed['$$$unknownword$$$']
+        embed['$$$unknownword$$$']
     else:
         with pytest.raises(KeyError):
             embed['$$$unknownword$$$']
@@ -1200,18 +1196,15 @@ def test_subword_function_ngramhashes():
     sf = nlp.vocab.create_subword_function('NGramHashes', ngrams=[3, 4, 5, 6],
                                            num_subwords=num_subwords)
 
-    with warnings.catch_warnings():  # 'RuntimeWarning: overflow encountered in
-                                     # uint_scalars' expected with numba
-        warnings.simplefilter("ignore")
-        assert set([8, 195, 271, 500, 201, 445, 379, 831, 617, 851]) == set(sf(['test'])[0])
-        assert set([8, 195, 271, 500, 201, 445, 379, 831, 617, 851]) == set(sf([u'test'])[0])
-        assert set([429, 793, 101, 334, 295, 474, 145, 524, 388, 790]) == set(sf([u'τεστ'])[0])
-        assert 1669484008 == sf.fasttext_hash_asbytes('<te')
-        assert 1669484008 == sf.fasttext_hash_asbytes(u'<te')
-        assert 2688791429 == sf.fasttext_hash_asbytes(u'<τε')
-        assert 1669484008 % num_subwords == next(iter(sf.subwords_to_indices(['<te'])))
-        assert 1669484008 % num_subwords == next(iter(sf.subwords_to_indices([u'<te'])))
-        assert 2688791429 % num_subwords == next(iter(sf.subwords_to_indices([u'<τε'])))
+    assert set([8, 195, 271, 500, 201, 445, 379, 831, 617, 851]) == set(sf(['test'])[0])
+    assert set([8, 195, 271, 500, 201, 445, 379, 831, 617, 851]) == set(sf([u'test'])[0])
+    assert set([429, 793, 101, 334, 295, 474, 145, 524, 388, 790]) == set(sf([u'τεστ'])[0])
+    assert 1669484008 == sf.fasttext_hash_asbytes('<te')
+    assert 1669484008 == sf.fasttext_hash_asbytes(u'<te')
+    assert 2688791429 == sf.fasttext_hash_asbytes(u'<τε')
+    assert 1669484008 % num_subwords == next(iter(sf.subwords_to_indices(['<te'])))
+    assert 1669484008 % num_subwords == next(iter(sf.subwords_to_indices([u'<te'])))
+    assert 2688791429 % num_subwords == next(iter(sf.subwords_to_indices([u'<τε'])))
 
 
 @pytest.mark.parametrize('unknown_token', ['<unk>', None])

--- a/tests/unittest/test_vocab_embed.py
+++ b/tests/unittest/test_vocab_embed.py
@@ -782,7 +782,8 @@ def test_vocab_set_embedding_with_subword_lookup_only_token_embedding(
     if initialize and unknown_token:
         e[e.unknown_token] = nd.zeros(embsize)
     elif initialize and allow_extend:
-        e["hello"] = e.unknown_lookup["hello"]
+        with pytest.warns(UserWarning):  # encouraged to batch their updates
+            e["hello"] = e.unknown_lookup["hello"]
     else:  # Cannot initialize, even if initialize is True
         with pytest.raises(AssertionError):
             v.set_embedding(e)

--- a/tests/unittest/train/test_embedding.py
+++ b/tests/unittest/train/test_embedding.py
@@ -76,9 +76,9 @@ def test_fasttext_embedding(sparse_grad, hybridize):
 
 def test_fasttext_embedding_load_binary_compare_vec():
     test_dir = os.path.dirname(os.path.realpath(__file__))
-    token_embedding_vec = nlp.embedding.TokenEmbedding.from_file(
-        os.path.join(str(test_dir), 'test_embedding', 'lorem_ipsum.vec'),
-        unknown_token=None)
+    with pytest.warns(UserWarning):  # UserWarning: skipped likely header line
+        token_embedding_vec = nlp.embedding.TokenEmbedding.from_file(
+            os.path.join(str(test_dir), 'test_embedding', 'lorem_ipsum.vec'), unknown_token=None)
 
     model = nlp.model.train.FasttextEmbeddingModel.load_fasttext_format(
         os.path.join(str(test_dir), 'test_embedding', 'lorem_ipsum.bin'))
@@ -91,10 +91,9 @@ def test_fasttext_embedding_load_binary_compare_vec():
 
 def test_word2vec_embedding_load_binary_format():
     test_dir = os.path.dirname(os.path.realpath(__file__))
-    word2vec_vec = nlp.embedding.Word2Vec.from_file(
-        os.path.join(str(test_dir), 'test_embedding', 'lorem_ipsum_w2v.vec'),
-        elem_delim=' '
-    )
+    with pytest.warns(UserWarning):  # UserWarning: skipped likely header line
+        word2vec_vec = nlp.embedding.Word2Vec.from_file(
+            os.path.join(str(test_dir), 'test_embedding', 'lorem_ipsum_w2v.vec'), elem_delim=' ')
     word2vec_bin = nlp.embedding.Word2Vec.from_w2v_binary(
         os.path.join(str(test_dir), 'test_embedding', 'lorem_ipsum_w2v.bin')
     )


### PR DESCRIPTION
## Description ##
Tell pytest to turn all warnings into errors.
For example, this helps to enforce that we don't run into problems like https://github.com/dmlc/gluon-nlp/issues/978

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- Update `gluonnlp.data.UnigramCandidateSampler` to make use of MXNet `random.uniform_like` operator and drop constructor `shape` argument. Now the `candidates_like` argument during forward is used to specify shape of to be sampled candidates. This was the originally intended design, but had to wait for MXNet `random.uniform_like` operator being available in stable MXNet.

cc @dmlc/gluon-nlp-team
