### PR TITLE
[Parallel] Avoid race condition when downloading datasets

### DIFF
--- a/src/gluonnlp/data/utils.py
+++ b/src/gluonnlp/data/utils.py
@@ -17,7 +17,6 @@
 
 """Utility classes and functions. They help organize and keep statistics of datasets."""
 import collections
-import errno
 import os
 import tarfile
 import zipfile

--- a/src/gluonnlp/utils/files.py
+++ b/src/gluonnlp/utils/files.py
@@ -17,7 +17,7 @@
 # pylint:disable=redefined-outer-name,logging-format-interpolation
 """Utility functions for files."""
 
-__all__ = ['mkdir', 'glob']
+__all__ = ['mkdir', 'glob', 'remove']
 
 import os
 import warnings
@@ -45,8 +45,28 @@ def glob(url, separator=','):
         result.extend(_glob.glob(os.path.expanduser(pattern.strip())))
     return result
 
+def remove(filename):
+    """Remove a file
+
+    Parameters
+    ----------
+    filename : str
+        The name of the target file to remove
+    """
+    if C.S3_PREFIX in filename:
+        msg = 'Removing objects on S3 is not supported: {}'.format(filename)
+        raise NotImplementedError(msg)
+    try:
+        os.remove(zip_file_path)
+    except OSError as e:
+        # file has already been removed.
+        if e.errno == 2:
+            pass
+        else:
+            raise e
+
 def mkdir(dirname):
-    """Create directory.
+    """Create a directory.
 
     Parameters
     ----------

--- a/src/gluonnlp/utils/files.py
+++ b/src/gluonnlp/utils/files.py
@@ -57,7 +57,7 @@ def remove(filename):
         msg = 'Removing objects on S3 is not supported: {}'.format(filename)
         raise NotImplementedError(msg)
     try:
-        os.remove(zip_file_path)
+        os.remove(filename)
     except OSError as e:
         # file has already been removed.
         if e.errno == 2:


### PR DESCRIPTION
## Description ##
Acquire a file lock before downloading the dataset. This helps when using multi-processing for multi-GPU training, or multi-machine training with a shared file system 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
