### PR TITLE
[DOC]Add a new argument to Makefile for making docs without computing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ compile_notebooks:
 		if [ -f $$TARGETNAME ]; then \
 			echo $$TARGETNAME exists. Skipping compilation of $$BASENAME in Makefile. ; \
 		else \
-			python $(MD2IPYNB) $$BASENAME ; \
+			python $(MD2IPYNB) $(COMPUTE) $$BASENAME ; \
 		fi ; \
 		cd - ; \
 	done;

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ compile_notebooks:
 		if [ -f $$TARGETNAME ]; then \
 			echo $$TARGETNAME exists. Skipping compilation of $$BASENAME in Makefile. ; \
 		else \
-			python $(MD2IPYNB) $(COMPUTE) $$BASENAME ; \
+			python $(MD2IPYNB) $(MD2IPYNB_OPTION) $$BASENAME ; \
 		fi ; \
 		cd - ; \
 	done;


### PR DESCRIPTION
## Description ##
As we want to simplify the process of compiling the docs and website manually on a laptop machine without GPU (e.g. MacBook Pro), we want a command that can disable computing python scripts in the docs.

This pull request is a standalone change to the interface of Makefile that supports converting without computing python scripts.

This change is compatible with all the existing CI and Makefile. It accepts existing commands and enables computing on default.

After this change, you can make the docs without computing the python scripts by using the following command:
```
make docs MD2IPYNB_OPTION =-d
```
What's more, you can still use the default command `make docs` to run the python scripts as before.
This change relies on the previous change #1191 


## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
