### PR TITLE
[CI] Lift timeout on cpu unittest

### DIFF
--- a/ci/jenkins/Jenkinsfile_py3-master_cpu_unittest
+++ b/ci/jenkins/Jenkinsfile_py3-master_cpu_unittest
@@ -21,7 +21,7 @@
 // See documents at https://jenkins.io/doc/book/pipeline/jenkinsfile/
 
 // timeout in minutes
-max_time = 120
+max_time = 180
 
 node {
   // Loading the utilities requires a node context unfortunately

--- a/ci/jenkins/Jenkinsfile_py3_cpu_unittest
+++ b/ci/jenkins/Jenkinsfile_py3_cpu_unittest
@@ -21,7 +21,7 @@
 // See documents at https://jenkins.io/doc/book/pipeline/jenkinsfile/
 
 // timeout in minutes
-max_time = 120
+max_time = 180
 
 node {
   // Loading the utilities requires a node context unfortunately


### PR DESCRIPTION
## Description ##
Here is a brief statistics of the CI time out occurrences:
Among the 25 most recent CI builds the following CI items has such **_rate of time out_**(excluding failures):
cpu-unittest: 45%
master-cpu-unittest: 33%
gpu-integration: 0%
gpu-unittest: 0%
master-gpu-doc: 0%
master-gpu-integration: 0%
master-gpu-unittest: 0%

Therefore, I am lifting the time out settings for cpu-unittest and master-cpu-unittest so that they can provide steady performance even on peak hours.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
