### PR TITLE
[BUGFIX] fix the in_channels of LN in qa script

### DIFF
--- a/scripts/language_model/model/qa.py
+++ b/scripts/language_model/model/qa.py
@@ -43,7 +43,7 @@ class PoolerEndLogits(HybridBlock):
         with self.name_scope():
             self.dense_0 = nn.Dense(units, activation='tanh', flatten=False)
             self.dense_1 = nn.Dense(1, flatten=False)
-            self.layernorm = nn.LayerNorm(epsilon=1e-12, in_channels=768)
+            self.layernorm = nn.LayerNorm(epsilon=1e-12, in_channels=units)
 
     def __call__(self,
                  hidden_states,


### PR DESCRIPTION
## Description ##
Fix the typo in question answering script of xlnet. The hidden units of xlnet large is 1024 which confilts with the fixed in_channels 768. see [#17654](https://github.com/apache/incubator-mxnet/issues/17654).

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] fix the typo in qa 

## Comments ##
@leezu @zburning 
cc @dmlc/gluon-nlp-team
