### PR TITLE
[Feature] add even_size option to split sampler

### DIFF
--- a/docs/examples/sentence_embedding/bert.md
+++ b/docs/examples/sentence_embedding/bert.md
@@ -41,6 +41,8 @@ import random
 import numpy as np
 import mxnet as mx
 import gluonnlp as nlp
+# this notebook assumes that all required scripts are already
+# downloaded from the corresponding tutorial webpage on http://gluon-nlp.mxnet.io
 from bert import data
 
 nlp.utils.check_version('0.8.1')

--- a/src/gluonnlp/data/sampler.py
+++ b/src/gluonnlp/data/sampler.py
@@ -508,29 +508,48 @@ class SplitSampler(Sampler):
     ----------
     length: int
       Number of examples in the dataset
-    num_parts: int
+    num_parts: int, default 1
       Number of partitions which the data is split into
-    part_index: int
+    part_index: int, default 0
       The index of the part to read from
+    even_size: bool, default False
+      If the number of samples is not even across all partitions, sample a few extra samples
+      for the ones with fewer samples.
     """
-    def __init__(self, length, num_parts=1, part_index=0):
+    def __init__(self, length, num_parts=1, part_index=0, even_size=False):
         assert length >= num_parts, \
             'Length (%d) must be greater than or equal to the number of partitions (%d).'%\
             (length, num_parts)
-        # Compute the length of each partition
-        part_len = length // num_parts
-        # Compute the start index for this partition
-        self._start = part_len * part_index
-        # Compute the end index for this partition
-        self._end = self._start + part_len
-        if part_index == num_parts - 1:
-            self._end = length
+        self.even_size = even_size
+        self.num_parts = num_parts
+        if not even_size:
+            # Compute the length of each partition
+            part_len = length // num_parts
+            remaining = length % num_parts
+            # Compute the start and end index for this partition
+            self._start = part_len * part_index + min(part_index, remaining)
+            self._end = self._start + part_len + (part_index < remaining)
+            self._len = self._end - self._start
+        else:
+            # round up partition length
+            part_len = int(length + num_parts - 1) // num_parts
+            # Compute the start and end index for this partition
+            self._start = part_len * part_index
+            self._end = self._start + part_len
+            self._start = self._start if self._start < length else length
+            self._end = self._end if self._end <= length else length
+            self._len = part_len
 
     def __iter__(self):
         # Extract examples between `start` and `end`, shuffle and return them.
         indices = list(range(self._start, self._end))
+        if self.even_size and len(indices) < self._len:
+            # guaranteed to have part_len number of samples
+            candidates = list(range(self._len * self.num_parts))
+            extras = random.sample(candidates, k=self._len-len(indices))
+            indices.extend(extras)
         random.shuffle(indices)
         return iter(indices)
 
     def __len__(self):
-        return self._end - self._start
+        return self._len

--- a/tests/unittest/test_sampler.py
+++ b/tests/unittest/test_sampler.py
@@ -118,3 +118,20 @@ def test_split_sampler(num_samples, num_parts):
         assert count == len(sampler)
     assert total_count == num_samples
     assert sorted(indices) == list(range(num_samples))
+
+@pytest.mark.parametrize('num_samples', [30])
+@pytest.mark.parametrize('num_parts', [3, 7])
+def test_split_sampler_even_size(num_samples, num_parts):
+    total_count = 0
+    indices = []
+    for part_idx in range(num_parts):
+        sampler = s.SplitSampler(num_samples, num_parts, part_idx, even_size=True)
+        count = 0
+        for i in sampler:
+            count += 1
+            indices.append(i)
+        total_count += count
+        assert count == len(sampler)
+        print(count)
+    expected_count = int(num_samples + num_parts - 1) // num_parts * num_parts
+    assert total_count == expected_count, (total_count, expected_count)


### PR DESCRIPTION
## Description ##
Add an option to ensure all partitions have the same number of samples. It will add extra samples if needed, like what torch DistributedSampler does. 

@rich-junwang

Example:
```
sampler = SplitSampler(len(train_dataset), num_workers, rank, even_size=True)
train_iter = gluon.data.DataLoader(train_dataset, batch_size=batch_size, sampler=sampler)
```

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
