### PR TITLE
[BUGFIX]Fix chdir Error when invoked from Makefile

### DIFF
--- a/docs/md2ipynb.py
+++ b/docs/md2ipynb.py
@@ -19,7 +19,8 @@ ignore_execution = []
 
 # Change working directory to directory of input file
 input_dir, input_fn = os.path.split(args.input)
-os.chdir(input_dir)
+if input_dir:
+    os.chdir(input_dir)
 
 output_fn = '.'.join(input_fn.split('.')[:-1] + ['ipynb'])
 


### PR DESCRIPTION
## Description ##
This is a **bug fix**, rather than an **enhancement**.
Currently this file is invoked smoothly from CI, because CI passes the full path as the argument to this python script. However, when invoked from Makefile, using the command `make docs`, only file name is passed to this file, resulting in the `input_dir` variable to be empty string, so that the `os.chdir()` will fail.

More detailed explanation:
When we use `make docs`, the L60 of `Makefile` will be executed, and then L86 of `Makefile` will be executed. See in L89, variable `BASENAME` will be the file name and variable `DIR` will be the directory. In L96, only `BASENAME` is passed to `MD2IPYNB` as an argument. So there will be error in the python file.
With this fix, the python script doesn't need to change directory explicitly because in L92 of the `Makefile`, the directory is changed already. So this fix will work fine.

This pull request is compatible with the existing CI, and can make Makefile work fine again.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
