### PR TITLE
[BUGFIX] modify the log average loss

### DIFF
--- a/scripts/machine_translation/train_gnmt.py
+++ b/scripts/machine_translation/train_gnmt.py
@@ -170,10 +170,10 @@ def evaluate(data_loader):
         tgt_valid_length = tgt_valid_length.as_in_context(ctx)
         # Calculating Loss
         out, _ = model(src_seq, tgt_seq[:, :-1], src_valid_length, tgt_valid_length - 1)
-        loss = loss_function(out, tgt_seq[:, 1:], tgt_valid_length - 1).mean().asscalar()
+        loss = loss_function(out, tgt_seq[:, 1:], tgt_valid_length - 1).sum().asscalar()
         all_inst_ids.extend(inst_ids.asnumpy().astype(np.int32).tolist())
         avg_loss += loss * (tgt_seq.shape[1] - 1)
-        avg_loss_denom += (tgt_seq.shape[1] - 1)
+        avg_loss_denom += (tgt_valid_length - 1).sum().asscalar()
         # Translate
         samples, _, sample_valid_length = translator.translate(
             src_seq=src_seq, src_valid_length=src_valid_length)
@@ -199,7 +199,8 @@ def train():
 
     best_valid_bleu = 0.0
     for epoch_id in range(args.epochs):
-        log_avg_loss = 0
+        log_loss = 0
+        log_denom = 0
         log_avg_gnorm = 0
         log_wc = 0
         log_start_time = time.time()
@@ -213,15 +214,18 @@ def train():
             with mx.autograd.record():
                 out, _ = model(src_seq, tgt_seq[:, :-1], src_valid_length, tgt_valid_length - 1)
                 loss = loss_function(out, tgt_seq[:, 1:], tgt_valid_length - 1).mean()
-                loss = loss * (tgt_seq.shape[1] - 1) / (tgt_valid_length - 1).mean()
+                loss = loss * (tgt_seq.shape[1] - 1)
+                log_loss += loss * tgt_seq.shape[0]
+                log_denom += (tgt_valid_length - 1).sum()
+                loss = loss / (tgt_valid_length - 1).mean()
                 loss.backward()
             grads = [p.grad(ctx) for p in model.collect_params().values()]
             gnorm = gluon.utils.clip_global_norm(grads, args.clip)
             trainer.step(1)
             src_wc = src_valid_length.sum().asscalar()
             tgt_wc = (tgt_valid_length - 1).sum().asscalar()
-            step_loss = loss.asscalar()
-            log_avg_loss += step_loss
+            log_loss = log_loss.asscalar()
+            log_denom = log_denom.asscalar()
             log_avg_gnorm += gnorm
             log_wc += src_wc + tgt_wc
             if (batch_id + 1) % args.log_interval == 0:
@@ -229,12 +233,13 @@ def train():
                 logging.info('[Epoch {} Batch {}/{}] loss={:.4f}, ppl={:.4f}, gnorm={:.4f}, '
                              'throughput={:.2f}K wps, wc={:.2f}K'
                              .format(epoch_id, batch_id + 1, len(train_data_loader),
-                                     log_avg_loss / args.log_interval,
-                                     np.exp(log_avg_loss / args.log_interval),
+                                     log_loss / log_denom,
+                                     np.exp(log_loss / log_denom),
                                      log_avg_gnorm / args.log_interval,
                                      wps / 1000, log_wc / 1000))
                 log_start_time = time.time()
-                log_avg_loss = 0
+                log_loss = 0
+                log_denom = 0
                 log_avg_gnorm = 0
                 log_wc = 0
         valid_loss, valid_translation_out = evaluate(val_data_loader)


### PR DESCRIPTION
## Description ##
Modify the log average loss during training and validation proposed in #1102 .

Fixes #1102.

