### PR TITLE
Add a general interface in md2ipynb for disable computing

### DIFF
--- a/docs/md2ipynb.py
+++ b/docs/md2ipynb.py
@@ -1,16 +1,15 @@
+import argparse
 import os
-import sys
 import time
-import notedown
-import nbformat
 
-help_message = 'Usage:' \
-               '  md2ipynb.py input.md [options]' \
-               '' \
-               'General Options:' \
-               '  -d                          Disable computing python scripts'
-assert len(sys.argv) > 1, help_message
-assert len(sys.argv) < 4, help_message
+import nbformat
+import notedown
+
+parser = argparse.ArgumentParser(description='Convert md file to ipynb files.')
+parser.add_argument('input', help='input.md', type=str)
+parser.add_argument('-d', '--disable_compute',
+                    help='Disable computing python scripts', action="store_true")
+args = parser.parse_args()
 
 # timeout for each notebook, in sec
 timeout = 40 * 60
@@ -18,14 +17,8 @@ timeout = 40 * 60
 # the files will be ignored for execution
 ignore_execution = []
 
-input_path = sys.argv[1]
-enable_compute = True
-if len(sys.argv) == 3:
-    if sys.argv[2] == '-d':
-        enable_compute = False
-
 # Change working directory to directory of input file
-input_dir, input_fn = os.path.split(input_path)
+input_dir, input_fn = os.path.split(args.input)
 os.chdir(input_dir)
 
 output_fn = '.'.join(input_fn.split('.')[:-1] + ['ipynb'])
@@ -38,9 +31,9 @@ with open(input_fn, encoding='utf-8', mode='r') as f:
 
 if not any([i in input_fn for i in ignore_execution]):
     tic = time.time()
-    if enable_compute:
+    if not args.d:
         notedown.run(notebook, timeout)
-    print('=== Finished evaluation in %f sec'%(time.time()-tic))
+    print('=== Finished evaluation in %f sec' % (time.time() - tic))
 
 # write
 # need to add language info to for syntax highlight

--- a/docs/md2ipynb.py
+++ b/docs/md2ipynb.py
@@ -31,7 +31,7 @@ with open(input_fn, encoding='utf-8', mode='r') as f:
 
 if not any([i in input_fn for i in ignore_execution]):
     tic = time.time()
-    if not args.d:
+    if not args.disable_compute:
         notedown.run(notebook, timeout)
     print('=== Finished evaluation in %f sec' % (time.time() - tic))
 

--- a/docs/md2ipynb.py
+++ b/docs/md2ipynb.py
@@ -4,7 +4,13 @@ import time
 import notedown
 import nbformat
 
-assert len(sys.argv) == 2, 'usage: input.md'
+help_message = 'Usage:' \
+               '  md2ipynb.py input.md [options]' \
+               '' \
+               'General Options:' \
+               '  -d                          Disable computing python scripts'
+assert len(sys.argv) > 1, help_message
+assert len(sys.argv) < 4, help_message
 
 # timeout for each notebook, in sec
 timeout = 40 * 60
@@ -13,6 +19,10 @@ timeout = 40 * 60
 ignore_execution = []
 
 input_path = sys.argv[1]
+enable_compute = True
+if len(sys.argv) == 3:
+    if sys.argv[2] == '-d':
+        enable_compute = False
 
 # Change working directory to directory of input file
 input_dir, input_fn = os.path.split(input_path)
@@ -28,7 +38,8 @@ with open(input_fn, encoding='utf-8', mode='r') as f:
 
 if not any([i in input_fn for i in ignore_execution]):
     tic = time.time()
-    notedown.run(notebook, timeout)
+    if enable_compute:
+        notedown.run(notebook, timeout)
     print('=== Finished evaluation in %f sec'%(time.time()-tic))
 
 # write


### PR DESCRIPTION
## Description ##
As we want to simplify the process of compiling the docs and website manually on a laptop machine without GPU (e.g. MacBook Pro), we want a command that can disable computing python scripts in the docs. 

This pull request is a standalone change to the interface of md2ipynb file that supports converting without computing python scripts. 

This change is compatible with all the existing CI and Makefile. It accepts existing commands and enables computing on default. 

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
