### PR TITLE
FEATURE Bert fp16 norm: multi-tensor sum_sq

### DIFF
--- a/scripts/bert/fp16_utils.py
+++ b/scripts/bert/fp16_utils.py
@@ -17,9 +17,7 @@
 
 """Trainer for mixed precision training."""
 import warnings
-import collections
 import mxnet as mx
-from mxnet import nd
 import gluonnlp as nlp
 
 class FP16Trainer:

--- a/scripts/bert/fp16_utils.py
+++ b/scripts/bert/fp16_utils.py
@@ -20,78 +20,7 @@ import warnings
 import collections
 import mxnet as mx
 from mxnet import nd
-from collections import defaultdict
-
-def grad_global_norm(parameters, max_norm):
-    """Calculate the 2-norm of gradients of parameters, and how much they should be scaled down
-    such that their 2-norm does not exceed `max_norm`.
-
-    If gradients exist for more than one context for a parameter, user needs to explicitly call
-    ``trainer.allreduce_grads`` so that the gradients are summed first before calculating
-    the 2-norm.
-
-    .. note::
-
-        This function is only for use when `update_on_kvstore` is set to False in trainer.
-
-    Example::
-
-        trainer = Trainer(net.collect_params(), update_on_kvstore=False, ...)
-        for x, y in mx.gluon.utils.split_and_load(X, [mx.gpu(0), mx.gpu(1)]):
-            with mx.autograd.record():
-                y = net(x)
-                loss = loss_fn(y, label)
-            loss.backward()
-        trainer.allreduce_grads()
-        norm, ratio = grad_global_norm(net.collect_params().values(), max_norm)
-        trainer.update(batch_size * ratio)
-        ...
-
-    Parameters
-    ----------
-    parameters : list of Parameters
-
-    Returns
-    -------
-    NDArray
-      Total norm. Shape is (1,)
-    NDArray
-      Ratio for rescaling gradients based on max_norm s.t. grad = grad / ratio.
-      If total norm is NaN, ratio will be NaN, too. Shape is (1,)
-    NDArray
-      Whether the total norm is finite. Shape is (1,)
-    """
-    # distribute gradients among contexts
-    idx = 0
-    arrays = defaultdict(list)
-    sum_norms = []
-    for p in parameters:
-        if p.grad_req != 'null':
-            p_grads = p.list_grad()
-            arrays[idx % len(p_grads)].append(p_grads[idx % len(p_grads)])
-            idx += 1
-    assert len(arrays) > 0, 'No parameter found available for gradient norm.'
-
-    ctx, dtype = arrays[0][0].context, 'float32'
-    for idx,arr in enumerate(arrays.values()):
-        sum_norm = mx.nd.multi_sum_sq(*arr,num_arrays=len(arr))
-        sum_norm = nd.add_n(*sum_norm)
-        sum_norms.append(sum_norm.as_in_context(ctx))
-
-    # reduce
-    total_norm = nd.add_n(*sum_norms).sqrt()
-    scale = total_norm / max_norm
-    # is_finite = 0 if NaN or Inf, 1 otherwise.
-    is_finite = nd.contrib.isfinite(scale)
-    # if scale is finite, nd.maximum selects the max between scale and 1. That is,
-    # 1 is returned if total_norm does not exceed max_norm.
-    # if scale = NaN or Inf, the result of nd.minimum is undefined. Therefore, we use
-    # choices.take to return NaN or Inf.
-    scale_or_one = nd.maximum(nd.ones((1,), dtype=dtype, ctx=ctx), scale)
-    choices = nd.concat(scale, scale_or_one, dim=0)
-    chosen_scale = choices.take(is_finite)
-    return total_norm, chosen_scale, is_finite
-
+import gluonnlp as nlp
 
 class FP16Trainer:
     """ Trainer for mixed precision training.
@@ -145,8 +74,8 @@ class FP16Trainer:
         self.fp32_trainer.allreduce_grads()
         step_size = batch_size * self._scaler.loss_scale
         if max_norm:
-            _, ratio, is_finite = grad_global_norm(self.fp32_trainer._params,
-                                                   max_norm * self._scaler.loss_scale)
+            _, ratio, is_finite = nlp.utils.grad_global_norm(self.fp32_trainer._params,
+                                                             max_norm * self._scaler.loss_scale)
             step_size = ratio * step_size
             if self._support_nan_check:
                 self.fp32_trainer.update(step_size)

--- a/src/gluonnlp/utils/parameter.py
+++ b/src/gluonnlp/utils/parameter.py
@@ -16,15 +16,88 @@
 # under the License.
 """Utility functions for trainer and parameters."""
 
-__all__ = ['clip_grad_global_norm', 'save_parameters',
+__all__ = ['grad_global_norm', 'clip_grad_global_norm', 'save_parameters',
            'save_states', 'load_parameters', 'load_states']
 
 import warnings
 
+from collections import defaultdict
 import numpy as np
+import mxnet as mx
 from mxnet import nd
 from .. import _constants as C
 from .files import _TempFilePath, _transfer_file_s3
+
+def grad_global_norm(parameters, max_norm=None):
+    """Calculate the 2-norm of gradients of parameters, and how much they should be scaled down
+    such that their 2-norm does not exceed `max_norm`, if `max_norm` if provided.
+
+    If gradients exist for more than one context for a parameter, user needs to explicitly call
+    ``trainer.allreduce_grads`` so that the gradients are summed first before calculating
+    the 2-norm.
+
+    .. note::
+        This function is only for use when `update_on_kvstore` is set to False in trainer.
+
+    Example::
+
+        trainer = Trainer(net.collect_params(), update_on_kvstore=False, ...)
+        for x, y in mx.gluon.utils.split_and_load(X, [mx.gpu(0), mx.gpu(1)]):
+            with mx.autograd.record():
+                y = net(x)
+                loss = loss_fn(y, label)
+            loss.backward()
+        trainer.allreduce_grads()
+        norm = grad_global_norm(net.collect_params().values())
+        ...
+
+    Parameters
+    ----------
+    parameters : list of Parameters
+    max_norm: NDArray, optional
+        The maximum L2 norm threshold. If provided, `ratio` and `is_finite` will be returned.
+
+    Returns
+    -------
+    NDArray
+      Total norm. Shape is (1,)
+    NDArray
+      Ratio for rescaling gradients based on max_norm s.t. grad = grad / ratio.
+      If total norm is NaN, ratio will be NaN, too.
+      Returned if `max_norm` is provided. Shape is (1,)
+    NDArray
+      Whether the total norm is finite, returned if `max_norm` is provided. Shape is (1,)
+    """
+    # distribute gradients among contexts
+    idx = 0
+    arrays = defaultdict(list)
+    sum_norms = []
+    for p in parameters:
+        if p.grad_req != 'null':
+            p_grads = p.list_grad()
+            arrays[idx % len(p_grads)].append(p_grads[idx % len(p_grads)])
+            idx += 1
+    assert len(arrays) > 0, 'No parameter found available for gradient norm.'
+
+    ctx, dtype = arrays[0][0].context, 'float32'
+    for idx, arr in enumerate(arrays.values()):
+        sum_norm = mx.nd.multi_sum_sq(*arr, num_arrays=len(arr))
+        sum_norm = nd.add_n(*sum_norm)
+        sum_norms.append(sum_norm.as_in_context(ctx))
+
+    # reduce
+    total_norm = nd.add_n(*sum_norms).sqrt()
+    scale = total_norm / max_norm
+    # is_finite = 0 if NaN or Inf, 1 otherwise.
+    is_finite = nd.contrib.isfinite(scale)
+    # if scale is finite, nd.maximum selects the max between scale and 1. That is,
+    # 1 is returned if total_norm does not exceed max_norm.
+    # if scale = NaN or Inf, the result of nd.minimum is undefined. Therefore, we use
+    # choices.take to return NaN or Inf.
+    scale_or_one = nd.maximum(nd.ones((1,), dtype=dtype, ctx=ctx), scale)
+    choices = nd.concat(scale, scale_or_one, dim=0)
+    chosen_scale = choices.take(is_finite)
+    return total_norm, chosen_scale, is_finite
 
 def clip_grad_global_norm(parameters, max_norm, check_isfinite=True):
     """Rescales gradients of parameters so that the sum of their 2-norm is smaller than `max_norm`.
