### PR TITLE
[BUGFIX]Change to python3 to invoke MD2IPYNB in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ compile_notebooks:
 		if [ -f $$TARGETNAME ]; then \
 			echo $$TARGETNAME exists. Skipping compilation of $$BASENAME in Makefile. ; \
 		else \
-			python $(MD2IPYNB) $(MD2IPYNB_OPTION) $$BASENAME ; \
+			python3 $(MD2IPYNB) $(MD2IPYNB_OPTION) $$BASENAME ; \
 		fi ; \
 		cd - ; \
 	done;


### PR DESCRIPTION
## Description ##
This is a **bugfix** for `Makefile`. 
This pull request doesn't affect CI.

Please see [L77 in ci/jenkins/Jenkinsfile_py3-master_gpu_doc](https://github.com/dmlc/gluon-nlp/blob/f092e60c1141ab4c5ea01a2b25d90ff3aedc857b/ci/jenkins/Jenkinsfile_py3-master_gpu_doc#L77) and [L110 in ci/jenkins/Jenkinsfile_py3-master_gpu_doc](https://github.com/dmlc/gluon-nlp/blob/f092e60c1141ab4c5ea01a2b25d90ff3aedc857b/ci/jenkins/Jenkinsfile_py3-master_gpu_doc#L110), we are using `python3` in CI and it is working well.

But in `Makefile`, we are using `python`. I have tried both on my laptop and the server and found out that this can lead to a fatal error with `python2` in this python script. The error is raised in L30 of the `md2ipynb.py` with the function `open()`. Please see the error log below.

If I change this command to `python3`, the problem is solved.

```
ubuntu@ip-172-31-9-37:~/gluon-nlp$ make docs MD2IPYNB_OPTION=-d
for f in docs/examples/language_model/train_language_model.md docs/examples/language_model/use_pretrained_lm.md docs/examples/sentence_embedding/elmo_sentence_representation.md docs/examples/sentence_embedding/bert.md docs/examples/sentiment_analysis/self_attentive_sentence_embedding.md docs/examples/sentiment_analysis/sentiment_analysis.md docs/examples/machine_translation/gnmt.md docs/examples/machine_translation/transformer.md docs/examples/word_embedding/word_embedding_training.md docs/examples/word_embedding/word_embedding.md docs/examples/sequence_sampling/sequence_sampling.md ; do \
	DIR=$(dirname $f) ; \
	BASENAME=$(basename $f) ; \
	TARGETNAME=${BASENAME%.md}.ipynb ; \
	echo $DIR $BASENAME $TARGETNAME; \
	cd $DIR ; \
	if [ -f $TARGETNAME ]; then \
		echo $TARGETNAME exists. Skipping compilation of $BASENAME in Makefile. ; \
	else \
		python /home/ubuntu/gluon-nlp/docs/md2ipynb.py -d $BASENAME ; \
	fi ; \
	cd - ; \
done;
docs/examples/language_model train_language_model.md train_language_model.ipynb
Traceback (most recent call last):
  File "/home/ubuntu/gluon-nlp/docs/md2ipynb.py", line 30, in <module>
    with open(input_fn, encoding='utf-8', mode='r') as f:
TypeError: 'encoding' is an invalid keyword argument for this function
/home/ubuntu/gluon-nlp

```

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
