### PR TITLE
[BUGFIX] Change distribute interpreter to python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,4 +110,4 @@ test:
 	py.test -v --capture=no --durations=0  tests/unittest scripts
 
 distribute: dist_scripts dist_notebooks
-	python setup.py sdist
+	python3 setup.py sdist


### PR DESCRIPTION
## Description ##
Currently the `distribute` part of the `Makefile` is using `python` engine, which will lead to the following errors. Changing to `python3` will fix this problem

```
 File "setup.py", line 95, in <module>
    Extension('gluonnlp.data.fast_bert_tokenizer', sources=['src/gluonnlp/data/fast_bert_tokenizer.pyx']),
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 111, in setup
    _setup_distribution = dist = klass(attrs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/dist.py", line 268, in __init__
    self.fetch_build_eggs(attrs['setup_requires'])
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/dist.py", line 313, in fetch_build_eggs
    replace_conflicting=True,
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 843, in resolve
    dist = best[req.key] = env.best_match(req, ws, installer)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 1088, in best_match
    return self.obtain(req, installer)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 1100, in obtain
    return installer(requirement)


```

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
