### PR TITLE
FEATURE: multi-tensor Update - Adam Optimizer 

### DIFF
--- a/src/gluonnlp/optimizer/bert_adam.py
+++ b/src/gluonnlp/optimizer/bert_adam.py
@@ -64,7 +64,7 @@ class BERTAdam(Optimizer):
         self.beta1 = beta1
         self.beta2 = beta2
         self.epsilon = epsilon
-        self.aggregate_num = max(1,min(50,int(os.getenv('MXNET_OPTIMIZER_AGGREGATION_SIZE',"4"))))
+        self.aggregate_num = max(1, min(50, int(os.getenv('MXNET_OPTIMIZER_AGGREGATION_SIZE', "4"))))
 
     def create_state_multi_precision(self, index, weight):
         """multi-precision state creation function."""
@@ -115,9 +115,9 @@ class BERTAdam(Optimizer):
                                   'pip install mxnet-cu90 --pre. Otherwise, please consider '
                                   'Adam optimizer with different hyper-parameters.')
         if self.aggregate_num > 1:
-          aggregate = True
+            aggregate = True
         else:
-          aggregate = False
+            aggregate = False
         if not isinstance(indices, (tuple, list)):
             indices = [indices]
             weight = [weight]
@@ -164,8 +164,8 @@ class BERTAdam(Optimizer):
                 else:
                     mean_var = list(zip(*state[sidx:eidx]))[0]
                     tmean_var = list(zip(*mean_var))
-                    mean=tmean_var[0]
-                    var=tmean_var[1]
+                    mean = tmean_var[0]
+                    var = tmean_var[1]
                     multi_mp_adamw_update(weight[sidx:eidx],
                                           grad[sidx:eidx],
                                           mean, var,
@@ -182,7 +182,7 @@ class BERTAdam(Optimizer):
                 if not multi_precision:
                     mean, var = s_i
                     adamw_update(w_i, g_i, mean, var, out=w_i,
-                                lr=1, wd=wd, eta=lr, **kwargs)
+                                 lr=1, wd=wd, eta=lr, **kwargs)
                 else:
                     mean, var = s_i[0]
                     mp_adamw_update(w_i, g_i, mean, var, s_i[1], out=w_i,

--- a/src/gluonnlp/optimizer/bert_adam.py
+++ b/src/gluonnlp/optimizer/bert_adam.py
@@ -22,6 +22,8 @@ import warnings
 import numpy
 from mxnet.optimizer import Optimizer, register
 from mxnet.ndarray import zeros, NDArray, full
+from mxnet.ndarray.contrib import adamw_update, multi_adamw_update, \
+    mp_adamw_update, multi_mp_adamw_update
 
 __all__ = ['BERTAdam']
 
@@ -97,24 +99,6 @@ class BERTAdam(Optimizer):
 
     def _update_impl(self, indices, weight, grad, state, multi_precision=False):
         """update function"""
-        try:
-            from mxnet.ndarray.contrib import adamw_update, multi_adamw_update
-        except ImportError:
-            raise ImportError('Failed to import nd.contrib.adamw_update from MXNet. '
-                              'BERTAdam optimizer requires mxnet>=1.5.0b20190220. '
-                              'Please upgrade your MXNet version. For example: '
-                              'pip install mxnet-cu90 --pre. Otherwise, please consider '
-                              'Adam optimizer with different hyper-parameters.')
-        if multi_precision:
-            try:
-                from mxnet.ndarray.contrib import mp_adamw_update, multi_mp_adamw_update
-            except ImportError:
-                raise ImportError('Failed to import '
-                                  'nd.contrib.mp_adamw_update from MXNet. '
-                                  'BERTAdam optimizer requires mxnet>=1.5.0b20190220. '
-                                  'Please upgrade your MXNet version. For example: '
-                                  'pip install mxnet-cu90 --pre. Otherwise, please consider '
-                                  'Adam optimizer with different hyper-parameters.')
         aggregate = self.aggregate_num > 1
         if not isinstance(indices, (tuple, list)):
             indices = [indices]

--- a/src/gluonnlp/optimizer/bert_adam.py
+++ b/src/gluonnlp/optimizer/bert_adam.py
@@ -64,8 +64,8 @@ class BERTAdam(Optimizer):
         self.beta1 = beta1
         self.beta2 = beta2
         self.epsilon = epsilon
-        self.aggregate_num = max(1,
-            min(50, int(os.getenv('MXNET_OPTIMIZER_AGGREGATION_SIZE', '4'))))
+        self.aggregate_num = max(1, min(50, int(os.getenv('MXNET_OPTIMIZER_AGGREGATION_SIZE',
+                                                          '4'))))
 
     def create_state_multi_precision(self, index, weight):
         """multi-precision state creation function."""

--- a/src/gluonnlp/optimizer/bert_adam.py
+++ b/src/gluonnlp/optimizer/bert_adam.py
@@ -17,11 +17,11 @@
 # under the License.
 
 """Weight updating functions."""
+import os
 import warnings
 import numpy
 from mxnet.optimizer import Optimizer, register
 from mxnet.ndarray import zeros, NDArray, full
-import os
 
 __all__ = ['BERTAdam']
 
@@ -64,7 +64,8 @@ class BERTAdam(Optimizer):
         self.beta1 = beta1
         self.beta2 = beta2
         self.epsilon = epsilon
-        self.aggregate_num = max(1, min(50, int(os.getenv('MXNET_OPTIMIZER_AGGREGATION_SIZE', "4"))))
+        self.aggregate_num = max(1,
+            min(50, int(os.getenv('MXNET_OPTIMIZER_AGGREGATION_SIZE', '4'))))
 
     def create_state_multi_precision(self, index, weight):
         """multi-precision state creation function."""
@@ -114,10 +115,7 @@ class BERTAdam(Optimizer):
                                   'Please upgrade your MXNet version. For example: '
                                   'pip install mxnet-cu90 --pre. Otherwise, please consider '
                                   'Adam optimizer with different hyper-parameters.')
