### PR TITLE
[CI] Enable type checks and inference with pytype

### DIFF
--- a/.pytype.cfg
+++ b/.pytype.cfg
@@ -1,0 +1,8 @@
+# NOTE: All relative paths are relative to the location of this file.
+[pytype]
+# Space-separated list of files or directories to process.
+inputs =
+    src/gluonnlp
+
+# Python version (major.minor) of the target code.
+python_version = 3.5

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ pylint:
 	pylint --rcfile=$(ROOTDIR)/.pylintrc $(lintdir)
 
 pytype:
-	pytype --rcfile=$(ROOTDIR)/.pytype.cfg
+	pytype --config=$(ROOTDIR)/.pytype.cfg
 
 restruc:
 	python setup.py check --restructuredtext --strict

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,16 @@ flake8:
 pylint:
 	pylint --rcfile=$(ROOTDIR)/.pylintrc $(lintdir)
 
+pytype:
+	pytype --rcfile=$(ROOTDIR)/.pytype.cfg
+
 restruc:
 	python setup.py check --restructuredtext --strict
 
 lint:
 	make lintdir=$(lintdir) flake8
 	make lintdir=$(lintdir) pylint
+	make pytype
 	make lintdir=$(lintdir) ratcheck
 	make restruc
 

--- a/env/cpu/py3-master.yml
+++ b/env/cpu/py3-master.yml
@@ -6,6 +6,7 @@ dependencies:
   - perl
   - pip:
     - cython
+    - pytype==2019.10.17
     - pytest==5.2.3
     - pytest-env==0.6.2
     - pytest-cov==2.8.1

--- a/env/cpu/py3-master.yml
+++ b/env/cpu/py3-master.yml
@@ -6,6 +6,7 @@ dependencies:
   - perl
   - pip:
     - cython
+    - boto3
     - pytype==2019.10.17
     - pytest==5.2.3
     - pytest-env==0.6.2

--- a/env/docker/py3.yml
+++ b/env/docker/py3.yml
@@ -21,6 +21,7 @@ dependencies:
     - jieba
     - scikit-learn==0.21.3
     - cython
+    - pytype==2019.10.17
     - pytest==5.2.3
     - pytest-env==0.6.2
     - pytest-cov==2.8.1

--- a/env/gpu/py3-master.yml
+++ b/env/gpu/py3-master.yml
@@ -20,6 +20,7 @@ dependencies:
     - seaborn
     - jieba
     - cython
+    - pytype==2019.10.17
     - pytest==5.2.3
     - pytest-env==0.6.2
     - pytest-cov==2.8.1

--- a/env/gpu/py3-master.yml
+++ b/env/gpu/py3-master.yml
@@ -20,6 +20,7 @@ dependencies:
     - seaborn
     - jieba
     - cython
+    - boto3
     - pytype==2019.10.17
     - pytest==5.2.3
     - pytest-env==0.6.2

--- a/src/gluonnlp/base.py
+++ b/src/gluonnlp/base.py
@@ -23,7 +23,7 @@ import os
 __all__ = ['numba_njit', 'numba_prange', 'numba_jitclass', 'numba_types', 'get_home_dir']
 
 try:
-    from numba import njit, prange, jitclass, types
+    from numba import njit, prange, jitclass, types  # pytype: disable=import-error
     numba_njit = njit(nogil=True)
     numba_prange = prange
     numba_jitclass = jitclass

--- a/src/gluonnlp/data/__init__.py
+++ b/src/gluonnlp/data/__init__.py
@@ -39,9 +39,10 @@ from .utils import *
 from .word_embedding_evaluation import *
 from .intent_slot import *
 
+
 __all__ = (['batchify'] + utils.__all__ + transforms.__all__ + sampler.__all__
            + dataset.__all__ + corpora.__all__ + sentiment.__all__
            + word_embedding_evaluation.__all__ + stream.__all__ + conll.__all__
            + translation.__all__ + registry.__all__ + question_answering.__all__
            + dataloader.__all__ + candidate_sampler.__all__ + intent_slot.__all__
-           + glue.__all__)
+           + glue.__all__)  # pytype: disable=attribute-error

--- a/src/gluonnlp/data/batchify/__init__.py
+++ b/src/gluonnlp/data/batchify/__init__.py
@@ -18,7 +18,7 @@
 # pylint: disable=wildcard-import
 """Batchify helpers."""
 
-from . import batchify, language_model
+from . import batchify, embedding, language_model
 from .batchify import *
 from .embedding import *
 from .language_model import *

--- a/src/gluonnlp/data/batchify/batchify.py
+++ b/src/gluonnlp/data/batchify/batchify.py
@@ -20,9 +20,8 @@ __all__ = ['Stack', 'Pad', 'Tuple', 'List', 'NamedTuple', 'Dict']
 
 import warnings
 import math
