### PR TITLE
[CI] switch batch jobs to use G4dn.2x instance

### DIFF
--- a/ci/batch/submit-job.py
+++ b/ci/batch/submit-job.py
@@ -18,7 +18,7 @@ parser.add_argument('--name', help='name of the job', type=str, default='dummy')
 parser.add_argument('--job-queue', help='name of the job queue to submit this job', type=str,
                     default='gluon-nlp-jobs')
 parser.add_argument('--job-definition', help='name of the job job definition', type=str,
-                    default='gluon-nlp-jobs:6')
+                    default='gluon-nlp-jobs:8')
 parser.add_argument('--source-ref',
                     help='ref in GluonNLP main github. e.g. master, refs/pull/500/head',
                     type=str, default='master')


### PR DESCRIPTION
## Description ##
switch batch jobs to use g4dn.2x instance. the updated job definition reduces allocated memory from 40G to 30G since g4dn.2x has 32G memory

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] update batch job definition to reduce memory requirement

cc @dmlc/gluon-nlp-team
