### PR TITLE
[Refactor] Split up inheritance structure of TransformerEncoder and BERTEncoder

### DIFF
--- a/docs/api/modules/model.rst
+++ b/docs/api/modules/model.rst
@@ -72,7 +72,6 @@ Components
 
     BERTModel
     BERTEncoder
-    BERTEncoderCell
 
 Pre-defined models
 

--- a/docs/api/modules/model.rst
+++ b/docs/api/modules/model.rst
@@ -71,10 +71,8 @@ Components
     :nosignatures:
 
     BERTModel
-    BERTLayerNorm
     BERTEncoder
     BERTEncoderCell
-    BERTPositionwiseFFN
 
 Pre-defined models
 

--- a/scripts/language_model/transformer/transformer.py
+++ b/scripts/language_model/transformer/transformer.py
@@ -523,7 +523,7 @@ class _BaseXLNet(mx.gluon.HybridBlock):
 
     """
     def __init__(self, vocab_size, num_layers=2, units=128, hidden_size=2048, num_heads=4,
-                 activation='gelutanh', two_stream: bool = False, scaled=True, dropout=0.0,
+                 activation='approx_gelu', two_stream: bool = False, scaled=True, dropout=0.0,
                  attention_dropout=0.0, use_residual=True, clamp_len: typing.Optional[int] = None,
                  use_decoder=True, tie_decoder_weight=True, weight_initializer=None,
                  bias_initializer='zeros', prefix=None, params=None):

--- a/scripts/language_model/transformer/transformer.py
+++ b/scripts/language_model/transformer/transformer.py
@@ -127,9 +127,6 @@ class TransformerXLCell(mx.gluon.HybridBlock):
                                                  weight_initializer=weight_initializer,
                                                  bias_initializer=bias_initializer,
                                                  layer_norm_eps=1e-12)
-            if activation == 'gelu':  # XLNet uses OpenAI GPT's gelu
-                assert hasattr(self.ffn.activation, '_support_erf')
-                self.ffn.activation._support_erf = False
             self.layer_norm = nn.LayerNorm(in_channels=units, epsilon=1e-12)
 
     def hybrid_forward(self, F, inputs, pos_emb, mem_value, mask):
@@ -526,7 +523,7 @@ class _BaseXLNet(mx.gluon.HybridBlock):
 
     """
     def __init__(self, vocab_size, num_layers=2, units=128, hidden_size=2048, num_heads=4,
-                 activation='gelu', two_stream: bool = False, scaled=True, dropout=0.0,
+                 activation='gelutanh', two_stream: bool = False, scaled=True, dropout=0.0,
                  attention_dropout=0.0, use_residual=True, clamp_len: typing.Optional[int] = None,
                  use_decoder=True, tie_decoder_weight=True, weight_initializer=None,
                  bias_initializer='zeros', prefix=None, params=None):

--- a/scripts/tests/test_scripts.py
+++ b/scripts/tests/test_scripts.py
@@ -225,7 +225,7 @@ def test_bert_embedding(use_pretrained):
 @pytest.mark.remote_required
 @pytest.mark.integration
 @pytest.mark.parametrize('backend', ['horovod', 'device'])