-from typing import Dict as t_Dict, Callable as t_Callable,\
-    NamedTuple as t_NamedTuple, List as t_List, Tuple as t_Tuple, AnyStr,\
-    Union as t_Union
+from typing import (Dict as t_Dict, Callable as t_Callable, List as t_List, Tuple as t_Tuple,
+                    AnyStr, Union as t_Union)
 
 import numpy as np
 import mxnet as mx
@@ -461,8 +460,8 @@ class NamedTuple:
 
     Parameters
     ----------
-    container
-        The object that constructs the namedtuple.
+    container : NamedTuple class
+        The object that constructs the NamedTuple.
     fn_info
         The information of the inner batchify functions.
 
@@ -501,11 +500,8 @@ class NamedTuple:
     [0 1 0]
     <NDArray 3 @cpu_shared(0)>)
     """
-    def __init__(self,
-                 container: t_NamedTuple,
-                 fn_info: t_Union[t_List[t_Callable],
-                                  t_Tuple[t_Callable],
-                                  t_Dict[AnyStr, t_Callable]]):
+    def __init__(self, container, fn_info: t_Union[t_List[t_Callable], t_Tuple[t_Callable],
+                                                   t_Dict[AnyStr, t_Callable]]):
         self._container = container
         if isinstance(fn_info, (list, tuple)):
             if len(container._fields) != len(fn_info):
@@ -526,17 +522,17 @@ class NamedTuple:
                 raise ValueError('All batchify functions must be callable.')
         self._fn_l = fn_info
 
-    def __call__(self, data: t_List[t_NamedTuple]) -> t_NamedTuple:
+    def __call__(self, data):
         """Batchify the input data.
 
         Parameters
         ----------
-        data
-            The samples to batchfy. Each sample should be a namedtuple.
+        data : List of NamedTuple
+            The samples to batchify. Each sample should be a NamedTuple.
 
         Returns
         -------
