### PR TITLE
Fix scripts/question_answering/data_pipeline.py requiring optional package

### DIFF
--- a/scripts/question_answering/data_pipeline.py
+++ b/scripts/question_answering/data_pipeline.py
@@ -432,7 +432,12 @@ class SQuADDataPipeline:
 
 class SQuADDataTokenizer:
     """SQuAD data tokenizer, that encapsulate the splitting logic of each entry of SQuAD dataset"""
-    spacy_tokenizer = nlp.data.SpacyTokenizer()
+    try:
+        _spacy_tokenizer = nlp.data.SpacyTokenizer()
+    except (ImportError, AttributeError) as e:
+        _spacy_error = e
+        def _spacy_tokenizer(*args, **kwargs):
+            raise SQuADDataTokenizer._spacy_error
 
     def __init__(self, use_spacy=True):
         """Init new SQuADDataTokenizer object
@@ -511,7 +516,7 @@ class SQuADDataTokenizer:
         tokens : List[str]
             List of tokens
         """
-        tokens = SQuADDataTokenizer.spacy_tokenizer(sent)
+        tokens = SQuADDataTokenizer._spacy_tokenizer(sent)
         return tokens
 
     @staticmethod

--- a/scripts/question_answering/data_pipeline.py
+++ b/scripts/question_answering/data_pipeline.py
@@ -436,7 +436,7 @@ class SQuADDataTokenizer:
         _spacy_tokenizer = nlp.data.SpacyTokenizer()
     except (ImportError, AttributeError) as e:
         _spacy_error = e
-        def _spacy_tokenizer(*args, **kwargs):
+        def _spacy_tokenizer(*args, **kwargs):  # pylint: disable=no-method-argument
             raise SQuADDataTokenizer._spacy_error
 
     def __init__(self, use_spacy=True):

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
             'boto3',
             'tqdm',
             'sacremoses',
+            'regex',
         ],
         'dev': [
             'pytest',


### PR DESCRIPTION
Because a nlp.data.SpacyTokenizer is created as class attribute, SpacyTokenizer
is required when Python parses the data_pipeline.py file. This means users will
always need to install the "optional" SpacyTokenizer dependencies, even if they
don't plan to use it. For example, just running an unrelated test in the scripts
folder will currently raise the following error.

```
ImportError while loading conftest '/home/ubuntu/projects/gluon-nlp/scripts/tests/conftest.py'.
scripts/tests/conftest.py:23: in <module>
    from ..question_answering.data_pipeline import SQuADDataPipeline
scripts/question_answering/data_pipeline.py:433: in <module>
    class SQuADDataTokenizer:
scripts/question_answering/data_pipeline.py:435: in SQuADDataTokenizer
    spacy_tokenizer = nlp.data.SpacyTokenizer()
src/gluonnlp/data/transforms.py:248: in __init__
    lang=lang))
E   OSError: SpaCy Model for the specified language="en_core_web_sm" has not been downloaded. You need to check the installation guide in https://spacy.io/usage/models. Usually, the installation command should be `python -m spacy download en_core_web_sm`.

```

cc @dmlc/gluon-nlp-team