The log message looks like:
```
2020-01-08 08:53:50,968 - root - [Epoch 0 Batch 100/1043] loss=6.4215, ppl=614.9522, gnorm=0.7030, throughput=39.15K wps, wc=606.57K
2020-01-08 08:54:04,325 - root - [Epoch 0 Batch 200/1043] loss=5.8612, ppl=351.1320, gnorm=0.3394, throughput=43.74K wps, wc=584.18K
2020-01-08 08:54:17,698 - root - [Epoch 0 Batch 300/1043] loss=5.4339, ppl=229.0387, gnorm=0.3442, throughput=44.33K wps, wc=592.78K
2020-01-08 08:54:30,365 - root - [Epoch 0 Batch 400/1043] loss=5.0884, ppl=162.1247, gnorm=0.3193, throughput=45.10K wps, wc=571.26K
2020-01-08 08:54:42,646 - root - [Epoch 0 Batch 500/1043] loss=4.8152, ppl=123.3674, gnorm=0.3304, throughput=45.15K wps, wc=554.48K
2020-01-08 08:54:54,788 - root - [Epoch 0 Batch 600/1043] loss=4.6290, ppl=102.4127, gnorm=0.3167, throughput=44.99K wps, wc=546.26K
2020-01-08 08:55:07,879 - root - [Epoch 0 Batch 700/1043] loss=4.4968, ppl=89.7277, gnorm=0.3128, throughput=43.31K wps, wc=566.96K
2020-01-08 08:55:20,536 - root - [Epoch 0 Batch 800/1043] loss=4.3731, ppl=79.2917, gnorm=0.3120, throughput=43.57K wps, wc=551.40K
2020-01-08 08:55:33,160 - root - [Epoch 0 Batch 900/1043] loss=4.2842, ppl=72.5451, gnorm=0.3177, throughput=45.76K wps, wc=577.61K
2020-01-08 08:55:46,234 - root - [Epoch 0 Batch 1000/1043] loss=4.2068, ppl=67.1437, gnorm=0.3055, throughput=44.99K wps, wc=588.16K
2020-01-08 08:56:07,177 - root - [Epoch 0] valid Loss=4.0706, valid ppl=58.5939, valid bleu=3.06
2020-01-08 08:56:19,967 - root - [Epoch 0] test Loss=4.1586, test ppl=63.9789, test bleu=2.72
2020-01-08 08:56:19,973 - root - Save best parameters to gnmt_en_vi_l2_h512_beam10/valid_best.params
2020-01-08 08:56:33,670 - root - [Epoch 1 Batch 100/1043] loss=4.0797, ppl=59.1269, gnorm=0.3241, throughput=44.73K wps, wc=593.66K
2020-01-08 08:56:47,342 - root - [Epoch 1 Batch 200/1043] loss=4.0627, ppl=58.1332, gnorm=0.3102, throughput=46.20K wps, wc=631.62K
2020-01-08 08:57:00,902 - root - [Epoch 1 Batch 300/1043] loss=3.9731, ppl=53.1482, gnorm=0.3028, throughput=44.22K wps, wc=599.65K
2020-01-08 08:57:14,253 - root - [Epoch 1 Batch 400/1043] loss=3.8960, ppl=49.2063, gnorm=0.3091, throughput=43.87K wps, wc=585.70K
2020-01-08 08:57:27,026 - root - [Epoch 1 Batch 500/1043] loss=3.8288, ppl=46.0072, gnorm=0.3117, throughput=44.40K wps, wc=567.14K
2020-01-08 08:57:38,951 - root - [Epoch 1 Batch 600/1043] loss=3.7593, ppl=42.9191, gnorm=0.3261, throughput=43.74K wps, wc=521.63K
2020-01-08 08:57:52,448 - root - [Epoch 1 Batch 700/1043] loss=3.8015, ppl=44.7673, gnorm=0.3136, throughput=43.86K wps, wc=591.94K
2020-01-08 08:58:05,002 - root - [Epoch 1 Batch 800/1043] loss=3.7148, ppl=41.0497, gnorm=0.3299, throughput=44.91K wps, wc=563.74K
2020-01-08 08:58:18,252 - root - [Epoch 1 Batch 900/1043] loss=3.6045, ppl=36.7644, gnorm=0.3157, throughput=43.63K wps, wc=578.06K
2020-01-08 08:58:30,346 - root - [Epoch 1 Batch 1000/1043] loss=3.5059, ppl=33.3121, gnorm=0.3349, throughput=43.29K wps, wc=523.53K
2020-01-08 08:58:48,447 - root - [Epoch 1] valid Loss=3.4634, valid ppl=31.9260, valid bleu=7.37
2020-01-08 08:59:00,361 - root - [Epoch 1] test Loss=3.4913, test ppl=32.8275, test bleu=7.86
2020-01-08 08:59:00,367 - root - Save best parameters to gnmt_en_vi_l2_h512_beam10/valid_best.params
2020-01-08 08:59:13,555 - root - [Epoch 2 Batch 100/1043] loss=3.3069, ppl=27.3007, gnorm=0.3481, throughput=42.90K wps, wc=542.87K
```