-        ret
+        ret : List of NamedTuple
             A namedtuple of length N. Contains the batchified result of each attribute in the input.
         """
         if not isinstance(data[0], self._container):

--- a/src/gluonnlp/data/batchify/embedding.py
+++ b/src/gluonnlp/data/batchify/embedding.py
@@ -24,17 +24,8 @@ import random
 
 import numpy as np
 
+from ...base import numba_njit, numba_prange
 from ..stream import DataStream
-
-try:
-    from numba import njit, prange
-    numba_njit = njit(nogil=True)
-except ImportError:
-    # Define numba shims
-    prange = range
-
-    def numba_njit(func):
-        return func
 
 
 class EmbeddingCenterContextBatchify:
@@ -127,7 +118,7 @@ class _EmbeddingCenterContextBatchify(DataStream):
         self._index_dtype = index_dtype
 
     def __iter__(self):
-        if prange is range:
+        if numba_prange is range:
             logging.warning(
                 'EmbeddingCenterContextBatchify supports just in time compilation '
                 'with numba, but numba is not installed. '

--- a/src/gluonnlp/data/conll.py
+++ b/src/gluonnlp/data/conll.py
@@ -79,7 +79,7 @@ class _CoNLLSequenceTagging(SimpleDataset):
         results = []
         for path in paths:
             with gzip.open(path, 'r') if path.endswith('gz') else io.open(path, 'rb') as f:
-                line_iter = codecs.getreader(self.codec)(io.BufferedReader(f))
+                line_iter = codecs.getreader(self.codec)(io.BufferedReader(f))  # pytype: disable=wrong-arg-types
                 results.append(self._process_iter(line_iter))
         return list([x for field in item for x in field] for item in zip(*results))
 

--- a/src/gluonnlp/data/conll.py
+++ b/src/gluonnlp/data/conll.py
@@ -79,7 +79,8 @@ class _CoNLLSequenceTagging(SimpleDataset):
         results = []
         for path in paths:
             with gzip.open(path, 'r') if path.endswith('gz') else io.open(path, 'rb') as f:
-                line_iter = codecs.getreader(self.codec)(io.BufferedReader(f))  # pytype: disable=wrong-arg-types
+                line_iter = codecs.getreader(self.codec)\
+                    (io.BufferedReader(f))  # pytype: disable=wrong-arg-types
                 results.append(self._process_iter(line_iter))
         return list([x for field in item for x in field] for item in zip(*results))
 

--- a/src/gluonnlp/data/stream.py
+++ b/src/gluonnlp/data/stream.py
@@ -25,6 +25,7 @@ import glob
 import multiprocessing
 import multiprocessing.pool
 import os
+import queue
 import random
 import sys
 import threading
@@ -33,12 +34,7 @@ import traceback
 import numpy as np
 
 import mxnet as mx
-from mxnet.gluon.data import RandomSampler, SequentialSampler, Sampler
-
-try:
-    import Queue as queue
-except ImportError:
-    import queue
+from mxnet.gluon.data import RandomSampler, Sampler, SequentialSampler
 
 __all__ = [
     'DataStream', 'SimpleDataStream', 'DatasetStream', 'SimpleDatasetStream',

--- a/src/gluonnlp/embedding/__init__.py
+++ b/src/gluonnlp/embedding/__init__.py
@@ -18,8 +18,7 @@
 # pylint: disable=wildcard-import
 """Word embeddings."""
 
+from . import evaluation, token_embedding
 from .token_embedding import *
-
-from . import evaluation
 
 __all__ = (token_embedding.__all__ + ['evaluation'])

--- a/src/gluonnlp/embedding/token_embedding.py
+++ b/src/gluonnlp/embedding/token_embedding.py
@@ -226,8 +226,8 @@ class TokenEmbedding:
                         unknown_index = 0
                     else:
                         raise ValueError('unknown_token "{}" is not part of idx_to_vec but '
-                                         'init_unknown_vec is None. You must provide either of them.'
-                                         .format(unknown_token))
+                                         'init_unknown_vec is None. '
+                                         'You must provide either of them.'.format(unknown_token))
 
             # Initialization
             self._unknown_token = unknown_token

--- a/src/gluonnlp/embedding/token_embedding.py
+++ b/src/gluonnlp/embedding/token_embedding.py
@@ -16,7 +16,6 @@
 # under the License.
 
 # pylint: disable=consider-iterating-dictionary, too-many-lines
-
 """Text token embedding."""
 
 __all__ = [
@@ -214,16 +213,21 @@ class TokenEmbedding:
             if idx_to_vec.shape[0] != len(idx_to_token):
                 raise ValueError('idx_to_token and idx_to_vec must contain '
                                  'the same number of tokens and embeddings respectively.')
-            if init_unknown_vec is not None:
-                logging.info('Ignoring init_unknown_vec as idx_to_vec is specified')
             if unknown_token is not None:
                 try:
                     unknown_index = idx_to_token.index(unknown_token)
+                    if init_unknown_vec is not None:
+                        logging.info('Ignoring init_unknown_vec as idx_to_vec is specified')
                 except ValueError:
-                    idx_to_token.insert(0, unknown_token)
-                    idx_to_vec = nd.concat(init_unknown_vec((1, idx_to_vec.shape[1])), idx_to_vec,
-                                           dim=0)
-                    unknown_index = 0
+                    if init_unknown_vec is not None:
+                        idx_to_token.insert(0, unknown_token)
+                        idx_to_vec = nd.concat(init_unknown_vec((1, idx_to_vec.shape[1])),
+                                               idx_to_vec, dim=0)
+                        unknown_index = 0
+                    else:
+                        raise ValueError('unknown_token "{}" is not part of idx_to_vec but '
+                                         'init_unknown_vec is None. You must provide either of them.'
+                                         .format(unknown_token))
 
             # Initialization
             self._unknown_token = unknown_token
@@ -350,7 +354,7 @@ class TokenEmbedding:
         with io.open(pretrained_file_path, 'rb') as f:
             for line_num, line in enumerate(f):
                 try:
-                    line = line.decode(encoding)
+                    line = line.decode(encoding)  # pytype: disable=attribute-error
                 except ValueError:
                     warnings.warn('line {} in {}: failed to decode. Skipping.'
                                   .format(line_num, pretrained_file_path))
@@ -1286,7 +1290,7 @@ class Word2Vec(TokenEmbedding):
         loaded_unknown_vec = None
         pretrained_file_path = os.path.expanduser(pretrained_file_path)
         with io.open(pretrained_file_path, 'rb') as f:
-            header = f.readline().decode(encoding=encoding)
+            header = f.readline().decode(encoding=encoding)  # pytype: disable=attribute-error
             vocab_size, vec_len = (int(x) for x in header.split())
             if unknown_token:
                 # Reserve a vector slot for the unknown token at the very beggining

--- a/src/gluonnlp/initializer/__init__.py
+++ b/src/gluonnlp/initializer/__init__.py
@@ -18,6 +18,8 @@
 # pylint: disable=wildcard-import
 """NLP initializer."""
 
+from . import initializer
+
 from .initializer import *
 
 __all__ = initializer.__all__

--- a/src/gluonnlp/loss/__init__.py
+++ b/src/gluonnlp/loss/__init__.py
@@ -18,6 +18,8 @@
 # pylint: disable=wildcard-import
 """NLP loss."""
 
+from . import activation_regularizer, loss, label_smoothing
+
 from .activation_regularizer import *
 from .loss import *
 from .label_smoothing import *

--- a/src/gluonnlp/metric/__init__.py
+++ b/src/gluonnlp/metric/__init__.py
@@ -18,6 +18,8 @@
 # pylint: disable=wildcard-import
 """NLP Metrics."""
 
+from . import masked_accuracy
+
 from .masked_accuracy import *
 
 __all__ = masked_accuracy.__all__

--- a/src/gluonnlp/model/sequence_sampler.py
+++ b/src/gluonnlp/model/sequence_sampler.py
@@ -18,10 +18,17 @@
 
 __all__ = ['BeamSearchScorer', 'BeamSearchSampler', 'HybridBeamSearchSampler', 'SequenceSampler']
 
+from typing import TypeVar
+
 import numpy as np
+
 import mxnet as mx
 from mxnet.gluon import HybridBlock
+
 from .._constants import LARGE_NEGATIVE_FLOAT
+
+
+__T = TypeVar('__T')
 
 class BeamSearchScorer(HybridBlock):
     r"""Score function used in beam search.
