### PR TITLE
[BUGFIX] unicode comma fix

### DIFF
--- a/scripts/language_model/word_language_model.py
+++ b/scripts/language_model/word_language_model.py
@@ -421,7 +421,7 @@ def train():
         else:
             model.save_parameters('{}.val.params'.format(args.save))
         val_L = evaluate(val_data, val_batch_size, '{}.val.params'.format(args.save), context[0])
-        print('[Epoch %d] time cost %.2fs, valid loss %.2f, valid ppl %.2f，lr %.2f' % (
+        print('[Epoch %d] time cost %.2fs, valid loss %.2f, valid ppl %.2f, lr %.2f' % (
             epoch, time.time() - start_epoch_time, val_L, math.exp(val_L),
             trainer.learning_rate))
 


### PR DESCRIPTION
## Description ##
There is a unicode comma in the print statement. It needed to be replaced with an ASCII comma.

Fixes #1055

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented


cc @dmlc/gluon-nlp-team