-@pytest.mark.skipif(datetime.date.today() < datetime.date(2019, 10, 31),
+@pytest.mark.skipif(datetime.date.today() < datetime.date(2019, 11, 30),
                     reason="mxnet nightly incompatible with horovod")
 def test_bert_pretrain(backend):
     # test data creation

--- a/scripts/text_generation/model/gpt.py
+++ b/scripts/text_generation/model/gpt.py
@@ -179,7 +179,7 @@ class GPT2FFNLayer(HybridBlock):
             self._out_map = nn.Dense(flatten=False, units=units,
                                      weight_initializer=weight_initializer,
                                      bias_initializer=bias_initializer)
-            self._act = GELU(use_erf=False)
+            self._act = GELU(approximate=True)
 
     def hybrid_forward(self, F, data): # pylint: disable=arguments-differ
         out = self._out_map(self._act(self._hidden_map(data)))

--- a/scripts/text_generation/model/gpt.py
+++ b/scripts/text_generation/model/gpt.py
@@ -20,14 +20,16 @@ __all__ = ['GPT2Model', 'GPT2SelfAttentionLayer', 'GPT2FFNLayer',
            'gpt2_117m', 'gpt2_345m']
 
 import os
-import numpy as np
+
 import mxnet as mx
-from mxnet.gluon import nn, Block, HybridBlock
+from mxnet.gluon import Block, HybridBlock, nn
 from mxnet.gluon.model_zoo import model_store
+import numpy as np
+
+from gluonnlp.base import get_home_dir
 from gluonnlp.model.attention_cell import DotProductAttentionCell
 from gluonnlp.model.block import GELU
-from gluonnlp.model.utils import _load_vocab, _load_pretrained_params
-from gluonnlp.base import get_home_dir
+from gluonnlp.model.utils import _load_pretrained_params, _load_vocab
 
 
 class GPT2SelfAttentionLayer(Block):
@@ -177,7 +179,7 @@ class GPT2FFNLayer(HybridBlock):
             self._out_map = nn.Dense(flatten=False, units=units,
                                      weight_initializer=weight_initializer,
                                      bias_initializer=bias_initializer)
-            self._act = GELU()
+            self._act = GELU(use_erf=False)
 
     def hybrid_forward(self, F, data): # pylint: disable=arguments-differ
         out = self._out_map(self._act(self._hidden_map(data)))
@@ -420,6 +422,4 @@ def _get_gpt2_model(model_name=None, dataset_name=None, vocab=None, pretrained=T
                     **kwargs)
     if pretrained:
         _load_pretrained_params(net, model_name, dataset_name, root, ctx)
-    for i in range(net._num_layers):
-        net._ffn_layers[i]._act._support_erf = False
     return net, vocab

--- a/src/gluonnlp/model/bert.py
+++ b/src/gluonnlp/model/bert.py
@@ -17,105 +17,34 @@
 """BERT models."""
 # pylint: disable=too-many-lines
 
-__all__ = ['BERTModel', 'RoBERTaModel', 'BERTEncoder', 'BERTEncoderCell', 'BERTPositionwiseFFN',
-           'BERTLayerNorm', 'BERTClassifier', 'RoBERTaClassifier',
+__all__ = ['BERTModel', 'RoBERTaModel', 'BERTEncoder', 'BERTEncoderCell',
+           'BERTClassifier', 'RoBERTaClassifier',
            'bert_12_768_12', 'bert_24_1024_16',
            'ernie_12_768_12', 'roberta_12_768_12', 'roberta_24_1024_16']
 
 import os
-from mxnet.gluon import HybridBlock
-from mxnet.gluon import nn
-from mxnet.gluon.model_zoo import model_store
-import mxnet as mx
-from .transformer import BasePositionwiseFFN, BaseTransformerEncoderCell, BaseTransformerEncoder
-from .block import GELU
-from .utils import _load_vocab, _load_pretrained_params
-from ..base import get_home_dir
+import warnings
 
+import mxnet as mx
+from mxnet.gluon import HybridBlock, nn
+from mxnet.gluon.model_zoo import model_store
+
+from ..base import get_home_dir
+from .block import GELU
+from .transformer import PositionwiseFFN
+from .seq2seq_encoder_decoder import _get_attention_cell
+from .utils import _load_pretrained_params, _load_vocab
 
 ###############################################################################
 #                              COMPONENTS                                     #
 ###############################################################################
 
-
-class BERTLayerNorm(nn.LayerNorm):
-    """BERT style Layer Normalization.
-
-    Epsilon is added inside the square root and set to 1e-12 by default.
-
-    Inputs:
-        - **data**: input tensor with arbitrary shape.
-        - **out**: output tensor with the same shape as `data`.
-    """
-
-    def __init__(self, epsilon=1e-12, in_channels=0, prefix=None, params=None):
-        super(BERTLayerNorm, self).__init__(epsilon=epsilon, in_channels=in_channels,
-                                            prefix=prefix, params=params)
-
-    def hybrid_forward(self, F, data, gamma, beta):
-        """forward computation."""
-        return F.LayerNorm(data, gamma=gamma, beta=beta, axis=self._axis, eps=self._epsilon)
-
-
-class BERTPositionwiseFFN(BasePositionwiseFFN):
-    """Structure of the Positionwise Feed-Forward Neural Network for
-    BERT.
-
-    Different from the original positionwise feed forward network
-    for transformer, `BERTPositionwiseFFN` uses `GELU` for activation
-    and `BERTLayerNorm` for layer normalization.
-
-    Parameters
-    ----------
-    units : int
-        Number of units for the output
-    hidden_size : int
-        Number of units in the hidden layer of position-wise feed-forward networks
-    dropout : float
-        Dropout probability for the output
-    use_residual : bool
-        Add residual connection between the input and the output
-    weight_initializer : str or Initializer
-        Initializer for the input weights matrix, used for the linear
-        transformation of the inputs.
-    bias_initializer : str or Initializer
-        Initializer for the bias vector.
-    prefix : str, default None
-        Prefix for name of `Block`s (and name of weight if params is `None`).
-    params : Parameter or None
-        Container for weight sharing between cells. Created if `None`.
-    activation : str, default 'gelu'
-        Activation methods in PositionwiseFFN
-    layer_norm_eps : float, default None
-        Epsilon for layer_norm
-
-    Inputs:
-        - **inputs** : input sequence of shape (batch_size, length, C_in).
-
-    Outputs:
-        - **outputs** : output encoding of shape (batch_size, length, C_out).
-    """
-
-    def __init__(self, units=512, hidden_size=2048, dropout=0.0, use_residual=True,
-                 weight_initializer=None, bias_initializer='zeros',
-                 prefix=None, params=None, activation='gelu', layer_norm_eps=None):
-        super(BERTPositionwiseFFN, self).__init__(units=units, hidden_size=hidden_size,
-                                                  dropout=dropout, use_residual=use_residual,
-                                                  weight_initializer=weight_initializer,
-                                                  bias_initializer=bias_initializer,
-                                                  prefix=prefix, params=params,
-                                                  # extra configurations for BERT
-                                                  activation=activation,
-                                                  use_bert_layer_norm=True,
-                                                  layer_norm_eps=layer_norm_eps)
-
-
-class BERTEncoder(BaseTransformerEncoder):
+class BERTEncoder(HybridBlock):
     """Structure of the BERT Encoder.
 
-    Different from the original encoder for transformer,
-    `BERTEncoder` uses learnable positional embedding, `BERTPositionwiseFFN`
-    and `BERTLayerNorm`.
+    Different from the original encoder for transformer, `BERTEncoder` uses
+    learnable positional embedding, a 'gelu' activation functions and a
+    separate epsilon value for LayerNorm.
 
     Parameters
     ----------
@@ -153,7 +82,7 @@ class BERTEncoder(BaseTransformerEncoder):
         Container for weight sharing between cells. Created if `None`.
     activation : str, default 'gelu'
         Activation methods in PositionwiseFFN
-    layer_norm_eps : float, default None
+    layer_norm_eps : float, default 1e-12
         Epsilon for layer_norm
 
     Inputs:
@@ -167,6 +96,7 @@ class BERTEncoder(BaseTransformerEncoder):
         - **additional_outputs** : list of tensors.
             Either be an empty list or contains the attention weights in this step.
             The attention weights will have shape (batch_size, num_heads, length, mem_length)
+
     """
 
     def __init__(self, attention_cell='multi_head', num_layers=2,
@@ -174,33 +104,162 @@ class BERTEncoder(BaseTransformerEncoder):
                  num_heads=4, scaled=True, dropout=0.0,
                  use_residual=True, output_attention=False, output_all_encodings=False,
                  weight_initializer=None, bias_initializer='zeros',
-                 prefix=None, params=None, activation='gelu', layer_norm_eps=None):
-        super(BERTEncoder, self).__init__(attention_cell=attention_cell,
-                                          num_layers=num_layers, units=units,
-                                          hidden_size=hidden_size, max_length=max_length,
-                                          num_heads=num_heads, scaled=scaled, dropout=dropout,
-                                          use_residual=use_residual,
-                                          output_attention=output_attention,
-                                          output_all_encodings=output_all_encodings,
-                                          weight_initializer=weight_initializer,
-                                          bias_initializer=bias_initializer,
-                                          prefix=prefix, params=params,
-                                          # extra configurations for BERT
-                                          positional_weight='learned',
-                                          use_bert_encoder=True,
-                                          use_layer_norm_before_dropout=False,
-                                          scale_embed=False,
-                                          activation=activation,
-                                          layer_norm_eps=layer_norm_eps)
+                 prefix=None, params=None, activation='gelu', layer_norm_eps=1e-12):
+        super().__init__(prefix=prefix, params=params)
+        assert units % num_heads == 0,\
+            'In BERTEncoder, The units should be divided exactly ' \
+            'by the number of heads. Received units={}, num_heads={}' \
+            .format(units, num_heads)
+        self._num_layers = num_layers
+        self._max_length = max_length
+        self._num_heads = num_heads
+        self._units = units
+        self._hidden_size = hidden_size
+        self._output_attention = output_attention
+        self._output_all_encodings = output_all_encodings
+        self._dropout = dropout
+        self._use_residual = use_residual
+        self._scaled = scaled
+        self._dtype = 'float32'
+
+        with self.name_scope():
+            if dropout:
+                self.dropout_layer = nn.Dropout(rate=dropout)
+            self.layer_norm = nn.LayerNorm(in_channels=units, epsilon=1e-12)
+            self.position_weight = self.params.get('position_weight', shape=(max_length, units),
+                                                   init=weight_initializer)
+            self.transformer_cells = nn.HybridSequential()
+            for i in range(num_layers):
+                cell = BERTEncoderCell(
+                    units=units, hidden_size=hidden_size, num_heads=num_heads,
+                    attention_cell=attention_cell, weight_initializer=weight_initializer,
+                    bias_initializer=bias_initializer, dropout=dropout, use_residual=use_residual,
+                    scaled=scaled, output_attention=output_attention, prefix='transformer%d_' % i,
+                    activation=activation, layer_norm_eps=layer_norm_eps)
+                self.transformer_cells.add(cell)
+
+    def cast(self, dtype):
+        """Cast the data type of the parameters"""
+        self._dtype = dtype
+        super().cast(dtype)
+
+    def __call__(self, inputs, states=None, valid_length=None): #pylint: disable=arguments-differ
+        """Encode the inputs given the states and valid sequence length.
+
+        Parameters
+        ----------
+        inputs : NDArray or Symbol
+            Input sequence. Shape (batch_size, length, C_in)
+        states : list of NDArrays or Symbols
+            Initial states. The list of initial states and masks
+        valid_length : NDArray or Symbol
+            Valid lengths of each sequence. This is usually used when part of sequence has
+            been padded. Shape (batch_size,)
+        Returns
+        -------
+        encoder_outputs: list
+            Outputs of the encoder. Contains:
+
+            - outputs of the transformer encoder. Shape (batch_size, length, C_out)
+            - additional_outputs of all the transformer encoder
+        """
+        return super().__call__(inputs, states, valid_length)
+
+    def hybrid_forward(self, F, inputs, states=None, valid_length=None, position_weight=None):
+        # pylint: disable=arguments-differ
+        """Encode the inputs given the states and valid sequence length.
+
+        Parameters
+        ----------
+        inputs : NDArray or Symbol
+            Input sequence. Shape (batch_size, length, C_in)
+        states : list of NDArrays or Symbols
+            Initial states. The list of initial states and masks
+        valid_length : NDArray or Symbol
+            Valid lengths of each sequence. This is usually used when part of sequence has
+            been padded. Shape (batch_size,)
+
+        Returns
+        -------
+        encoder_outputs: list
+            Outputs of the encoder. Contains:
+
+            - outputs of the transformer encoder. Shape (batch_size, length, C_out)
+            - additional_outputs of all the transformer encoder
+
+        Returns
+        -------
+        outputs : NDArray or Symbol, or List[NDArray] or List[Symbol]
+            If output_all_encodings flag is False, then the output of the last encoder.
+            If output_all_encodings flag is True, then the list of all outputs of all encoders.
+            In both cases, shape of the tensor(s) is/are (batch_size, length, C_out)
+        additional_outputs : list
+            Either be an empty list or contains the attention weights in this step.
+            The attention weights will have shape (batch_size, length, length) or
+            (batch_size, num_heads, length, length)
+
+        """
+        steps = F.contrib.arange_like(inputs, axis=1)
+        if valid_length is not None:
+            ones = F.ones_like(steps)
+            mask = F.broadcast_lesser(F.reshape(steps, shape=(1, -1)),
+                                      F.reshape(valid_length, shape=(-1, 1)))
+            mask = F.broadcast_mul(F.expand_dims(mask, axis=1),
+                                   F.broadcast_mul(ones, F.reshape(ones, shape=(-1, 1))))
+            if states is None:
+                states = [mask]
+            else:
+                states.append(mask)
+        else:
+            mask = None
+
+        if states is None:
+            states = [steps]
+        else:
+            states.append(steps)
+
+        # positional encoding
+        positional_embed = F.Embedding(steps, position_weight, self._max_length, self._units)
+        inputs = F.broadcast_add(inputs, F.expand_dims(positional_embed, axis=0))
+
+        if self._dropout:
+            inputs = self.dropout_layer(inputs)
+            inputs = self.layer_norm(inputs)
+        else:
+            inputs = self.layer_norm(inputs)
+        outputs = inputs
+
+        all_encodings_outputs = []
+        additional_outputs = []
+        for cell in self.transformer_cells:
+            outputs, attention_weights = cell(inputs, mask)
+            inputs = outputs
+            if self._output_all_encodings:
+                if valid_length is not None:
+                    outputs = F.SequenceMask(outputs, sequence_length=valid_length,
+                                             use_sequence_length=True, axis=1)
+                all_encodings_outputs.append(outputs)
+
+            if self._output_attention:
+                additional_outputs.append(attention_weights)
+
+        if valid_length is not None and not self._output_all_encodings:
+            # if self._output_all_encodings, SequenceMask is already applied above
+            outputs = F.SequenceMask(outputs, sequence_length=valid_length,
+                                     use_sequence_length=True, axis=1)
+
+        if self._output_all_encodings:
+            return all_encodings_outputs, additional_outputs
+        else:
+            return outputs, additional_outputs
 
 
-class BERTEncoderCell(BaseTransformerEncoderCell):
-    """Structure of the Transformer Encoder Cell for BERT.
+class BERTEncoderCell(HybridBlock):
+    """BERT Encoder Cell.
 
-    Different from the original encoder cell for transformer,
-    `BERTEncoderCell` adds bias terms for attention and the projection
-    on attention output. It also uses `BERTPositionwiseFFN` and
-    `BERTLayerNorm`.
+    Different from the original encoder for transformer, `BERTEncoderCell` uses
+    learnable positional embedding, a 'gelu' activation functions and a
+    separate epsilon value for LayerNorm.
 
     Parameters
     ----------
@@ -230,44 +289,74 @@ class BERTEncoderCell(BaseTransformerEncoderCell):
     params : Parameter or None
         Container for weight sharing between cells. Created if `None`.
     activation : str, default 'gelu'
-        Activation methods in PositionwiseFFN
-    layer_norm_eps : float, default None
-        Epsilon for layer_norm
+        Activation method parameter passed to PositionwiseFFN
+    layer_norm_eps : float, default 1e-12
+        Epsilon parameter passed to for mxnet.gluon.nn.LayerNorm
 
-    Inputs:
-        - **inputs** : input sequence. Shape (batch_size, length, C_in)
-        - **mask** : mask for inputs. Shape (batch_size, length, length)
-
-    Outputs:
-        - **outputs**: output tensor of the transformer encoder cell.
-            Shape (batch_size, length, C_out)
-        - **additional_outputs**: the additional output of all the transformer encoder cell.
     """
 
-    def __init__(self, attention_cell='multi_head', units=128,
-                 hidden_size=512, num_heads=4, scaled=True,
-                 dropout=0.0, use_residual=True, output_attention=False,
-                 weight_initializer=None, bias_initializer='zeros',
-                 prefix=None, params=None, activation='gelu', layer_norm_eps=None):
-        super(BERTEncoderCell, self).__init__(attention_cell=attention_cell,
-                                              units=units, hidden_size=hidden_size,
-                                              num_heads=num_heads, scaled=scaled,
-                                              dropout=dropout, use_residual=use_residual,
-                                              output_attention=output_attention,
-                                              weight_initializer=weight_initializer,
-                                              bias_initializer=bias_initializer,
-                                              prefix=prefix, params=params,
-                                              # extra configurations for BERT
-                                              attention_use_bias=True,
-                                              attention_proj_use_bias=True,
-                                              use_bert_layer_norm=True,
-                                              use_bert_ffn=True,
-                                              activation=activation,
-                                              layer_norm_eps=layer_norm_eps)
+    def __init__(self, attention_cell='multi_head', units=128, hidden_size=512, num_heads=4,
+                 scaled=True, dropout=0.0, use_residual=True, output_attention=False,
+                 weight_initializer=None, bias_initializer='zeros', prefix=None, params=None,
+                 activation='gelu', layer_norm_eps=1e-12):
+        super().__init__(prefix=prefix, params=params)
+        self._units = units
+        self._num_heads = num_heads
+        self._dropout = dropout
+        self._use_residual = use_residual
+        self._output_attention = output_attention
+        with self.name_scope():
+            if dropout:
+                self.dropout_layer = nn.Dropout(rate=dropout)
+            self.attention_cell = _get_attention_cell(attention_cell, units=units,
+                                                      num_heads=num_heads, scaled=scaled,
+                                                      dropout=dropout, use_bias=True)
+            self.proj = nn.Dense(units=units, flatten=False, use_bias=True,
+                                 weight_initializer=weight_initializer,
+                                 bias_initializer=bias_initializer, prefix='proj_')
+            self.ffn = PositionwiseFFN(units=units, hidden_size=hidden_size, dropout=dropout,
+                                       use_residual=use_residual,
+                                       weight_initializer=weight_initializer,
+                                       bias_initializer=bias_initializer, activation=activation,
+                                       layer_norm_eps=layer_norm_eps)
+            self.layer_norm = nn.LayerNorm(in_channels=units, epsilon=layer_norm_eps)
+
+    def hybrid_forward(self, F, inputs, mask=None):  # pylint: disable=arguments-differ
+        # pylint: disable=unused-argument
+        """Transformer Encoder Attention Cell.
+
+        Parameters
+        ----------
+        inputs : Symbol or NDArray
+            Input sequence. Shape (batch_size, length, C_in)
+        mask : Symbol or NDArray or None
+            Mask for inputs. Shape (batch_size, length, length)
+
+        Returns
+        -------
+        encoder_cell_outputs: list
+            Outputs of the encoder cell. Contains:
+
+            - outputs of the transformer encoder cell. Shape (batch_size, length, C_out)
+            - additional_outputs of all the transformer encoder cell
+        """
+        outputs, attention_weights = self.attention_cell(inputs, inputs, inputs, mask)
+        outputs = self.proj(outputs)
+        if self._dropout:
+            outputs = self.dropout_layer(outputs)
+        if self._use_residual:
+            outputs = outputs + inputs
+        outputs = self.layer_norm(outputs)
+        outputs = self.ffn(outputs)
+        additional_outputs = []
+        if self._output_attention:
+            additional_outputs.append(attention_weights)
+        return outputs, additional_outputs
 
 ###############################################################################
 #                                FULL MODEL                                   #
 ###############################################################################
+
 
 class BERTModel(HybridBlock):
     """Generic Model for BERT (Bidirectional Encoder Representations from Transformers).
@@ -342,7 +431,7 @@ class BERTModel(HybridBlock):
                  embed_size=None, embed_dropout=0.0, embed_initializer=None,
                  word_embed=None, token_type_embed=None, use_pooler=True, use_decoder=True,
                  use_classifier=True, use_token_type_embed=True, prefix=None, params=None):
