### PR TITLE
[DEV] Lift numba version to 0.49

### DIFF
--- a/env/cpu/py3.yml
+++ b/env/cpu/py3.yml
@@ -16,7 +16,7 @@ dependencies:
     - nbsphinx>=0.3.4,<0.4
     - ipython
     - ipykernel
-    - numba==0.47
+    - numba==0.49
     - https://github.com/szha/mx-theme/tarball/master
     - seaborn
     - jieba

--- a/env/gpu/py3.yml
+++ b/env/gpu/py3.yml
@@ -16,7 +16,7 @@ dependencies:
     - nbsphinx>=0.3.4,<0.4
     - ipython
     - ipykernel
-    - numba==0.47
+    - numba==0.49
     - https://github.com/szha/mx-theme/tarball/master
     - seaborn
     - jieba


### PR DESCRIPTION
## Description ##
Currently the CI is failed due to incompatible versions between numba and llvm. 
This pull request fixes this problem

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