@@ -141,7 +148,7 @@ def _reconstruct_flattened_structure(structure, flattened):
         raise NotImplementedError
 
 
-def _expand_to_beam_size(data, beam_size, batch_size, state_info=None):
+def _expand_to_beam_size(data: __T, beam_size, batch_size, state_info=None) -> __T:
     """Tile all the states to have batch_size * beam_size on the batch axis.
 
     Parameters

--- a/src/gluonnlp/optimizer/__init__.py
+++ b/src/gluonnlp/optimizer/__init__.py
@@ -18,6 +18,8 @@
 # pylint: disable=wildcard-import
 """NLP optimizer."""
 
+from . import bert_adam, lamb
+
 from .bert_adam import *
 from .lamb import *
 

--- a/src/gluonnlp/utils/__init__.py
+++ b/src/gluonnlp/utils/__init__.py
@@ -18,11 +18,10 @@
 # pylint: disable=wildcard-import, arguments-differ
 """Module for utility functions."""
 
-from . import (parallel, parameter, files)
-
+from . import files, parallel, parameter, version
+from .files import *
 from .parallel import *
 from .parameter import *
-from .files import *
 from .version import *
 
 __all__ = parallel.__all__ + parameter.__all__ + files.__all__ + version.__all__

--- a/src/gluonnlp/utils/parallel.py
+++ b/src/gluonnlp/utils/parallel.py
@@ -15,11 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 """Utility functions for parallel processing."""
+import queue
 import threading
-try:
-    import Queue as queue
-except ImportError:
-    import queue
 
 __all__ = ['Parallelizable', 'Parallel']
 

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -261,7 +261,8 @@ class Vocab:
         if token_to_idx:
             self._sort_index_according_to_user_specification(token_to_idx)
             if unknown_token:
-                self._token_to_idx._default = self._token_to_idx[unknown_token]  # pytype: disable=not-writable
+                self._token_to_idx._default = \
+                    self._token_to_idx[unknown_token]  # pytype: disable=not-writable
 
 
     def _index_counter_keys(self, counter, unknown_token, special_tokens, max_size,

--- a/src/gluonnlp/vocab/vocab.py
+++ b/src/gluonnlp/vocab/vocab.py
@@ -261,7 +261,7 @@ class Vocab:
         if token_to_idx:
             self._sort_index_according_to_user_specification(token_to_idx)
             if unknown_token:
-                self._token_to_idx._default = self._token_to_idx[unknown_token]
+                self._token_to_idx._default = self._token_to_idx[unknown_token]  # pytype: disable=not-writable
 
 
     def _index_counter_keys(self, counter, unknown_token, special_tokens, max_size,


### PR DESCRIPTION
## Description ##
Pytype is a static type analyzer for Python code.

> Pytype checks and infers types for your Python code - without requiring type annotations. Pytype can:
> 
>  - Lint plain Python code, flagging common mistakes such as misspelled attribute names, incorrect function calls, and much more, even across file boundaries.
> - Enforce user-provided type annotations. While annotations are optional for pytype, it will check and apply them where present.
> - Generate type annotations in standalone files ("pyi files"), which can be merged back into the Python source with a provided merge-pyi tool.
> 
> Pytype is a static analyzer; it does not execute the code it runs on.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

### Changes ###
- [X] Enable type checks and inference with pytype
 
## Comments ##
Later we can use the `merge-pyi` to integrate the inferred types into the codebase.

cc @dmlc/gluon-nlp-team
