### PR TITLE
Disable multi-processing in bert pre-training dataloader

### DIFF
--- a/scripts/bert/pretraining_utils.py
+++ b/scripts/bert/pretraining_utils.py
@@ -255,12 +255,14 @@ class BERTDataLoaderFn(DataLoaderFn):
             dataloader = nlp.data.ShardedDataLoader(dataset,
                                                     batch_sampler=sampler,
                                                     batchify_fn=self._batchify_fn,
-                                                    num_workers=self._num_ctxes)
+                                                    num_workers=self._num_ctxes,
+                                                    thread_pool=True)
         else:
             dataloader = DataLoader(dataset=dataset,
                                     batch_sampler=sampler,
                                     batchify_fn=self._batchify_fn,
-                                    num_workers=self._num_ctxes)
+                                    num_workers=self._num_ctxes,
+                                    thread_pool=True)
         return dataloader
 
 class BERTLoaderTransform:


### PR DESCRIPTION
## Description ##
With multiple dataloaders created with multi-processing, mpi sometimes crashes. This affects users who use horovod for bert pre-training. Temporarily disable multi-processing before the new version of dataloader is available. 

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
