### PR TITLE
[BUGFIX]Exclude .idea from make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ docs: compile_notebooks distribute
 	sed -i.bak 's/2196f3/178dc9/g' docs/_build/html/_static/sphinx_materialdesign_theme.css;
 
 clean:
-	git clean -ff -d -x --exclude="$(ROOTDIR)/tests/data/*" --exclude="$(ROOTDIR)/conda/"
+	git clean -ff -d -x --exclude="$(ROOTDIR)/tests/data/*" --exclude="$(ROOTDIR)/conda/" --exclude="$(ROOTDIR)/.idea/"
 
 compile_notebooks:
 	for f in $(shell find docs/examples -type f -name '*.md' -print) ; do \


### PR DESCRIPTION
## Description ##
I am using PyCharm for developing. I often use `make docs` to preview the newly built website files and use `make clean` to wipe all the artifacts out.

However, the `make clean` command removes everything in the `./idea` folder, which is very unfriendly and destructive, meaning that I will need to manually set all the settings and preferences for this project.

I think the change in this pull request will benefit the PyCharm users who build the website.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