-        if self.aggregate_num > 1:
-            aggregate = True
-        else:
-            aggregate = False
+        aggregate = self.aggregate_num > 1
         if not isinstance(indices, (tuple, list)):
             indices = [indices]
             weight = [weight]
@@ -145,7 +143,6 @@ class BERTAdam(Optimizer):
             kwargs['clip_gradient'] = self.clip_gradient
 
         if aggregate:
-            import numpy as np
             current_index = 0
             while current_index < len(indices):
                 sidx = current_index
@@ -157,7 +154,7 @@ class BERTAdam(Optimizer):
                                        mean, var,
                                        out=weight[sidx:eidx],
                                        size=len(weight[sidx:eidx]),
-                                       lrs=list(np.ones(len(weight[sidx:eidx]))),
+                                       lrs=list(numpy.ones(len(weight[sidx:eidx]))),
                                        wds=wds[sidx:eidx],
                                        etas=lrs[sidx:eidx],
                                        **kwargs)
@@ -172,7 +169,7 @@ class BERTAdam(Optimizer):
                                           list(zip(*state[sidx:eidx]))[1],
                                           out=weight[sidx:eidx],
                                           size=len(weight[sidx:eidx]),
-                                          lrs=list(np.ones(len(weight[sidx:eidx]))),
+                                          lrs=list(numpy.ones(len(weight[sidx:eidx]))),
                                           wds=wds[sidx:eidx],
                                           etas=lrs[sidx:eidx],
                                           **kwargs)

--- a/tests/unittest/test_optimizer.py
+++ b/tests/unittest/test_optimizer.py
@@ -34,33 +34,55 @@ def compare_ndarray_tuple(t1, t2, rtol=None, atol=None):
 def compare_optimizer(opt1, opt2, shape, dtype, w_stype='default', g_stype='default',
                       rtol=1e-4, atol=1e-5, compare_states=True):
     """Compare opt1 and opt2."""
-    if w_stype == 'default':
-        w2 = mx.random.uniform(shape=shape, ctx=default_context(), dtype=dtype)
-        w1 = w2.copyto(default_context())
-    elif w_stype == 'row_sparse' or w_stype == 'csr':
-        w2 = rand_ndarray(shape, w_stype, density=1, dtype=dtype)
-        w1 = w2.copyto(default_context()).tostype('default')
-    else:
-        raise Exception("type not supported yet")
-    if g_stype == 'default':
-        g2 = mx.random.uniform(shape=shape, ctx=default_context(), dtype=dtype)
-        g1 = g2.copyto(default_context())
-    elif g_stype == 'row_sparse' or g_stype == 'csr':
-        g2 = rand_ndarray(shape, g_stype, dtype=dtype)
-        g1 = g2.copyto(default_context()).tostype('default')
-    else:
-        raise Exception("type not supported yet")
+    if not isinstance(shape, list):
+        if w_stype == 'default':
+            w2 = mx.random.uniform(shape=shape, ctx=default_context(), dtype=dtype)
+            w1 = w2.copyto(default_context())
+        elif w_stype == 'row_sparse' or w_stype == 'csr':
+            w2 = rand_ndarray(shape, w_stype, density=1, dtype=dtype)
+            w1 = w2.copyto(default_context()).tostype('default')
+        else:
+            raise Exception("type not supported yet")
+        if g_stype == 'default':
+            g2 = mx.random.uniform(shape=shape, ctx=default_context(), dtype=dtype)
+            g1 = g2.copyto(default_context())
+        elif g_stype == 'row_sparse' or g_stype == 'csr':
+            g2 = rand_ndarray(shape, g_stype, dtype=dtype)
+            g1 = g2.copyto(default_context()).tostype('default')
+        else:
+            raise Exception("type not supported yet")
 
