### PR TITLE
[Bugfix] TransformerXL LayerNorm eps and XLNet pretrained model config

### DIFF
--- a/scripts/language_model/conversion_utils/compare_transformerxl_pytorch_gluon_model.py
+++ b/scripts/language_model/conversion_utils/compare_transformerxl_pytorch_gluon_model.py
@@ -107,7 +107,7 @@ def compare_transformerxl(args, kwargs, corpus):
 
         loss, mems, last_hidden = model(features_nd, labels_nd, mems)
 
-        loss_p, _, mems_p, all_hidden_p = model_p(features_p, labels_p, mems_p)
+        loss_p, _, mems_p, all_hidden_p = model_p(features_p, mems=mems_p, labels=labels_p)
 
         for i in range(kwargs['num_layers']):
             a_b = mems_p[i][:, 0].numpy() - mems[i][0].asnumpy()

--- a/scripts/language_model/conversion_utils/compare_transformerxl_pytorch_gluon_model.py
+++ b/scripts/language_model/conversion_utils/compare_transformerxl_pytorch_gluon_model.py
@@ -123,6 +123,7 @@ def compare_transformerxl(args, kwargs, corpus):
         stdev = np.std(a_b)
         print('Loss: Maximum error {err:.2e} at position {pos}. stdev={stdev:.2e}'.format(
             i=i, err=max_error, pos=np.unravel_index(argmax_error, shape=a_b.shape), stdev=stdev))
+        assert max_error < 5e-5
 
 
 if __name__ == '__main__':

--- a/scripts/language_model/conversion_utils/compare_xlnet_pytorch_gluon_model.py
+++ b/scripts/language_model/conversion_utils/compare_xlnet_pytorch_gluon_model.py
@@ -42,7 +42,7 @@ def compare_xlnet(args):
         kwargs = {
             'hidden_size': 3072,
             'units': 768,
-            'activation': 'gelu',
+            'activation': 'approx_gelu',
             'num_heads': 12,
             'num_layers': 12,
             'vocab_size': 32000
@@ -51,7 +51,7 @@ def compare_xlnet(args):
         kwargs = {
             'hidden_size': 4096,
             'units': 1024,
-            'activation': 'gelu',
+            'activation': 'approx_gelu',
             'num_heads': 16,
             'num_layers': 24,
             'vocab_size': 32000

--- a/scripts/language_model/conversion_utils/compare_xlnet_pytorch_gluon_model.py
+++ b/scripts/language_model/conversion_utils/compare_xlnet_pytorch_gluon_model.py
@@ -32,11 +32,14 @@ import transformers
 
 
 def compare_xlnet(args):
+    batch_size, qlen, mlen = 2, 16, 100
+
     model_p = transformers.XLNetLMHeadModel.from_pretrained(
         'xlnet-base-cased'
         if args.model_name == 'xlnet_cased_L-12_H-768_A-12' else 'xlnet-large-cased', dropout=0)
     model_p.transformer.attentions = False  # no change of default
     model_p.transformer.output_hidden_states = True
+    model_p.transformer.mem_len = mlen
 
     if args.model_name == 'xlnet_cased_L-12_H-768_A-12':
         kwargs = {
@@ -68,7 +71,6 @@ def compare_xlnet(args):
     model.hybridize()
 
     # Computation
-    batch_size, qlen, mlen = 2, 16, 100
     mems = model.begin_mems(batch_size, mlen, context=mx.cpu())
     x = mx.nd.ones(shape=(batch_size, qlen))
     token_types = mx.nd.ones(shape=(batch_size, qlen))

--- a/scripts/language_model/transformer/model.py
+++ b/scripts/language_model/transformer/model.py
@@ -236,7 +236,7 @@ def xlnet_cased_l24_h1024_a16(dataset_name: Optional[str] = None, vocab: Optiona
     kwargs.update(**{
         'hidden_size': 4096,
         'units': 1024,
-        'activation': 'gelu',
+        'activation': 'approx_gelu',
         'num_heads': 16,
         'num_layers': 24,
     })

--- a/scripts/language_model/transformer/transformer.py
+++ b/scripts/language_model/transformer/transformer.py
@@ -85,6 +85,8 @@ class TransformerXLCell(mx.gluon.HybridBlock):
         in multi-head attention
     dropout : float
     attention_dropout : float
+    layer_norm_eps : float, default 1e-5
+        Epsilon parameter passed to for mxnet.gluon.nn.LayerNorm
     use_residual : bool
     output_attention: bool
         Whether to output the attention weights
@@ -103,8 +105,8 @@ class TransformerXLCell(mx.gluon.HybridBlock):
 
     def __init__(self, attention_cell: PositionalEmbeddingMultiHeadAttentionCell, units=128,
                  hidden_size=512, num_heads=4, activation='relu', scaled=True, dropout=0.0,
-                 use_residual=True, output_attention=False, weight_initializer=None,
-                 bias_initializer='zeros', prefix=None, params=None):
+                 layer_norm_eps=1e-5, output_attention=False, use_residual=True,
+                 weight_initializer=None, bias_initializer='zeros', prefix=None, params=None):
         super().__init__(prefix=prefix, params=params)
         self._units = units
         self._num_heads = num_heads
@@ -126,8 +128,8 @@ class TransformerXLCell(mx.gluon.HybridBlock):
                                                  ffn1_dropout=True, activation=activation,
                                                  weight_initializer=weight_initializer,
                                                  bias_initializer=bias_initializer,
-                                                 layer_norm_eps=1e-12)
-            self.layer_norm = nn.LayerNorm(in_channels=units, epsilon=1e-12)
+                                                 layer_norm_eps=layer_norm_eps)
+            self.layer_norm = nn.LayerNorm(in_channels=units, epsilon=layer_norm_eps)
 
     def hybrid_forward(self, F, inputs, pos_emb, mem_value, mask):
         #  pylint: disable=arguments-differ
@@ -555,7 +557,7 @@ class _BaseXLNet(mx.gluon.HybridBlock):
                     dropout=attention_dropout)
                 self.transformer_cells.add(
                     XLNetCell(attention_cell=attention_cell, units=units, hidden_size=hidden_size,
-                              num_heads=num_heads, activation=activation,
+                              num_heads=num_heads, activation=activation, layer_norm_eps=1e-12,
                               weight_initializer=weight_initializer,
                               bias_initializer=bias_initializer, dropout=dropout, scaled=scaled,
                               use_residual=use_residual, prefix='transformer%d_' % i))

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ readme = io.open('README.rst', encoding='utf-8').read()
 VERSION = find_version('src', 'gluonnlp', '__init__.py')
 
 requirements = [
-    'numpy',
+    'numpy>=1.16.0',
     'cython'
 ]
 


### PR DESCRIPTION
## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Fix TransformerXL LayerNorm eps. Change from `1e-12` to `1e-5`

## Comments ##
We previously asserted that our implementation computes the same result as the pytorch-transformers implementation. However, that implementation was wrong up until 1.2.0 release in which their implementation was fixed unintentionally / by accident in https://github.com/huggingface/transformers/pull/1089/#issuecomment-526154630.

This also updates the comparison scripts which broke to API breakage in the packages that we compare to (renaming / reordering of arguments etc.).

Also updates `gelu` to `approx_gelu` in the XLNet pretrained model configuration, which should have been done in #988.

cc @dmlc/gluon-nlp-team
@zburning FYI