-        super(BERTModel, self).__init__(prefix=prefix, params=params)
+        super().__init__(prefix=prefix, params=params)
         self._use_decoder = use_decoder
         self._use_classifier = use_classifier
         self._use_pooler = use_pooler
@@ -382,7 +471,7 @@ class BERTModel(HybridBlock):
             decoder = nn.HybridSequential(prefix=prefix)
             decoder.add(nn.Dense(units, flatten=False))
             decoder.add(GELU())
-            decoder.add(BERTLayerNorm(in_channels=units))
+            decoder.add(nn.LayerNorm(in_channels=units, epsilon=1e-12))
             decoder.add(nn.Dense(vocab_size, flatten=False, params=embed.collect_params()))
         assert decoder[3].weight == list(embed.collect_params().values())[0], \
             'The weights of word embedding are not tied with those of decoder'
@@ -421,8 +510,7 @@ class BERTModel(HybridBlock):
 
         This is used in training or fine-tuning a BERT model.
         """
-        return super(BERTModel, self).__call__(inputs, token_types,
-                                               valid_length, masked_positions)
+        return super().__call__(inputs, token_types, valid_length, masked_positions)
 
     def hybrid_forward(self, F, inputs, token_types, valid_length=None, masked_positions=None):
         # pylint: disable=arguments-differ
@@ -1195,7 +1283,7 @@ def get_roberta_model(model_name=None, dataset_name=None, vocab=None, pretrained
                           output_all_encodings=output_all_encodings,
                           use_residual=predefined_args['use_residual'],
                           activation=predefined_args.get('activation', 'gelu'),
-                          layer_norm_eps=predefined_args.get('layer_norm_eps', None))
+                          layer_norm_eps=predefined_args.get('layer_norm_eps', 1e-5))
 
     from ..vocab import Vocab
     bert_vocab = _load_vocab(dataset_name, vocab, root, cls=Vocab)
@@ -1303,7 +1391,7 @@ def get_bert_model(model_name=None, dataset_name=None, vocab=None, pretrained=Tr
                           output_all_encodings=output_all_encodings,
                           use_residual=predefined_args['use_residual'],
                           activation=predefined_args.get('activation', 'gelu'),
-                          layer_norm_eps=predefined_args.get('layer_norm_eps', None))
+                          layer_norm_eps=predefined_args.get('layer_norm_eps', 1e-12))
 
     from ..vocab import BERTVocab
     # bert_vocab

--- a/src/gluonnlp/model/bert.py
+++ b/src/gluonnlp/model/bert.py
@@ -211,9 +211,7 @@ class BERTEncoder(HybridBlock, Seq2SeqEncoder):
 
         if self._dropout:
             inputs = self.dropout_layer(inputs)
-            inputs = self.layer_norm(inputs)
-        else:
-            inputs = self.layer_norm(inputs)
+        inputs = self.layer_norm(inputs)
         outputs = inputs
 
         all_encodings_outputs = []
@@ -237,8 +235,7 @@ class BERTEncoder(HybridBlock, Seq2SeqEncoder):
 
         if self._output_all_encodings:
             return all_encodings_outputs, additional_outputs
-        else:
-            return outputs, additional_outputs
+        return outputs, additional_outputs
 
 
 ###############################################################################

--- a/src/gluonnlp/model/bert.py
+++ b/src/gluonnlp/model/bert.py
@@ -110,17 +110,11 @@ class BERTEncoder(HybridBlock):
             'In BERTEncoder, The units should be divided exactly ' \
             'by the number of heads. Received units={}, num_heads={}' \
             .format(units, num_heads)
-        self._num_layers = num_layers
         self._max_length = max_length
-        self._num_heads = num_heads
         self._units = units
-        self._hidden_size = hidden_size
         self._output_attention = output_attention
         self._output_all_encodings = output_all_encodings
         self._dropout = dropout
-        self._use_residual = use_residual
-        self._scaled = scaled
-        self._dtype = 'float32'
 
         with self.name_scope():
             if dropout:
@@ -137,11 +131,6 @@ class BERTEncoder(HybridBlock):
                     scaled=scaled, output_attention=output_attention, prefix='transformer%d_' % i,
                     activation=activation, layer_norm_eps=layer_norm_eps)
                 self.transformer_cells.add(cell)
-
-    def cast(self, dtype):
-        """Cast the data type of the parameters"""
-        self._dtype = dtype
-        super().cast(dtype)
 
     def __call__(self, inputs, states=None, valid_length=None): #pylint: disable=arguments-differ
         """Encode the inputs given the states and valid sequence length.