-    state1 = opt1.create_state_multi_precision(0, w1)
-    state2 = opt2.create_state_multi_precision(0, w2)
-    if compare_states:
-        compare_ndarray_tuple(state1, state2)
+        state1 = opt1.create_state_multi_precision(0, w1)
+        state2 = opt2.create_state_multi_precision(0, w2)
+        if compare_states:
+            compare_ndarray_tuple(state1, state2)
 
-    opt1.update_multi_precision(0, w1, g1, state1)
-    opt2.update_multi_precision(0, w2, g2, state2)
-    if compare_states:
-        compare_ndarray_tuple(state1, state2, rtol=rtol, atol=atol)
-    assert_almost_equal(w1.asnumpy(), w2.asnumpy(), rtol=rtol, atol=atol)
+        opt1.update_multi_precision(0, w1, g1, state1)
+        opt2.update_multi_precision(0, w2, g2, state2)
+        if compare_states:
+            compare_ndarray_tuple(state1, state2, rtol=rtol, atol=atol)
+        assert_almost_equal(w1.asnumpy(), w2.asnumpy(), rtol=rtol, atol=atol)
+
+    else:
+        # test multi-tensor: Opt1 single-tensor reference, Opt2 multi-tensor
+        from copy import deepcopy
+        ntensors = len(shape)
+        w1, g1 = [], []
+        for s in shape:
+            w1.append(mx.random.uniform(shape=s, ctx=default_context(), dtype=dtype))
+            g1.append(mx.random.uniform(shape=s, ctx=default_context(), dtype=dtype))
+        w1 = tuple(w1)
+        w2 = deepcopy(w1)
+        g1 = tuple(g1)
+        g2 = deepcopy(g1)
+        state2 = [opt2.create_state_multi_precision(0, w2[i]) for i in range(ntensors)]
+        opt2.update_multi_precision(list(range(ntensors)), w2, g2, state2)
+        for i in range(ntensors):
+            state1 = opt1.create_state_multi_precision(i, w1[i])
+            opt1.update_multi_precision(i, w1[i], g1[i], state1)
+            if compare_states:
+                compare_ndarray_tuple(state1, state2[i], rtol, atol)
+            assert_almost_equal(w1[i].asnumpy(), w2[i].asnumpy(), rtol=rtol, atol=atol)
 
 # BERT ADAM
 class PyBERTAdam(mx.optimizer.Optimizer):
@@ -161,6 +183,42 @@ def test_bert_adam():
                         rtol = 1e-4
                     try:
                         compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, dtype,
+                                          rtol=rtol, atol=2e-5)
+                    except ImportError:
+                        print('skipping test_bert_adam() because an old version of MXNet is found')
+                        return
+
+def test_bert_multi_adam():
+    opt1 = PyBERTAdam
+    opt2 = optimizer.BERTAdam
+    # shapes as Bert-large
+    dims_x = [1024, 4096, 1024, 1024]
+    dims_y = [1, 1, 1024, 4096]
+    dims_occurrences = [3, 1, 2, 2]
+    nlayers = 2
+    shapes=[]
+    for l in range(nlayers):
+        for i, (dx,dy) in enumerate(zip(dims_x, dims_y)):
+            for j in range(dims_occurrences[i]):
+                shapes.append((dx,dy))
+    cg_options = [{}, {'clip_gradient': 0.4}, {'clip_gradient': 0.5}]
+    rg_options = [{}, {'rescale_grad': 0.14}, {'rescale_grad': 0.8}]
+    wd_options = [{}, {'wd': 0.03}, {'wd': 0.05}]
+    for dtype in [np.float16, np.float32]:
+        for cg_option in cg_options:
+            for rg_option in rg_options:
+                for wd_option in wd_options:
+                    kwarg = {}
+                    kwarg.update(cg_option)
+                    kwarg.update(rg_option)
+                    kwarg.update(wd_option)
+                    if np.float16 == dtype:
+                        kwarg['multi_precision'] = True
+                        rtol = 1e-3
+                    else:
+                        rtol = 1e-4
+                    try:
+                        compare_optimizer(opt1(**kwarg), opt2(**kwarg), shapes, dtype,
                                           rtol=rtol, atol=2e-5)
                     except ImportError:
                         print('skipping test_bert_adam() because an old version of MXNet is found')


### PR DESCRIPTION
## Description ##
Using a multi-tensor update operator, instead of single-tensor update operator, for updating the weights in Adam Optimizer.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Modification in Adam optimizer for adding the possibility of updating several weight tensors within same operator. This expose more parallelism several. Up to 50 tensors can be updated within the operator. Observed ~7% throughput increase on V100.  The multi-tensor version will be used when MXNET_OPTIMIZER_AGGREGATION_SIZE > 1

## Comments ##
