### PR TITLE
[BUGFIX] avoid using dict for attention cell parameter creation

### DIFF
--- a/src/gluonnlp/model/attention_cell.py
+++ b/src/gluonnlp/model/attention_cell.py
@@ -217,8 +217,8 @@ class MultiHeadAttentionCell(AttentionCell):
         self._base_cell = base_cell
         self._num_heads = num_heads
         self._use_bias = use_bias
-        units = {'query': query_units, 'key': key_units, 'value': value_units}
-        for name, unit in units.items():
+        units = [('query', query_units), ('key', key_units), ('value', value_units)]
+        for name, unit in units:
             if unit % self._num_heads != 0:
                 raise ValueError(
                     'In MultiHeadAttetion, the {name}_units should be divided exactly'


### PR DESCRIPTION
## Description ##
To circumvent https://github.com/apache/incubator-mxnet/issues/17056 which causes bert distributed training to diverge 


## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