--- a/src/gluonnlp/model/bert.py
+++ b/src/gluonnlp/model/bert.py
@@ -142,6 +142,7 @@ class BERTEncoder(HybridBlock, Seq2SeqEncoder):
         valid_length : NDArray or Symbol
             Valid lengths of each sequence. This is usually used when part of sequence has
             been padded. Shape (batch_size,)
+
         Returns
         -------
         encoder_outputs: list

--- a/src/gluonnlp/model/bert.py
+++ b/src/gluonnlp/model/bert.py
@@ -168,14 +168,6 @@ class BERTEncoder(HybridBlock, Seq2SeqEncoder):
 
         Returns
         -------
-        encoder_outputs: list
-            Outputs of the encoder. Contains:
-
-            - outputs of the transformer encoder. Shape (batch_size, length, C_out)
-            - additional_outputs of all the transformer encoder
-
-        Returns
-        -------
         outputs : NDArray or Symbol, or List[NDArray] or List[Symbol]
             If output_all_encodings flag is False, then the output of the last encoder.
             If output_all_encodings flag is True, then the list of all outputs of all encoders.

--- a/src/gluonnlp/model/block.py
+++ b/src/gluonnlp/model/block.py
@@ -96,11 +96,16 @@ class GELU(HybridBlock):
     This is a smoother version of the RELU.
     https://arxiv.org/abs/1606.08415
 
