### PR TITLE
[BUGFIX]Disable nbsphinx plugin execute code chunks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ templates_path = ['_templates']
 nbsphinx_kernel_name = 'python3'
 nbsphinx_allow_errors = True
 nbsphinx_timeout = 1200
+nbsphinx_execute = 'never'
 html_sourcelink_suffix = ''
 
 html_context = {


### PR DESCRIPTION
## Description ##
There are cases that we don't want to compute the results for the `python` code chunks in the `.md` files. So I added a configuration for disabling execute code chunks when converting `.md` files to `.ipynb` files. See #1191 #1192 

However, the `nbsphinx` plugin of `sphinx`, which is in charge of reading `.ipynb` files for `sphinx`, automatically executes all chunks without output, which is opposite to what we want. So this pull request turns this feature off.

Turning this off won't have any side effect because all the `ipynb` files in this project resides in the `docs/examples/` path and they are all converted from `md` files. So even if we want to compute the results, all the computation should be done in `md2ipynb.py` file and `nbsphinx` will still not compute code chunks in the normal process.


## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
