### PR TITLE
[Refactor]Add a switch for attention to return an unnormalized weight matrix.  Move _get_attention_cell function position

### DIFF
--- a/scripts/machine_translation/gnmt.py
+++ b/scripts/machine_translation/gnmt.py
@@ -22,7 +22,8 @@ from mxnet.base import _as_list
 from mxnet.gluon import nn, rnn
 from mxnet.gluon.block import HybridBlock
 from gluonnlp.model.seq2seq_encoder_decoder import Seq2SeqEncoder, Seq2SeqDecoder, \
-     Seq2SeqOneStepDecoder, _get_attention_cell, _get_cell_type, _nested_sequence_last
+     Seq2SeqOneStepDecoder, _get_cell_type, _nested_sequence_last
+from gluonnlp.model.attention_cell import _get_attention_cell
 
 
 class GNMTEncoder(Seq2SeqEncoder):

--- a/src/gluonnlp/model/attention_cell.py
+++ b/src/gluonnlp/model/attention_cell.py
@@ -121,6 +121,10 @@ class AttentionCell(HybridBlock):
         att_weights : Symbol or NDArray
             For single-head attention, Shape (batch_size, query_length, memory_length)
             For multi-head attention, Shape (batch_size, num_heads, query_length, memory_length)
+        att_score : Symbol or NDArray
+            unnormalized weight matrix.
+            For single-head attention, Shape (batch_size, query_length, memory_length)
+            For multi-head attention, Shape (batch_size, num_heads, query_length, memory_length)
         """
         raise NotImplementedError
 
@@ -285,7 +289,9 @@ class MultiHeadAttentionCell(AttentionCell):
                     .reshape(shape=(-1, 0, 0), reverse=True)
         att_weights, att_score = self._base_cell._compute_weight(F, query, key, mask)
         return att_weights.reshape(shape=(-1, self._num_heads, 0, 0),
-                                reverse=True), att_score
+                                   reverse=True), att_score.reshape(
+                                       shape=(-1, self._num_heads, 0, 0),
+                                       reverse=True)
 
     def _read_by_weight(self, F, att_weights, value):
         att_weights = att_weights.reshape(shape=(-1, 0, 0), reverse=True)

--- a/src/gluonnlp/model/attention_cell.py
+++ b/src/gluonnlp/model/attention_cell.py
@@ -92,8 +92,9 @@ class AttentionCell(HybridBlock):
         out = cell(query, key, value, mask)
 
     """
-    def __init__(self, prefix=None, params=None):
+    def __init__(self,unnormalized_score=False, prefix=None, params=None):
         self._dtype = np.float32
+        self._unnormalized_score = unnormalized_score
         super(AttentionCell, self).__init__(prefix=prefix, params=params)
 
     def cast(self, dtype):
@@ -209,6 +210,8 @@ class MultiHeadAttentionCell(AttentionCell):
         Initializer of the weights.
     bias_initializer : str or `Initializer`, default 'zeros'
         Initializer of the bias.
+    unnormalized_score: bool, default False
+        Whether to return an unnormalized weight matrix
     prefix : str or None, default None
         See document of `Block`.
     params : str or None, default None