+    Parameters
+    ----------
+    approximate : bool, default False
+        If True, use tanh approximation to calculate gelu. If False, use erf.
+
     """
 
-    def __init__(self, use_erf=True, prefix=None, params=None):
+    def __init__(self, approximate=False, prefix=None, params=None):
         super().__init__(prefix=prefix, params=params)
-        self._use_erf = use_erf
+        self._approximate = approximate
 
     def hybrid_forward(self, F, x):  # pylint: disable=arguments-differ
         """
@@ -112,7 +117,7 @@ class GELU(HybridBlock):
         Outputs:
             - **out**: output tensor with the same shape as `data`.
         """
-        if self._use_erf:
+        if not self._approximate:
             return x * 0.5 * (1.0 + F.erf(x / math.sqrt(2.0)))
         else:
             return 0.5 * x * (1 + F.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * (x ** 3))))

--- a/src/gluonnlp/model/block.py
+++ b/src/gluonnlp/model/block.py
@@ -89,31 +89,32 @@ class L2Normalization(HybridBlock):
         ret = F.broadcast_div(x, F.norm(x, axis=self._axis, keepdims=True) + self._eps)
         return ret
 
+
 class GELU(HybridBlock):
-    r"""Gaussian Error Linear Unit.
+    """Gaussian Error Linear Unit.
 
     This is a smoother version of the RELU.
     https://arxiv.org/abs/1606.08415
 
-    Parameters
-    ----------
-    Inputs:
-        - **data**: input tensor with arbitrary shape.
-    Outputs:
-        - **out**: output tensor with the same shape as `data`.
     """