The log message prior to this fix is:
```
2020-01-08 07:23:10,514 - root - [Epoch 0 Batch 100/1043] loss=6.2948, ppl=541.7368, gnorm=0.7030, throughput=38.01K wps, wc=606.57K
2020-01-08 07:23:23,880 - root - [Epoch 0 Batch 200/1043] loss=5.7232, ppl=305.8789, gnorm=0.3394, throughput=43.71K wps, wc=584.18K
2020-01-08 07:23:36,590 - root - [Epoch 0 Batch 300/1043] loss=5.2613, ppl=192.7247, gnorm=0.3442, throughput=46.64K wps, wc=592.78K
2020-01-08 07:23:49,343 - root - [Epoch 0 Batch 400/1043] loss=4.9213, ppl=137.1854, gnorm=0.3193, throughput=44.79K wps, wc=571.26K
2020-01-08 07:24:01,503 - root - [Epoch 0 Batch 500/1043] loss=4.6531, ppl=104.9109, gnorm=0.3304, throughput=45.60K wps, wc=554.48K
2020-01-08 07:24:14,218 - root - [Epoch 0 Batch 600/1043] loss=4.4185, ppl=82.9729, gnorm=0.3167, throughput=42.96K wps, wc=546.26K
2020-01-08 07:24:26,804 - root - [Epoch 0 Batch 700/1043] loss=4.3236, ppl=75.4571, gnorm=0.3128, throughput=45.05K wps, wc=566.96K
2020-01-08 07:24:39,098 - root - [Epoch 0 Batch 800/1043] loss=4.2010, ppl=66.7544, gnorm=0.3120, throughput=44.86K wps, wc=551.40K
2020-01-08 07:24:51,588 - root - [Epoch 0 Batch 900/1043] loss=4.0903, ppl=59.7581, gnorm=0.3177, throughput=46.25K wps, wc=577.61K
2020-01-08 07:25:04,737 - root - [Epoch 0 Batch 1000/1043] loss=4.0345, ppl=56.5169, gnorm=0.3055, throughput=44.73K wps, wc=588.16K
2020-01-08 07:25:25,812 - root - [Epoch 0] valid Loss=3.0219, valid ppl=20.5296, valid bleu=3.06
2020-01-08 07:25:38,293 - root - [Epoch 0] test Loss=3.1398, test ppl=23.0996, test bleu=2.72
2020-01-08 07:25:38,299 - root - Save best parameters to gnmt_en_vi_l2_h512_beam10/valid_best.params
2020-01-08 07:25:51,729 - root - [Epoch 1 Batch 100/1043] loss=3.8406, ppl=46.5551, gnorm=0.3241, throughput=46.13K wps, wc=593.66K
2020-01-08 07:26:05,829 - root - [Epoch 1 Batch 200/1043] loss=3.8650, ppl=47.7020, gnorm=0.3102, throughput=44.80K wps, wc=631.62K
2020-01-08 07:26:19,786 - root - [Epoch 1 Batch 300/1043] loss=3.8157, ppl=45.4108, gnorm=0.3028, throughput=42.97K wps, wc=599.65K
2020-01-08 07:26:32,657 - root - [Epoch 1 Batch 400/1043] loss=3.7100, ppl=40.8531, gnorm=0.3091, throughput=45.51K wps, wc=585.70K
2020-01-08 07:26:45,399 - root - [Epoch 1 Batch 500/1043] loss=3.6674, ppl=39.1519, gnorm=0.3117, throughput=44.51K wps, wc=567.14K
2020-01-08 07:26:57,125 - root - [Epoch 1 Batch 600/1043] loss=3.5434, ppl=34.5833, gnorm=0.3261, throughput=44.49K wps, wc=521.63K
2020-01-08 07:27:10,752 - root - [Epoch 1 Batch 700/1043] loss=3.5904, ppl=36.2497, gnorm=0.3136, throughput=43.44K wps, wc=591.94K
2020-01-08 07:27:23,379 - root - [Epoch 1 Batch 800/1043] loss=3.4860, ppl=32.6562, gnorm=0.3299, throughput=44.65K wps, wc=563.74K
2020-01-08 07:27:36,107 - root - [Epoch 1 Batch 900/1043] loss=3.4471, ppl=31.4081, gnorm=0.3157, throughput=45.42K wps, wc=578.06K
2020-01-08 07:27:48,146 - root - [Epoch 1 Batch 1000/1043] loss=3.3270, ppl=27.8557, gnorm=0.3349, throughput=43.49K wps, wc=523.53K
2020-01-08 07:28:06,191 - root - [Epoch 1] valid Loss=2.5888, valid ppl=13.3142, valid bleu=7.37
2020-01-08 07:28:18,089 - root - [Epoch 1] test Loss=2.6505, test ppl=14.1612, test bleu=7.86

```

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

