### PR TITLE
[Website] Lift timeout restriction per notebook to 90 minutes

### DIFF
--- a/docs/md2ipynb.py
+++ b/docs/md2ipynb.py
@@ -12,7 +12,7 @@ parser.add_argument('-d', '--disable_compute',
 args = parser.parse_args()
 
 # timeout for each notebook, in sec
-timeout = 40 * 60
+timeout = 90 * 60
 
 # the files will be ignored for execution
 ignore_execution = []


### PR DESCRIPTION
## Description ##

Lift timeout restriction per notebook to 90 minutes

This pull request serves for #1230 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