-    def __init__(self, **kwargs):
-        super(GELU, self).__init__(**kwargs)
-        # Always True as GluonNLP requires sufficiently recent MXNet. Not
-        # deleting, as gpt script relies on overwriting this internal variable
-        self._support_erf = bool(ndarray.erf)
 
+    def __init__(self, use_erf=True, prefix=None, params=None):
+        super().__init__(prefix=prefix, params=params)
+        self._use_erf = use_erf
 
-    def hybrid_forward(self, F, x): # pylint: disable=arguments-differ
-        if self._support_erf:
+    def hybrid_forward(self, F, x):  # pylint: disable=arguments-differ
+        """
+
+        Parameters
+        ----------
+        Inputs:
+            - **data**: input tensor with arbitrary shape.
+        Outputs:
+            - **out**: output tensor with the same shape as `data`.
+        """
+        if self._use_erf:
             return x * 0.5 * (1.0 + F.erf(x / math.sqrt(2.0)))
         else:
-            # approximate GELU if erf is not supported
             return 0.5 * x * (1 + F.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * (x ** 3))))
 
     def __repr__(self):

--- a/src/gluonnlp/model/transformer.py
+++ b/src/gluonnlp/model/transformer.py
@@ -383,14 +383,6 @@ class TransformerEncoder(HybridBlock, Seq2SeqEncoder):
 
         Returns
         -------
