### PR TITLE
[SCRIPTS]update pre-trained model link for transformer

### DIFF
--- a/scripts/machine_translation/inference_transformer.py
+++ b/scripts/machine_translation/inference_transformer.py
@@ -166,10 +166,10 @@ model = NMTModel(src_vocab=src_vocab, tgt_vocab=tgt_vocab, encoder=encoder, deco
 param_name = args.model_parameter
 if (not os.path.exists(param_name)):
     archive_param_url = 'http://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/gluon/models/{}'
-    archive_file_hash = ('transformer_en_de_512_WMT2014-97ffd554a.zip',
-                         'c182aae397ead66cc91f1bf241ce07a91884c869')
-    param_file_hash = ('transformer_en_de_512_WMT2014-97ffd554a.params',
-                       '97ffd554aac1f4ba2c5a99483543f47440bd9738')
+    archive_file_hash = ('transformer_en_de_512_WMT2014-e25287c5.zip',
+                         '5193b469e0e2dfdda3c834f9212420758a0d1d71')
+    param_file_hash = ('transformer_en_de_512_WMT2014-e25287c5.params',
+                       'e25287c5a924b7025e08d626f02626d5fa3af2d1')
     archive_file, archive_hash = archive_file_hash
     param_file, param_hash = param_file_hash
     logging.warning('The provided param file {} does not exist, start to download it from {}...'


### PR DESCRIPTION
## Description ##
This PR is to update the default transformer pre-trained model to the link of [e25287c5](http://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/gluon/models/transformer_en_de_512_WMT2014-e25287c5.zip) to align with [website](https://gluon-nlp.mxnet.io/master/model_zoo/machine_translation/index.html#transformers).

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

@leezu @eric-haibin-lin 