### PR TITLE
[FEATURE]Add new command for building website locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,7 @@ ratcheck: ci/rat/apache-rat.jar
         echo "SUCCESS: There are no files with an Unknown License."; \
     fi
 
-docs: compile_notebooks distribute
-	make -C docs html SPHINXOPTS=-W
+docs: docs_local
 	for f in $(shell find docs/examples -type f -name '*.md' -print) ; do \
 		FILE=`echo $$f | sed 's/docs\///g'` ; \
 		DIR=`dirname $$FILE` ; \
@@ -79,6 +78,9 @@ docs: compile_notebooks distribute
 	done;
 	sed -i.bak 's/33\,150\,243/23\,141\,201/g' docs/_build/html/_static/material-design-lite-1.3.0/material.blue-deep_orange.min.css;
 	sed -i.bak 's/2196f3/178dc9/g' docs/_build/html/_static/sphinx_materialdesign_theme.css;
+
+docs_local: compile_notebooks distribute
+	make -C docs html SPHINXOPTS=-W
 
 clean:
 	git clean -ff -d -x --exclude="$(ROOTDIR)/tests/data/*" --exclude="$(ROOTDIR)/conda/"


### PR DESCRIPTION
## Description ##
Currently, the L62 to L81 in the old Makefile is preventing users from building the website locally. It gives the following errors:

```

for f in docs/examples/word_embedding/word_embedding_training.md docs/examples/word_embedding/word_embedding.md docs/examples/machine_translation/transformer.md docs/examples/machine_translation/gnmt.md docs/examples/sentence_embedding/elmo_sentence_representation.md docs/examples/sentence_embedding/bert.md docs/examples/language_model/train_language_model.md docs/examples/language_model/use_pretrained_lm.md docs/examples/sentiment_analysis/sentiment_analysis.md docs/examples/sentiment_analysis/self_attentive_sentence_embedding.md docs/examples/sequence_sampling/sequence_sampling.md ; do \
                FILE=`echo $f | sed 's/docs\///g'` ; \
                DIR=`dirname $FILE` ; \
                BASENAME=`basename $FILE` ; \
                HTML_BASENAME=`echo $BASENAME | sed 's/md/html/'` ; \
                IPYNB_BASENAME=`echo $BASENAME | sed 's/md/ipynb/'` ; \
                TARGET_HTML="docs/_build/html/$DIR/$HTML_BASENAME" ; \
                echo "processing" $BASENAME ; \
                sed -i "s/$IPYNB_BASENAME/$BASENAME/g" $TARGET_HTML; \
        done;
processing word_embedding_training.md
sed: 1: "docs/_build/html/exampl ...": extra characters at the end of d command
processing word_embedding.md
sed: 1: "docs/_build/html/exampl ...": extra characters at the end of d command
processing transformer.md
sed: 1: "docs/_build/html/exampl ...": extra characters at the end of d command
processing gnmt.md
sed: 1: "docs/_build/html/exampl ...": extra characters at the end of d command
processing elmo_sentence_representation.md
sed: 1: "docs/_build/html/exampl ...": extra characters at the end of d command
processing bert.md
sed: 1: "docs/_build/html/exampl ...": extra characters at the end of d command
processing train_language_model.md
sed: 1: "docs/_build/html/exampl ...": extra characters at the end of d command
processing use_pretrained_lm.md
sed: 1: "docs/_build/html/exampl ...": extra characters at the end of d command
processing sentiment_analysis.md
sed: 1: "docs/_build/html/exampl ...": extra characters at the end of d command
processing self_attentive_sentence_embedding.md
sed: 1: "docs/_build/html/exampl ...": extra characters at the end of d command
processing sequence_sampling.md
sed: 1: "docs/_build/html/exampl ...": extra characters at the end of d command
make: *** [docs] Error 1

```

These errors are unfriendly to users who want to build the website locally. So I invented a new command to circumvent such codes with the most concise way.

It doesn't affect all the existing command and CI. 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