-        encoder_outputs: list
-            Outputs of the encoder. Contains:
-
-            - outputs of the transformer encoder. Shape (batch_size, length, C_out)
-            - additional_outputs of all the transformer encoder
-
-        Returns
-        -------
         outputs : NDArray or Symbol, or List[NDArray] or List[Symbol]
             If output_all_encodings flag is False, then the output of the last encoder.
             If output_all_encodings flag is True, then the list of all outputs of all encoders.

--- a/src/gluonnlp/model/transformer.py
+++ b/src/gluonnlp/model/transformer.py
@@ -91,8 +91,6 @@ class PositionwiseFFN(HybridBlock):
                  ffn1_dropout=False, activation='relu', layer_norm_eps=1e-5,
                  weight_initializer=None, bias_initializer='zeros', prefix=None, params=None):
         super().__init__(prefix=prefix, params=params)
-        self._hidden_size = hidden_size
-        self._units = units
         self._use_residual = use_residual
         self._dropout = dropout
         self._ffn1_dropout = ffn1_dropout
@@ -197,8 +195,6 @@ class TransformerEncoderCell(HybridBlock):
                  weight_initializer=None, bias_initializer='zeros',
                  prefix=None, params=None, activation='relu', layer_norm_eps=1e-5):
         super().__init__(prefix=prefix, params=params)
