### PR TITLE
[DOC] remove py3 usage from the doc

### DIFF
--- a/env/cpu/py3-master.yml
+++ b/env/cpu/py3-master.yml
@@ -5,6 +5,7 @@ dependencies:
   - pip
   - perl
   - pip:
+    - numpy==1.17.4
     - cython
     - boto3
     - pytype==2019.10.17

--- a/env/cpu/py3.yml
+++ b/env/cpu/py3.yml
@@ -30,6 +30,7 @@ dependencies:
   - boto3=1.9.207
   - scipy=1.3.1
   - pip:
+    - numpy==1.17.4
     - pylint-quotes==0.2.1
     - mxnet-mkl>=1.5.0
     - sacremoses

--- a/env/docker/py3.yml
+++ b/env/docker/py3.yml
@@ -8,6 +8,7 @@ dependencies:
   - tornado=5.1.1
   - sphinx=2.2.1
   - pip:
+    - numpy==1.17.4
     - notedown==1.5.1
     - sphinx-gallery==0.4.0
     - recommonmark==0.6.0

--- a/env/gpu/py3-master.yml
+++ b/env/gpu/py3-master.yml
@@ -8,6 +8,7 @@ dependencies:
   - tornado=5.1.1
   - sphinx=2.2.1
   - pip:
+    - numpy==1.17.4
     - notedown==1.5.1
     - sphinx-gallery==0.4.0
     - recommonmark==0.6.0

--- a/env/gpu/py3.yml
+++ b/env/gpu/py3.yml
@@ -29,6 +29,7 @@ dependencies:
   - regex
   - scipy=1.3.1
   - pip:
+    - numpy==1.17.4
     - pylint-quotes==0.2.1
     - mxnet-cu101mkl>=1.5.0
     - sacremoses

--- a/scripts/bert/index.rst
+++ b/scripts/bert/index.rst
@@ -258,7 +258,7 @@ Named Entity Recognition
 
 GluonNLP provides training and prediction script for named entity recognition models.
 
-The training script for NER requires python3 and the seqeval package:
+The training script for NER requires the seqeval package:
 
 .. code-block:: console
 
@@ -271,7 +271,7 @@ prefix in file names:
 
 .. code-block:: console
 
-    $ python3 finetune_ner.py \
+    $ python finetune_ner.py \
         --train-path ${DATA_DIR}/train.txt \
         --dev-path ${DATA_DIR}/dev.txt \
         --test-path ${DATA_DIR}/test.txt
@@ -366,7 +366,7 @@ Here's one example of the ATIS dataset, it uses the `IOB2 format <https://en.wik
 In this example, we demonstrate how to use GluonNLP to fine-tune a pretrained BERT model for joint intent classification and slot labelling. We
 choose to finetune a pretrained BERT model.  We use two datasets `ATIS <https://github.com/yvchen/JointSLU>`__ and `SNIPS <https://github.com/snipsco/nlu-benchmark/tree/master/2017-06-custom-intent-engines>`__.
 
-The training script requires python3 and the seqeval and tqdm packages:
+The training script requires the seqeval and tqdm packages:
 
 .. code-block:: console
 
@@ -377,7 +377,7 @@ For the ATIS dataset, use the following command to run the experiment:
 
 .. code-block:: console
 
-    $ python3 finetune_icsl.py --gpu 0 --dataset atis
+    $ python finetune_icsl.py --gpu 0 --dataset atis
 
 It produces the final slot labelling F1 = `95.83%` and intent classification accuracy = `98.66%`
 
@@ -385,7 +385,7 @@ For the SNIPS dataset, use the following command to run the experiment:
 
 .. code-block:: console
 
-    $ python3 finetune_icsl.py --gpu 0 --dataset snips
+    $ python finetune_icsl.py --gpu 0 --dataset snips
 
 It produces the final slot labelling F1 = `96.06%` and intent classification accuracy = `98.71%`
 

--- a/scripts/natural_language_inference/index.rst
+++ b/scripts/natural_language_inference/index.rst
@@ -17,19 +17,19 @@ Preprocess the data:
 
 .. code-block:: console
 
-	$ for split in train dev test; do python3 preprocess.py --input data/snli_1.0/snli_1.0_$split.txt --output data/snli_1.0/$split.txt; done
+	$ for split in train dev test; do python preprocess.py --input data/snli_1.0/snli_1.0_$split.txt --output data/snli_1.0/$split.txt; done
 
 Train the model without intra-sentence attention:
 
 .. code-block:: console
 
-	$ python3 main.py --train-file data/snli_1.0/train.txt --test-file data/snli_1.0/dev.txt --output-dir output/snli-basic --batch-size 32 --print-interval 5000 --lr 0.025 --epochs 300 --gpu-id 0 --dropout 0.2 --weight-decay 1e-5 --fix-embedding
+	$ python main.py --train-file data/snli_1.0/train.txt --test-file data/snli_1.0/dev.txt --output-dir output/snli-basic --batch-size 32 --print-interval 5000 --lr 0.025 --epochs 300 --gpu-id 0 --dropout 0.2 --weight-decay 1e-5 --fix-embedding
 
 Test:
 
 .. code-block:: console
 
-	$ python3 main.py --test-file data/snli_1.0/test.txt --model-dir output/snli-basic --gpu-id 0 --mode test --output-dir output/snli-basic/test 
+	$ python main.py --test-file data/snli_1.0/test.txt --model-dir output/snli-basic --gpu-id 0 --mode test --output-dir output/snli-basic/test
 
 We achieve 85.0% accuracy on the SNLI test set, comparable to 86.3% reported in the
 original paper. `[Training log] <https://github.com/dmlc/web-data/blob/master/gluonnlp/logs/natural_language_inference/decomposable_attention_snli.log>`__
@@ -38,13 +38,13 @@ Train the model with intra-sentence attention:
 
 .. code-block:: console
 
-	$ python3 main.py --train-file data/snli_1.0/train.txt --test-file data/snli_1.0/dev.txt --output-dir output/snli-intra --batch-size 32 --print-interval 5000 --lr 0.025 --epochs 300 --gpu-id 0 --dropout 0.2 --weight-decay 1e-5 --intra-attention --fix-embedding   
+	$ python main.py --train-file data/snli_1.0/train.txt --test-file data/snli_1.0/dev.txt --output-dir output/snli-intra --batch-size 32 --print-interval 5000 --lr 0.025 --epochs 300 --gpu-id 0 --dropout 0.2 --weight-decay 1e-5 --intra-attention --fix-embedding
 
 Test:
 
 .. code-block:: console
 
-	$ python3 main.py --test-file data/snli_1.0/test.txt --model-dir output/snli-intra --gpu-id 0 --mode test --output-dir output/snli-intra/test
+	$ python main.py --test-file data/snli_1.0/test.txt --model-dir output/snli-intra --gpu-id 0 --mode test --output-dir output/snli-intra/test
 
 We achieve 85.5% accuracy on the SNLI test set, compared to 86.8% reported in the
 original paper. `[Training log] <https://github.com/dmlc/web-data/blob/master/gluonnlp/logs/natural_language_inference/decomposable_intra_attention_snli.log>`__


### PR DESCRIPTION
## Description ##
remove py3 usage from the doc

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