@@ -67,33 +140,13 @@ def clip_grad_global_norm(parameters, max_norm, check_isfinite=True):
       False. Otherwise a float is returned.
 
     """
-    def _norm(array):
-        if array.stype == 'default':
-            x = array.reshape((-1))
-            return nd.dot(x, x)
-        return array.norm().square()
-
-    arrays = []
-    i = 0
-    for p in parameters:
-        if p.grad_req != 'null':
-            grad_list = p.list_grad()
-            arrays.append(grad_list[i % len(grad_list)])
-            i += 1
-    assert len(arrays) > 0, 'No parameter found available for gradient norm clipping.'
-    ctx, dtype = arrays[0].context, arrays[0].dtype
-    total_norm = nd.add_n(*[_norm(arr).as_in_context(ctx) for arr in arrays])
-    total_norm = nd.sqrt(total_norm)
+    total_norm, ratio, is_finite = grad_global_norm(parameters, max_norm)
+    scale = 1 / ratio
     if check_isfinite:
-        total_norm = total_norm.asscalar()
-        if not np.isfinite(total_norm):
+        if is_finite != 1:
             warnings.warn(
                 UserWarning('nan or inf is detected. '
                             'Clipping results will be undefined.'), stacklevel=2)
-    scale = max_norm / (total_norm + 1e-8)
-    if check_isfinite:
-        scale = nd.array([scale], dtype=dtype, ctx=ctx)
-    scale = nd.min(nd.concat(scale, nd.ones((1,), dtype=dtype, ctx=ctx), dim=0))
     for p in parameters:
         if p.grad_req != 'null':
             for arr in p.list_grad():

--- a/src/gluonnlp/utils/parameter.py
+++ b/src/gluonnlp/utils/parameter.py
@@ -22,7 +22,6 @@ __all__ = ['grad_global_norm', 'clip_grad_global_norm', 'save_parameters',
 import warnings
 
 from collections import defaultdict
-import numpy as np
 import mxnet as mx
 from mxnet import nd
 from .. import _constants as C
@@ -87,6 +86,8 @@ def grad_global_norm(parameters, max_norm=None):
 
     # reduce
     total_norm = nd.add_n(*sum_norms).sqrt()
+    if not max_norm:
+        return total_norm
     scale = total_norm / max_norm
     # is_finite = 0 if NaN or Inf, 1 otherwise.
     is_finite = nd.contrib.isfinite(scale)

--- a/src/gluonnlp/utils/parameter.py
+++ b/src/gluonnlp/utils/parameter.py
@@ -86,7 +86,7 @@ def grad_global_norm(parameters, max_norm=None):
 
     # reduce
     total_norm = nd.add_n(*sum_norms).sqrt()
-    if not max_norm:
+    if max_norm is None:
         return total_norm
     scale = total_norm / max_norm
     # is_finite = 0 if NaN or Inf, 1 otherwise.

--- a/tests/unittest/test_utils.py
+++ b/tests/unittest/test_utils.py
@@ -73,6 +73,35 @@ def test_parallel(num_workers):
                           (1, False),
                           (3, True),
                           (3, False)])
+def test_grad_global_norm(max_norm, check_isfinite):
+    contexts = [mx.cpu(0), mx.cpu(1)]
+    nunits = 100
+    net = mx.gluon.nn.Dense(nunits, weight_initializer='ones', bias_initializer='ones')
+    net.initialize(ctx=contexts)
+    net.hybridize()
+    trainer = mx.gluon.Trainer(net.collect_params(), 'sgd', update_on_kvstore=False)
+    for ctx in contexts:
+        with mx.autograd.record():
+            out = net(mx.nd.ones((1, 1), ctx=ctx))
+        out.backward()
+    trainer.allreduce_grads()
+    norm, ratio, is_finite = nlp.utils.grad_global_norm(net.collect_params().values(),
+                                                        max_norm)
+    # Reference
+    ref_norm = 0
+    for p in net.collect_params().values():
+        x = p.list_grad()[0].reshape((-1,)).astype('float32', copy=False)
+        dot_product = mx.nd.dot(x, x)
+        ref_norm += mx.nd.add_n(dot_product)
+    ref_norm = ref_norm.sqrt()
+
+    mx.test_utils.assert_almost_equal(ref_norm.asnumpy(), norm.asnumpy(), rtol=1e-7, atol=1e-7)
+
+@pytest.mark.parametrize('max_norm,check_isfinite',
+                         [(1, True),
+                          (1, False),
+                          (3, True),
+                          (3, False)])
 def test_clip_grad_norm(max_norm, check_isfinite):
     contexts = [mx.cpu(0), mx.cpu(1)]
     net = mx.gluon.nn.Dense(1, weight_initializer='ones', bias_initializer='ones')


### PR DESCRIPTION
## Description ##
Make use of multi-tensor sum of squares during the computation of the norm in bert training.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Instead of computing the dot product of each tensor sequentially, for later compute the sum of squares, in this PR we use the Mxnet operator multi_sum_sq, which computes the dot product of several tensors in parallel.
If multiple contexts/devices are available, the tensors are distributed among them, and later they are reduced into a single scalar.
- [x] Added test in test/test_utils.py (test_grad_global_norm)
- [x] Modified clip_grad_global_norm to use grad_global_norm

## Comments ##