-        self._units = units
-        self._num_heads = num_heads
         self._dropout = dropout
         self._use_residual = use_residual
         self._output_attention = output_attention
@@ -314,17 +310,11 @@ class TransformerEncoder(HybridBlock):
             'In TransformerEncoder, The units should be divided exactly ' \
             'by the number of heads. Received units={}, num_heads={}' \
             .format(units, num_heads)
-        self._num_layers = num_layers
         self._max_length = max_length
-        self._num_heads = num_heads
         self._units = units
-        self._hidden_size = hidden_size
         self._output_attention = output_attention
         self._output_all_encodings = output_all_encodings
         self._dropout = dropout
-        self._use_residual = use_residual
-        self._scaled = scaled
-        self._dtype = 'float32'
 
         with self.name_scope():
             if dropout:
@@ -340,11 +330,6 @@ class TransformerEncoder(HybridBlock):
                     scaled=scaled, output_attention=output_attention, prefix='transformer%d_' % i,
                     activation=activation, layer_norm_eps=layer_norm_eps)
                 self.transformer_cells.add(cell)
-
-    def cast(self, dtype):
-        """Cast the data type of the parameters"""
-        self._dtype = dtype
-        super().cast(dtype)
 
     def __call__(self, inputs, states=None, valid_length=None): #pylint: disable=arguments-differ
         """Encode the inputs given the states and valid sequence length.

--- a/src/gluonnlp/model/transformer.py
+++ b/src/gluonnlp/model/transformer.py
@@ -113,7 +113,7 @@ class PositionwiseFFN(HybridBlock):
         if isinstance(act, str):
             if act.lower() == 'gelu':
                 return GELU()
-            elif act.lower() == 'gelutanh':
+            elif act.lower() == 'approx_gelu':
                 return GELU(use_erf=False)
             else:
                 return gluon.nn.Activation(act)

--- a/src/gluonnlp/model/transformer.py
+++ b/src/gluonnlp/model/transformer.py
@@ -113,6 +113,8 @@ class PositionwiseFFN(HybridBlock):
         if isinstance(act, str):
             if act.lower() == 'gelu':
                 return GELU()
+            elif act.lower() == 'gelutanh':
+                return GELU(use_erf=False)
             else:
                 return gluon.nn.Activation(act)
         assert isinstance(act, gluon.Block)
@@ -420,10 +422,7 @@ class TransformerEncoder(HybridBlock, Seq2SeqEncoder):
 
         if self._dropout:
             inputs = self.dropout_layer(inputs)
-            inputs = self.layer_norm(inputs)
-        else:
-            inputs = self.layer_norm(inputs)
-        outputs = inputs
+        inputs = self.layer_norm(inputs)
 
         all_encodings_outputs = []
         additional_outputs = []

--- a/src/gluonnlp/model/transformer.py
+++ b/src/gluonnlp/model/transformer.py
@@ -114,7 +114,7 @@ class PositionwiseFFN(HybridBlock):
             if act.lower() == 'gelu':
                 return GELU()
             elif act.lower() == 'approx_gelu':
-                return GELU(use_erf=False)
+                return GELU(approximate=True)
             else:
                 return gluon.nn.Activation(act)
         assert isinstance(act, gluon.Block)

--- a/src/gluonnlp/model/transformer.py
+++ b/src/gluonnlp/model/transformer.py
@@ -331,7 +331,8 @@ class TransformerEncoder(HybridBlock, Seq2SeqEncoder):
         with self.name_scope():
             if dropout:
                 self.dropout_layer = nn.Dropout(rate=dropout)
-            self.layer_norm = nn.LayerNorm(in_channels=units, epsilon=1e-5)
+            if self._norm_inputs:
+                self.layer_norm = nn.LayerNorm(in_channels=units, epsilon=1e-5)
             self.position_weight = self.params.get_constant(
                 'const', _position_encoding_init(max_length, units))
             self.transformer_cells = nn.HybridSequential()
@@ -602,7 +603,8 @@ class _BaseTransformerDecoder(HybridBlock):
         with self.name_scope():
             if dropout:
                 self.dropout_layer = nn.Dropout(rate=dropout)
-            self.layer_norm = nn.LayerNorm()
+            if self._norm_inputs:
+                self.layer_norm = nn.LayerNorm()
             encoding = _position_encoding_init(max_length, units)
             self.position_weight = self.params.get_constant('const', encoding.astype(np.float32))
             self.transformer_cells = nn.HybridSequential()


### PR DESCRIPTION
## Description ##
Split up inheritance structure of TransformerEncoder and BERTEncoder

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Split up inheritance structure of TransformerEncoder and BERTEncoder

## Comments ##
- Removes `BERTLayerNorm` and `BERTPositionwiseFFN`
- Changes the `layer_norm_eps=None` default to `layer_norm_eps=1e-5` for Transformer models and `layer_norm_eps=1e-12` for BERT models. The distinction was previously done by using `BERTLayerNorm` vs `nn.LayerNorm`.

cc @dmlc/gluon-nlp-team @fierceX 
