### PR TITLE
[BUGFIX] fix the weight tied and weight sharing collision error

### DIFF
--- a/src/gluonnlp/model/train/language_model.py
+++ b/src/gluonnlp/model/train/language_model.py
@@ -18,7 +18,7 @@
 __all__ = ['AWDRNN', 'StandardRNN', 'BigRNN']
 
 from mxnet import init, nd, autograd
-from mxnet.gluon import nn, Block, HybridBlock, contrib, rnn
+from mxnet.gluon import nn, Block, HybridBlock, contrib, rnn, ParameterDict
 from mxnet import sym
 
 from ..utils import _get_rnn_layer, apply_weight_drop
@@ -71,6 +71,9 @@ class AWDRNN(HybridBlock):
         self._drop_e = drop_e
         self._weight_drop = weight_drop
         self._tie_weights = tie_weights
+        self._weight_share = False
+        if 'params' in kwargs and kwargs['params'] is not None:
+            self._weight_share = True
 
         with self.name_scope():
             self.embedding = self._get_embedding()
@@ -103,8 +106,15 @@ class AWDRNN(HybridBlock):
         output = nn.HybridSequential()
         with output.name_scope():
             if self._tie_weights:
-                output.add(nn.Dense(self._vocab_size, flatten=False,
-                                    params=self.embedding[0].params))
+                if self._weight_share:
+                    shared_params = self.embedding[0].params
+                    shared_params = ParameterDict(shared_params.prefix)
+                    shared_params.update(output._params._shared)
+                    output.add(nn.Dense(self._vocab_size, flatten=False,
+                                        params=shared_params))
+                else:
+                    output.add(nn.Dense(self._vocab_size, flatten=False,
+                                        params=self.embedding[0].params))
             else:
                 output.add(nn.Dense(self._vocab_size, flatten=False))
         return output

--- a/src/gluonnlp/model/train/language_model.py
+++ b/src/gluonnlp/model/train/language_model.py
@@ -71,6 +71,9 @@ class AWDRNN(HybridBlock):
         self._drop_e = drop_e
         self._weight_drop = weight_drop
         self._tie_weights = tie_weights
+        self._shared_params = None
+        if 'params' in kwargs:
+            self._shared_params = kwargs['params']
 
         with self.name_scope():
             self.embedding = self._get_embedding()
@@ -103,10 +106,10 @@ class AWDRNN(HybridBlock):
         output = nn.HybridSequential()
         with output.name_scope():
             if self._tie_weights:
-                if output._params._shared is not None:
+                if self._shared_params is not None:
                     shared_params = self.embedding[0].params
                     shared_params = ParameterDict(shared_params.prefix)
-                    shared_params.update(output._params._shared)
+                    shared_params.update(self._shared_params)
                     output.add(nn.Dense(self._vocab_size, flatten=False,
                                         params=shared_params))
                 else:

--- a/src/gluonnlp/model/train/language_model.py
+++ b/src/gluonnlp/model/train/language_model.py
@@ -71,9 +71,6 @@ class AWDRNN(HybridBlock):
         self._drop_e = drop_e
         self._weight_drop = weight_drop
         self._tie_weights = tie_weights
-        self._weight_share = False
-        if 'params' in kwargs and kwargs['params'] is not None:
-            self._weight_share = True
 
         with self.name_scope():
             self.embedding = self._get_embedding()
@@ -106,7 +103,7 @@ class AWDRNN(HybridBlock):
         output = nn.HybridSequential()
         with output.name_scope():
             if self._tie_weights:
-                if self._weight_share:
+                if output._params._shared is not None:
                     shared_params = self.embedding[0].params
                     shared_params = ParameterDict(shared_params.prefix)
                     shared_params.update(output._params._shared)

--- a/src/gluonnlp/model/train/language_model.py
+++ b/src/gluonnlp/model/train/language_model.py
@@ -107,6 +107,10 @@ class AWDRNN(HybridBlock):
         with output.name_scope():
             if self._tie_weights:
                 if self._shared_params is not None:
+                    # self.embedding[0].params do not contain the bias, it
+                    # may leave the decoder bias uninitialized. We resolve this
+                    # issue by creating a new ParameterDict and stuffing
+                    # every shared params into the ParameterDict.
                     shared_params = self.embedding[0].params
                     shared_params = ParameterDict(shared_params.prefix)
                     shared_params.update(self._shared_params)


### PR DESCRIPTION
## Description ##
Resolve the conflict between weight sharing and weight tied. 
Fixes #1086

Running the code below:
```python
model = nlp.model.train.AWDRNN(args.model, len(vocab), args.emsize, args.nhid, args.nlayers,
                               args.tied, args.dropout, args.weight_dropout,
                               args.dropout_h, args.dropout_i, args.dropout_e)
model_eval = nlp.model.AWDRNN(args.model, len(vocab), args.emsize, args.nhid, args.nlayers,
                              args.tied, args.dropout, args.weight_dropout,
                              args.dropout_h, args.dropout_i, args.dropout_e,
                              params=model.collect_params())

model.initialize(mx.init.Xavier(), ctx=context)

model.hybridize(static_alloc=True)

print(model)

def check_initialized(net):
    params = net.collect_params()
    for param in params:
        try:
            params[param].list_ctx()
        except RuntimeError:
            return False
    return True

print(check_initialized(model))
print(check_initialized(model_eval))
```
It now produces the right answer:
```python
True
True
```

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