@@ -216,7 +219,8 @@ class MultiHeadAttentionCell(AttentionCell):
     """
     def __init__(self, base_cell, query_units, key_units, value_units, num_heads, use_bias=True,
                  weight_initializer=None, bias_initializer='zeros',unnormalized_score=False, prefix=None, params=None):
-        super(MultiHeadAttentionCell, self).__init__(prefix=prefix, params=params)
+        super(MultiHeadAttentionCell,
+              self).__init__(unnormalized_score=unnormalized_score,prefix=prefix, params=params)
         self._base_cell = base_cell
         self._num_heads = num_heads
         self._use_bias = use_bias
@@ -324,6 +328,8 @@ class MLPAttentionCell(AttentionCell):
         Initializer of the weights.
     bias_initializer : str or `Initializer`, default 'zeros'
         Initializer of the bias.
+    unnormalized_score: bool, default False
+        Whether to return an unnormalized weight matrix
     prefix : str or None, default None
         See document of `Block`.
     params : ParameterDict or None, default None
@@ -351,7 +357,10 @@ class MLPAttentionCell(AttentionCell):
                                        flatten=False, name='fwd')
                 return out
 
-        super(MLPAttentionCell, self).__init__(prefix=prefix, params=params)
+        super(MLPAttentionCell,
+              self).__init__(unnormalized_score=unnormalized_score,
+                             prefix=prefix,
+                             params=params)
         self._units = units
         self._act = act
         self._normalized = normalized
@@ -449,6 +458,8 @@ class DotProductAttentionCell(AttentionCell):
         Initializer of the weights
     bias_initializer : str or `Initializer`, default 'zeros'
         Initializer of the bias
+    unnormalized_score: bool, default False
+        Whether to return an unnormalized weight matrix
     prefix : str or None, default None
         See document of `Block`.
     params : str or None, default None
@@ -457,7 +468,10 @@ class DotProductAttentionCell(AttentionCell):
     def __init__(self, units=None, luong_style=False, scaled=True, normalized=False, use_bias=True,
                  dropout=0.0, weight_initializer=None, bias_initializer='zeros',unnormalized_score=False,
                  prefix=None, params=None):
-        super(DotProductAttentionCell, self).__init__(prefix=prefix, params=params)
+        super(DotProductAttentionCell,
+              self).__init__(unnormalized_score=unnormalized_score,
+                             prefix=prefix,
+                             params=params)
         self._units = units
         self._scaled = scaled
         self._normalized = normalized

--- a/src/gluonnlp/model/seq2seq_encoder_decoder.py
+++ b/src/gluonnlp/model/seq2seq_encoder_decoder.py
@@ -53,51 +53,6 @@ def _get_cell_type(cell_type):
     else:
         return cell_type
 
-
-def _get_attention_cell(attention_cell, units=None,
-                        scaled=True, num_heads=None,
-                        use_bias=False, dropout=0.0):
-    """
-
-    Parameters
-    ----------
-    attention_cell : AttentionCell or str
-    units : int or None
-
-    Returns
-    -------
-    attention_cell : AttentionCell
-    """
-    if isinstance(attention_cell, str):
-        if attention_cell == 'scaled_luong':
-            return DotProductAttentionCell(units=units, scaled=True, normalized=False,
-                                           use_bias=use_bias, dropout=dropout, luong_style=True)
-        elif attention_cell == 'scaled_dot':
-            return DotProductAttentionCell(units=units, scaled=True, normalized=False,
-                                           use_bias=use_bias, dropout=dropout, luong_style=False)
-        elif attention_cell == 'dot':
-            return DotProductAttentionCell(units=units, scaled=False, normalized=False,
-                                           use_bias=use_bias, dropout=dropout, luong_style=False)
-        elif attention_cell == 'cosine':
-            return DotProductAttentionCell(units=units, scaled=False, use_bias=use_bias,
-                                           dropout=dropout, normalized=True)
-        elif attention_cell == 'mlp':
-            return MLPAttentionCell(units=units, normalized=False)
-        elif attention_cell == 'normed_mlp':
-            return MLPAttentionCell(units=units, normalized=True)
-        elif attention_cell == 'multi_head':
-            base_cell = DotProductAttentionCell(scaled=scaled, dropout=dropout)
-            return MultiHeadAttentionCell(base_cell=base_cell, query_units=units, use_bias=use_bias,
-                                          key_units=units, value_units=units, num_heads=num_heads)
-        else:
-            raise NotImplementedError
-    else:
-        assert isinstance(attention_cell, AttentionCell),\
-            'attention_cell must be either string or AttentionCell. Received attention_cell={}'\
-                .format(attention_cell)
-        return attention_cell
-
-
 def _nested_sequence_last(data, valid_length):
     """
 

--- a/src/gluonnlp/model/transformer.py
+++ b/src/gluonnlp/model/transformer.py
@@ -34,8 +34,8 @@ from ..base import get_home_dir
 from ..utils.parallel import Parallelizable
 from .block import GELU
 from .seq2seq_encoder_decoder import (Seq2SeqDecoder, Seq2SeqEncoder,
-                                      Seq2SeqOneStepDecoder,
-                                      _get_attention_cell)
+                                      Seq2SeqOneStepDecoder)
+from .attention_cell import _get_attention_cell
 from .translation import NMTModel
 from .utils import _load_pretrained_params, _load_vocab
 


### PR DESCRIPTION
## Description ##
Added the option for attention to return an unnormalized weight matrix. 
This will be used for tinybert training. 
Moved the position of the `_get_attention_cell` function from `seq2seq_encoder_decoder` to `attention_cell`,which I think makes more sense.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
