### PR TITLE
[MAINTENANCE] Move ParallelBigRNN into model api

### DIFF
--- a/scripts/language_model/large_word_language_model.py
+++ b/scripts/language_model/large_word_language_model.py
@@ -45,7 +45,7 @@ from mxnet import gluon, autograd
 import gluonnlp as nlp
 from gluonnlp.utils import Parallel, Parallelizable
 from sampler import LogUniformSampler
-from gluonnlp.model.train import ParallelBigRNN
+from gluonnlp.model.train.language_model import ParallelBigRNN
 
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.append(os.path.join(curr_path, '..', '..'))

--- a/scripts/language_model/large_word_language_model.py
+++ b/scripts/language_model/large_word_language_model.py
@@ -41,11 +41,11 @@ import sys
 import argparse
 import numpy as np
 import mxnet as mx
-from mxnet import gluon, autograd
+from mxnet import gluon
 import gluonnlp as nlp
-from gluonnlp.utils import Parallel, Parallelizable
-from sampler import LogUniformSampler
+from gluonnlp.utils import Parallel
 from gluonnlp.model.train.language_model import ParallelBigRNN
+from sampler import LogUniformSampler
 
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.append(os.path.join(curr_path, '..', '..'))

--- a/src/gluonnlp/model/train/language_model.py
+++ b/src/gluonnlp/model/train/language_model.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Language models for training."""
-__all__ = ['AWDRNN', 'StandardRNN', 'BigRNN']
+__all__ = ['AWDRNN', 'StandardRNN', 'BigRNN', 'ParallelBigRNN']
 
 from mxnet import init, nd, autograd
 from mxnet.gluon import nn, Block, HybridBlock, contrib, rnn, ParameterDict
@@ -23,6 +23,7 @@ from mxnet import sym
 
 from ..utils import _get_rnn_layer, apply_weight_drop
 from ..sampled_block import ISDense, SparseISDense
+from ...utils import Parallelizable
 
 class AWDRNN(HybridBlock):
     """AWD language model by salesforce.
@@ -506,3 +507,21 @@ class BigRNN(Block):
         out = out.reshape((length, batch_size, -1))
         new_target = new_target.reshape((length, batch_size))
         return out, out_states, new_target
+
+class ParallelBigRNN(Parallelizable):
+    """Data parallel BigRNN model for training."""
+    def __init__(self, rnn, loss_fn, batch_size):
+        self._model = rnn
+        self._loss = loss_fn
+        self._batch_size = batch_size
+
+    def forward_backward(self, x):
+        X, y, m, s, h = x
+        with autograd.record():
+            output, hidden, new_target = self._model(X, y, h, s)
+            output = output.reshape((-3, -1))
+            new_target = new_target.reshape((-1,))
+            ls = self._loss(output, new_target) * m.reshape((-1,))
+            ls = ls / self._batch_size
+            ls.backward()
+        return hidden, ls

--- a/src/gluonnlp/model/train/language_model.py
+++ b/src/gluonnlp/model/train/language_model.py
@@ -513,7 +513,7 @@ class ParallelBigRNN(Parallelizable):
 
     Parameters
     ----------
-    rnn : HybridBlock
+    model : HybridBlock
         The RNN model to be parallelized
     loss_fn : function
         A function computes the loss of given predictions.
@@ -521,8 +521,8 @@ class ParallelBigRNN(Parallelizable):
         Defines the batch size at each iteration
     ----------
     """
-    def __init__(self, rnn, loss_fn, batch_size):
-        self._model = rnn
+    def __init__(self, model, loss_fn, batch_size):
+        self._model = model
         self._loss = loss_fn
         self._batch_size = batch_size
 

--- a/src/gluonnlp/model/train/language_model.py
+++ b/src/gluonnlp/model/train/language_model.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Language models for training."""
-__all__ = ['AWDRNN', 'StandardRNN', 'BigRNN', 'ParallelBigRNN']
+__all__ = ['AWDRNN', 'StandardRNN', 'BigRNN']
 
 from mxnet import init, nd, autograd
 from mxnet.gluon import nn, Block, HybridBlock, contrib, rnn, ParameterDict

--- a/src/gluonnlp/model/train/language_model.py
+++ b/src/gluonnlp/model/train/language_model.py
@@ -509,13 +509,38 @@ class BigRNN(Block):
         return out, out_states, new_target
 
 class ParallelBigRNN(Parallelizable):
-    """Data parallel BigRNN model for training."""
+    """Data parallel BigRNN model for training.
+
+    Parameters
+    ----------
+    rnn : HybridBlock
+        The RNN model to be parallelized
+    loss_fn : function
+        A function computes the loss of given predictions.
+    batch_size : int
+        Defines the batch size at each iteration
+    ----------
+    """
     def __init__(self, rnn, loss_fn, batch_size):
         self._model = rnn
         self._loss = loss_fn
         self._batch_size = batch_size
 
     def forward_backward(self, x):
+        """Defines the forward computation.
+
+        Parameters
+        ----------
+        x : tuple
+        It contains the input, target, masked, sampled and hidden states
+
+        Returns
+        ----------
+        hidden : NDArray
+        Next hidden states computed by the parallel model
+        ls : NDArray
+        Loss computed with provided loss function
+        """
         X, y, m, s, h = x
         with autograd.record():
             output, hidden, new_target = self._model(X, y, h, s)


### PR DESCRIPTION
## Description ##
There is a `class ParallelBigRNN` defined in the `large_word_language_model.py` script. I think it should be merged to the model api like `class ParallelTransformer`. Additionally, I need to reuse this class in some estimator api.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented


