### PR TITLE
Adam multitensor

### DIFF
--- a/src/gluonnlp/optimizer/bert_adam.py
+++ b/src/gluonnlp/optimizer/bert_adam.py
@@ -16,11 +16,13 @@
 # under the License.
 
 """Weight updating functions."""
+import os
 import warnings
 import numpy
 from mxnet.optimizer import Optimizer, register
 from mxnet.ndarray import zeros, NDArray, full
-from mxnet.ndarray.contrib import mp_adamw_update, adamw_update
+from mxnet.ndarray.contrib import mp_adamw_update, adamw_update, \
+    multi_mp_adamw_update, multi_adamw_update
 
 __all__ = ['BERTAdam']
 
@@ -63,6 +65,8 @@ class BERTAdam(Optimizer):
         self.beta1 = beta1
         self.beta2 = beta2
         self.epsilon = epsilon
+        self.aggregate_num = max(1, min(50, int(os.getenv('MXNET_OPTIMIZER_AGGREGATION_SIZE',
+                                                          '4'))))
 
     def create_state_multi_precision(self, index, weight):
         """multi-precision state creation function."""
@@ -88,31 +92,78 @@ class BERTAdam(Optimizer):
 
     def update_multi_precision(self, index, weight, grad, state):
         """multi-precision update function"""
-        use_multi_precision = self.multi_precision and weight.dtype == numpy.float16
+        use_multi_precision = self.multi_precision and weight[0].dtype == numpy.float16
         self._update_impl(index, weight, grad, state,
                           multi_precision=use_multi_precision)
 
     def _update_impl(self, indices, weight, grad, state, multi_precision=False):
         """update function"""
+        aggregate = self.aggregate_num > 1
+        if not isinstance(indices, (tuple, list)):
+            indices = [indices]
+            weight = [weight]
+            grad = [grad]
+            state = [state]
+        for w_i, g_i in zip(weight, grad):
+            assert(isinstance(w_i, NDArray))
+            assert(isinstance(g_i, NDArray))
+            aggregate = (aggregate and
+                         w_i.stype == 'default' and
+                         g_i.stype == 'default')
         self._update_count(indices)
-        lr = self._get_lr(indices)
-        wd = self._get_wd(indices)
+        lrs = self._get_lrs(indices)
+        wds = self._get_wds(indices)
 
         # pylint: disable=access-member-before-definition
         if not isinstance(self.rescale_grad, NDArray):
-            self.rescale_grad = full(shape=(1,), val=self.rescale_grad, ctx=weight.context)
+            self.rescale_grad = full(shape=(1,), val=self.rescale_grad, ctx=weight[0].context)
         else:
-            self.rescale_grad = self.rescale_grad.as_in_context(weight.context)
+            self.rescale_grad = self.rescale_grad.as_in_context(weight[0].context)
 
         kwargs = {'beta1': self.beta1, 'beta2': self.beta2, 'epsilon': self.epsilon,
                   'rescale_grad': self.rescale_grad}
         if self.clip_gradient:
             kwargs['clip_gradient'] = self.clip_gradient
-        if not multi_precision:
-            mean, var = state
-            adamw_update(weight, grad, mean, var, out=weight,
-                         lr=1, wd=wd, eta=lr, **kwargs)
+
+        if aggregate:
+            current_index = 0
+            while current_index < len(indices):
+                sidx = current_index
+                eidx = min(current_index + self.aggregate_num, len(indices))
+                if not multi_precision:
+                    mean, var = list(zip(*state[sidx:eidx]))
+                    multi_adamw_update(weight[sidx:eidx],
+                                       grad[sidx:eidx],
+                                       mean, var,
+                                       out=weight[sidx:eidx],
+                                       size=len(weight[sidx:eidx]),
+                                       lrs=list(numpy.ones(len(weight[sidx:eidx]))),
+                                       wds=wds[sidx:eidx],
+                                       etas=lrs[sidx:eidx],
+                                       **kwargs)
+                else:
+                    mean_var = list(zip(*state[sidx:eidx]))[0]
+                    tmean_var = list(zip(*mean_var))
+                    mean = tmean_var[0]
+                    var = tmean_var[1]
+                    multi_mp_adamw_update(weight[sidx:eidx],
+                                          grad[sidx:eidx],
+                                          mean, var,
+                                          list(zip(*state[sidx:eidx]))[1],
+                                          out=weight[sidx:eidx],
+                                          size=len(weight[sidx:eidx]),
+                                          lrs=list(numpy.ones(len(weight[sidx:eidx]))),
+                                          wds=wds[sidx:eidx],
+                                          etas=lrs[sidx:eidx],
+                                          **kwargs)
+                current_index += self.aggregate_num
         else:
-            mean, var = state[0]
-            mp_adamw_update(weight, grad, mean, var, state[1], out=weight,
-                            lr=1, wd=wd, eta=lr, **kwargs)
+            for w_i, g_i, s_i, lr, wd in zip(weight, grad, state, lrs, wds):
+                if not multi_precision:
+                    mean, var = s_i
+                    adamw_update(w_i, g_i, mean, var, out=w_i,
+                                 lr=1, wd=wd, eta=lr, **kwargs)
+                else:
+                    mean, var = s_i[0]
+                    mp_adamw_update(w_i, g_i, mean, var, s_i[1], out=w_i,
+                                    lr=1, wd=wd, eta=lr, **kwargs)


### PR DESCRIPTION
## Description ##
FEATURE: multi-tensor Update - Adam Optimizer 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Modification in Adam optimizer for adding the possibility of updating several weight tensors within same operator. This expose more parallelism several. Up to 50 tensors can be updated within the operator. Observed ~7% throughput increase on V100. The multi-tensor version will be used when MXNET_OPTIMIZER_AGGREGATION_SIZE > 1
- [x] Added multi-tensor Adam optimizer test

## Comments ##