### PR TITLE
Update for Block API

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Other Dependencies
         run: |
           python -m pip install --user --upgrade pip
-          python -m pip install --user setuptools pytest pytest-cov
+          python -m pip install --user setuptools pytest pytest-cov contextvars
           python -m pip install --upgrade cython
           python -m pip install --pre --user "mxnet>=2.0.0b20200716" -f https://dist.mxnet.io/python
           python -m pip install --user -e .[extras]

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -35,7 +35,7 @@ jobs:
           python -m pip install --user --upgrade pip
           python -m pip install --user setuptools pytest pytest-cov
           python -m pip install --upgrade cython
-          python -m pip install --pre --user "mxnet>=2.0.0b20200604,<=2.0.0b20200619" -f https://dist.mxnet.io/python
+          python -m pip install --pre --user "mxnet>=2.0.0b20200716" -f https://dist.mxnet.io/python
           python -m pip install --user -e .[extras]
       - name: Test project
         run: |

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ First of all, install the latest MXNet. You may use the following commands:
 ```bash
 
 # Install the version with CUDA 10.1
-pip install -U --pre mxnet-cu101>=2.0.0b20200604 -f https://dist.mxnet.io/python
+pip install -U --pre mxnet-cu101>=2.0.0b20200716 -f https://dist.mxnet.io/python
 
 # Install the cpu-only version
-pip install -U --pre mxnet>=2.0.0b20200604 -f https://dist.mxnet.io/python
+pip install -U --pre mxnet>=2.0.0b20200716 -f https://dist.mxnet.io/python
 ```
 
 

--- a/scripts/conversion_toolkits/convert_electra.py
+++ b/scripts/conversion_toolkits/convert_electra.py
@@ -265,11 +265,11 @@ def convert_tf_model(model_dir, save_dir, test_conversion, model_size, gpu, elec
         assert_allclose(tf_params[k], backbone_params[k])
 
     # Build gluon model and initialize
-    gluon_model = ElectraModel.from_cfg(cfg, prefix='electra_')
+    gluon_model = ElectraModel.from_cfg(cfg)
     gluon_model.initialize(ctx=ctx)
     gluon_model.hybridize()
 
-    gluon_disc_model = ElectraDiscriminator(cfg, prefix='electra_')
+    gluon_disc_model = ElectraDiscriminator(cfg)
     gluon_disc_model.initialize(ctx=ctx)
     gluon_disc_model.hybridize()
 
@@ -283,8 +283,7 @@ def convert_tf_model(model_dir, save_dir, test_conversion, model_size, gpu, elec
                                        word_embed_params=word_embed_params,
                                        token_type_embed_params=token_type_embed_params,
                                        token_pos_embed_params=token_pos_embed_params,
-                                       embed_layer_norm_params=embed_layer_norm_params,
-                                       prefix='generator_')
+                                       embed_layer_norm_params=embed_layer_norm_params)
     gluon_gen_model.initialize(ctx=ctx)
     gluon_gen_model.hybridize()
 

--- a/scripts/conversion_toolkits/convert_mobilebert.py
+++ b/scripts/conversion_toolkits/convert_mobilebert.py
@@ -270,7 +270,7 @@ def convert_tf_model(model_dir, save_dir, test_conversion, gpu, mobilebert_dir):
     gluon_model.initialize(ctx=ctx)
     gluon_model.hybridize()
 
-    gluon_pretrain_model = MobileBertForPretrain(cfg, prefix='')
+    gluon_pretrain_model = MobileBertForPretrain(cfg)
     gluon_pretrain_model.initialize(ctx=ctx)
     gluon_pretrain_model.hybridize()
 

--- a/scripts/conversion_toolkits/convert_tf_hub_model.py
+++ b/scripts/conversion_toolkits/convert_tf_hub_model.py
@@ -358,7 +358,7 @@ def convert_tf_model(hub_model_dir, save_dir, test_conversion, model_type, gpu):
     gluon_model = PretrainedModel.from_cfg(cfg, prefix='', use_pooler=True)
     gluon_model.initialize(ctx=ctx)
     gluon_model.hybridize()
-    gluon_mlm_model = PretrainedMLMModel(backbone_cfg=cfg, prefix='')
+    gluon_mlm_model = PretrainedMLMModel(backbone_cfg=cfg)
     gluon_mlm_model.initialize(ctx=ctx)
     gluon_mlm_model.hybridize()
 

--- a/scripts/machine_translation/train_transformer.py
+++ b/scripts/machine_translation/train_transformer.py
@@ -350,7 +350,7 @@ def train(args):
     for v in model.collect_params().values():
         if v.grad_req != 'null':
             v.grad_req = 'add'
-    model.collect_params().zero_grad()
+    model.zero_grad()
     model_averager = AverageSGDTracker(model.collect_params())
     log_start_time = time.time()
     num_params, num_fixed_params = None, None
@@ -413,7 +413,7 @@ def train(args):
                 trainer.step(loss_denom.asnumpy() / rescale_loss)
                 accum_count = 0
                 loss_denom = 0
-                model.collect_params().zero_grad()
+                model.zero_grad()
                 if epoch_id >= (args.epochs - args.num_averages):
                     model_averager.step()
                 if n_epoch_train_iters % args.log_interval == 0:

--- a/scripts/pretraining/run_electra.py
+++ b/scripts/pretraining/run_electra.py
@@ -155,8 +155,7 @@ def get_pretraining_model(model_name, ctx_l,
                                tied_generator=False,
                                tied_embeddings=True,
                                disallow_correct=False,
-                               weight_initializer=TruncNorm(stdev=0.02),
-                               prefix='Pretrain_')
+                               weight_initializer=TruncNorm(stdev=0.02))
     model.initialize(ctx=ctx_l)
     model.hybridize()
     return cfg, tokenizer, model

--- a/scripts/question_answering/run_squad.py
+++ b/scripts/question_answering/run_squad.py
@@ -528,7 +528,7 @@ def train(args):
     log_sample_num = 0
     if args.num_accumulated != 1:
         # set grad to zero for gradient accumulation
-        qa_net.collect_params().zero_grad()
+        qa_net.zero_grad()
     global_tic = time.time()
     while not finish_flag:
         epoch_tic = time.time()
@@ -593,7 +593,7 @@ def train(args):
                 step_num += 1
                 if args.num_accumulated != 1:
                     # set grad to zero for gradient accumulation
-                    qa_net.collect_params().zero_grad()
+                    qa_net.zero_grad()
 
                 # saving
                 if step_num % save_interval == 0 or step_num >= num_train_steps:
@@ -963,7 +963,6 @@ def evaluate(args, last=True):
 
 if __name__ == '__main__':
     os.environ['MXNET_GPU_MEM_POOL_TYPE'] = 'Round'
-    os.environ['MXNET_USE_FUSION'] = '0'  # Manually disable pointwise fusion
     args = parse_args()
     logging_config(args.output_dir, name='finetune_squad{}'.format(args.version))
     set_seed(args.seed)

--- a/scripts/question_answering/run_squad.py
+++ b/scripts/question_answering/run_squad.py
@@ -324,8 +324,7 @@ def get_network(model_name,
                 backbone_params_path, num_params, num_fixed_params))
     qa_net = ModelForQAConditionalV1(backbone=backbone,
                                      dropout_prob=dropout,
-                                     weight_initializer=TruncNorm(stdev=0.02),
-                                     prefix='qa_net_')
+                                     weight_initializer=TruncNorm(stdev=0.02))
     if checkpoint_path is None:
         # Ignore the UserWarning during initialization,
         # There is no need to re-initialize the parameters of backbone

--- a/src/gluonnlp/attention_cell.py
+++ b/src/gluonnlp/attention_cell.py
@@ -601,9 +601,8 @@ class MultiHeadAttentionCell(HybridBlock):
     """
     def __init__(self, query_units=None, num_heads=None, attention_dropout=0.0,
                  scaled: bool = True, normalized: bool = False, eps: float = 1E-6,
-                 dtype='float32', layout='NTK', use_einsum=False,
-                 prefix=None, params=None):
-        super().__init__(prefix=prefix, params=params)
+                 dtype='float32', layout='NTK', use_einsum=False):
+        super().__init__()
         self._query_units = query_units
         self._num_heads = num_heads
         self._attention_dropout = attention_dropout
@@ -705,8 +704,7 @@ class RelAttentionScoreCell(HybridBlock):
                  dropout: float = 0.0,
                  dtype='float32',
                  layout='NTK',
-                 use_einsum=False,
-                 prefix=None, params=None):
+                 use_einsum=False):
         """
 
         Parameters
@@ -725,10 +723,8 @@ class RelAttentionScoreCell(HybridBlock):
         scaled
         dtype
         layout
-        prefix
-        params
         """
-        super().__init__(prefix=prefix, params=params)
+        super().__init__()
         self._dropout = dropout
         self._method = method
         self._query_units = query_units
@@ -744,49 +740,44 @@ class RelAttentionScoreCell(HybridBlock):
         self._layout = layout
         if self._layout not in ['NKT', 'NTK', 'TNK']:
             raise ValueError('layout="{}" is not supported'.format(self._layout))
-        with self.name_scope():
-            if method == 'transformer_xl':
-                if pos_embed_units is None:
-                    pos_embed_units = self._num_heads * self._head_query_units
-                self._rel_pos_embed = SinusoidalPositionalEmbedding(units=pos_embed_units,
-                                                                    prefix='rel_pos_embed_',
-                                                                    dtype=self._dtype)
-                self._rel_proj = nn.Dense(units=query_units,
-                                          in_units=pos_embed_units,
-                                          flatten=False,
-                                          use_bias=False,
-                                          prefix='rel_proj_',
-                                          dtype=self._dtype)
-                self._dropout_layer = nn.Dropout(dropout)
-            elif method == 'shaw':
-                assert self._max_distance is not None, 'Must set max_distance when method="shaw".'
-                if self._bidirectional:
-                    vocab_size = self._max_distance * 2 + 1
-                else:
-                    vocab_size = self._max_distance + 1
-                self._rel_pos_embed = LearnedPositionalEmbedding(
-                    units=self._num_heads * self._head_query_units,
-                    max_length=vocab_size,
-                    weight_initializer=mx.init.Xavier(rnd_type="gaussian",
-                                                      factor_type="in",
-                                                      magnitude=1),
-                    prefix='rel_pos_embed_',
-                    mode='wrap' if self._bidirectional else 'raise',
-                    dtype=self._dtype)
-            elif method == 't5':
-                if self._num_buckets is None:
-                    self._num_buckets = 32
-                if self._max_distance is None:
-                    self._max_distance = 128
-                self._rel_pos_embed = BucketPositionalEmbedding(
-                    units=num_heads,
-                    num_buckets=self._num_buckets,
-                    max_distance=self._max_distance,
-                    bidirectional=self._bidirectional,
-                    prefix='rel_pos_embed_',
-                    dtype=self._dtype)
+        if method == 'transformer_xl':
+            if pos_embed_units is None:
+                pos_embed_units = self._num_heads * self._head_query_units
+            self._rel_pos_embed = SinusoidalPositionalEmbedding(units=pos_embed_units,
+                                                                dtype=self._dtype)
+            self._rel_proj = nn.Dense(units=query_units,
+                                      in_units=pos_embed_units,
+                                      flatten=False,
+                                      use_bias=False,
+                                      dtype=self._dtype)
+            self._dropout_layer = nn.Dropout(dropout)
+        elif method == 'shaw':
+            assert self._max_distance is not None, 'Must set max_distance when method="shaw".'
+            if self._bidirectional:
+                vocab_size = self._max_distance * 2 + 1
             else:
-                raise NotImplementedError('method="{}" is currently not supported!'.format(method))
+                vocab_size = self._max_distance + 1
+            self._rel_pos_embed = LearnedPositionalEmbedding(
+                units=self._num_heads * self._head_query_units,
+                max_length=vocab_size,
+                weight_initializer=mx.init.Xavier(rnd_type="gaussian",
+                                                  factor_type="in",
+                                                  magnitude=1),
+                mode='wrap' if self._bidirectional else 'raise',
+                dtype=self._dtype)
+        elif method == 't5':
+            if self._num_buckets is None:
+                self._num_buckets = 32
+            if self._max_distance is None:
+                self._max_distance = 128
+            self._rel_pos_embed = BucketPositionalEmbedding(
+                units=num_heads,
+                num_buckets=self._num_buckets,
+                max_distance=self._max_distance,
+                bidirectional=self._bidirectional,
+                dtype=self._dtype)
+        else:
+            raise NotImplementedError('method="{}" is currently not supported!'.format(method))
 
     def hybrid_forward(self, F, rel_positions, query=None):
         """

--- a/src/gluonnlp/data/loading.py
+++ b/src/gluonnlp/data/loading.py
@@ -81,7 +81,7 @@ class NumpyDataset(ArrayDataset):
         else:
             raise ValueError('Unsupported extension: %s' % filename)
         self._keys = keys
-        super(NumpyDataset, self).__init__(*data)
+        super().__init__(*data)
 
     @property
     def keys(self):
@@ -125,7 +125,7 @@ class _PathDataset(SimpleDataset):
         files = sorted(files)
         if len(files) == 0:
             raise ValueError('Cannot find any file with path "%s"' % file_pattern)
-        super(_PathDataset, self).__init__(files)
+        super().__init__(files)
 
 
 def _dataset_worker_fn(urls, dataset_fn, batch_sampler_fn):

--- a/src/gluonnlp/initializer.py
+++ b/src/gluonnlp/initializer.py
@@ -51,7 +51,7 @@ class TruncNorm(Initializer):
     """
     def __init__(self, mean: float = 0, stdev: float = 0.01,
                  scale=2, **kwargs):
-        super(TruncNorm, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._mean = mean
         self._stdev = stdev
         self._scale = scale

--- a/src/gluonnlp/layers.py
+++ b/src/gluonnlp/layers.py
@@ -347,7 +347,7 @@ class GELU(HybridBlock):
         Parameters
         ----------
         mode
-                """
+        """
         super().__init__()
         if mode not in ['erf', 'tanh', 'sigmoid']:
             raise ValueError('Unsupported mode, only support "erf", "tanh", or "sigmoid". '
@@ -598,7 +598,7 @@ class PositionwiseFFN(HybridBlock):
             This will stabilize the training of Transformers.
             You may also refer to
             "[Arxiv2020] Understanding the Difficulty of Training Transformers"
-                """
+        """
         super().__init__()
         self._dtype = dtype
         self._pre_norm = pre_norm
@@ -709,7 +709,7 @@ class AdaptiveEmbedding(HybridBlock):
             Initializer of projection layers
         bias_initializer
             Initializer of the bias
-                """
+        """
         super().__init__()
         cutoffs = _fmt_and_check_cutoffs(cutoffs, vocab_size)
         if cutoffs is None:
@@ -884,7 +884,7 @@ class ProjectedAdaptiveLogSoftmaxWithLoss(HybridBlock):
             Whether to use bias when computing the scores for the tokens
         weight_initializer
         bias_initializer
-                """
+        """
         super().__init__()
         cutoffs = _fmt_and_check_cutoffs(cutoffs, vocab_size)
         if cutoffs is None:

--- a/src/gluonnlp/loss.py
+++ b/src/gluonnlp/loss.py
@@ -29,7 +29,7 @@ class LabelSmoothCrossEntropyLoss(HybridBlock):
         Whether input is a log probability (usually from log_softmax) instead of unnormalized numbers.
     """
     def __init__(self, num_labels: int, alpha: float = 0.1, from_logits: bool = False, **kwargs):
-        super(LabelSmoothCrossEntropyLoss, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._num_labels = num_labels
         self._alpha = alpha
         self._from_logits = from_logits

--- a/src/gluonnlp/lr_scheduler.py
+++ b/src/gluonnlp/lr_scheduler.py
@@ -23,7 +23,7 @@ class InverseSquareRootScheduler(lr_scheduler.LRScheduler):
     """
 
     def __init__(self, warmup_steps: int, base_lr: float = 1E-3, warmup_init_lr: float = 0.0):
-        super(InverseSquareRootScheduler, self).__init__(
+        super().__init__(
             base_lr, warmup_steps, warmup_init_lr, 'linear')
         self.base_lr = base_lr
         self.warmup_steps = warmup_steps

--- a/src/gluonnlp/models/albert.py
+++ b/src/gluonnlp/models/albert.py
@@ -425,7 +425,7 @@ class AlbertForMLM(HybridBlock):
         backbone_cfg
         weight_initializer
         bias_initializer
-                """
+        """
         super().__init__()
         self.backbone_model = AlbertModel.from_cfg(backbone_cfg)
         if weight_initializer is None:
@@ -446,7 +446,7 @@ class AlbertForMLM(HybridBlock):
         self.mlm_decoder.add(nn.Dense(units=self.backbone_model.vocab_size,
                                       flatten=False,
                                       bias_initializer=bias_initializer))
-        self.mlm_decoder[-1].weight = self.backbone_model.word_embed.weight  # TODO(leezu) double check
+        self.mlm_decoder[-1].weight = self.backbone_model.word_embed.weight
         self.mlm_decoder.hybridize()
 
     def hybrid_forward(self, F, inputs, token_types, valid_length,
@@ -497,7 +497,7 @@ class AlbertForPretrain(HybridBlock):
             The cfg of the backbone model
         weight_initializer
         bias_initializer
-                """
+        """
         super().__init__()
         self.backbone_model = AlbertModel.from_cfg(backbone_cfg)
         if weight_initializer is None:
@@ -521,7 +521,7 @@ class AlbertForPretrain(HybridBlock):
         self.mlm_decoder.add(nn.Dense(units=self.backbone_model.vocab_size,
                                       flatten=False,
                                       bias_initializer=bias_initializer))
-        self.mlm_decoder[-1].weight = self.backbone_model.word_embed.weight  # TODO(leezu) double check
+        self.mlm_decoder[-1].weight = self.backbone_model.word_embed.weight
         self.mlm_decoder.hybridize()
 
     def hybrid_forward(self, F, inputs, token_types, valid_length,

--- a/src/gluonnlp/models/bert.py
+++ b/src/gluonnlp/models/bert.py
@@ -418,7 +418,7 @@ class BertForMLM(HybridBlock):
         backbone_cfg
         weight_initializer
         bias_initializer
-                """
+        """
         super().__init__()
         self.backbone_model = BertModel.from_cfg(backbone_cfg)
         if weight_initializer is None:
@@ -491,7 +491,7 @@ class BertForPretrain(HybridBlock):
             The cfg of the backbone model
         weight_initializer
         bias_initializer
-                """
+        """
         super().__init__()
         self.backbone_model = BertModel.from_cfg(backbone_cfg)
         if weight_initializer is None:

--- a/src/gluonnlp/models/bert.py
+++ b/src/gluonnlp/models/bert.py
@@ -119,9 +119,8 @@ class BertTransformer(HybridBlock):
                  layer_norm_eps: float = 1E-12,
                  weight_initializer: InitializerType = TruncNorm(stdev=0.02),
                  bias_initializer: InitializerType = 'zeros',
-                 activation='gelu',
-                 prefix=None, params=None):
-        super().__init__(prefix=prefix, params=params)
+                 activation='gelu'):
+        super().__init__()
         assert units % num_heads == 0,\
             'In BertTransformer, The units should be divided exactly ' \
             'by the number of heads. Received units={}, num_heads={}' \
@@ -132,21 +131,18 @@ class BertTransformer(HybridBlock):
         self._output_attention = output_attention
         self._output_all_encodings = output_all_encodings
 
-        with self.name_scope():
-            self.all_layers = nn.HybridSequential(prefix='layers_')
-            with self.all_layers.name_scope():
-                for layer_idx in range(num_layers):
-                    self.all_layers.add(
-                      TransformerEncoderLayer(units=units,
-                                              hidden_size=hidden_size,
-                                              num_heads=num_heads,
-                                              attention_dropout_prob=attention_dropout_prob,
-                                              hidden_dropout_prob=hidden_dropout_prob,
-                                              layer_norm_eps=layer_norm_eps,
-                                              weight_initializer=weight_initializer,
-                                              bias_initializer=bias_initializer,
-                                              activation=activation,
-                                              prefix='{}_'.format(layer_idx)))
+        self.all_layers = nn.HybridSequential()
+        for layer_idx in range(num_layers):
+            self.all_layers.add(
+              TransformerEncoderLayer(units=units,
+                                      hidden_size=hidden_size,
+                                      num_heads=num_heads,
+                                      attention_dropout_prob=attention_dropout_prob,
+                                      hidden_dropout_prob=hidden_dropout_prob,
+                                      layer_norm_eps=layer_norm_eps,
+                                      weight_initializer=weight_initializer,
+                                      bias_initializer=bias_initializer,
+                                      activation=activation))
 
     def hybrid_forward(self, F, data, valid_length):
         """
@@ -214,10 +210,8 @@ class BertModel(HybridBlock):
                  weight_initializer=TruncNorm(stdev=0.02),
                  bias_initializer='zeros',
                  dtype='float32',
-                 use_pooler=True,
-                 prefix=None,
-                 params=None):
-        super().__init__(prefix=prefix, params=params)
+                 use_pooler=True):
+        super().__init__()
         self._dtype = dtype
         self.use_pooler = use_pooler
         self.pos_embed_type = pos_embed_type
@@ -230,53 +224,46 @@ class BertModel(HybridBlock):
         self.weight_initializer = weight_initializer
         self.bias_initializer = bias_initializer
         self.layer_norm_eps = layer_norm_eps
-        with self.name_scope():
-            # Construct BertTransformer
-            self.encoder = BertTransformer(
-                units=units,
-                hidden_size=hidden_size,
-                num_layers=num_layers,
-                num_heads=num_heads,
-                attention_dropout_prob=attention_dropout_prob,
-                hidden_dropout_prob=hidden_dropout_prob,
-                output_attention=False,
-                output_all_encodings=False,
-                activation=activation,
-                layer_norm_eps=layer_norm_eps,
-                weight_initializer=weight_initializer,
-                bias_initializer=bias_initializer,
-                dtype=dtype,
-                prefix='enc_',
-            )
-            self.encoder.hybridize()
-            # Construct word embedding
-            self.word_embed = nn.Embedding(input_dim=vocab_size,
-                                           output_dim=units,
-                                           weight_initializer=embed_initializer,
-                                           dtype=dtype,
-                                           prefix='word_embed_')
-            self.embed_layer_norm = nn.LayerNorm(epsilon=self.layer_norm_eps,
-                                                 prefix='embed_ln_')
-            self.embed_dropout = nn.Dropout(hidden_dropout_prob)
-            # Construct token type embedding
-            self.token_type_embed = nn.Embedding(input_dim=num_token_types,
-                                                 output_dim=units,
-                                                 weight_initializer=weight_initializer,
-                                                 prefix='token_type_embed_')
-            self.token_pos_embed = PositionalEmbedding(units=units,
-                                                       max_length=max_length,
-                                                       dtype=self._dtype,
-                                                       method=pos_embed_type,
-                                                       prefix='token_pos_embed_')
-            if self.use_pooler:
-                # Construct pooler
-                self.pooler = nn.Dense(units=units,
-                                       in_units=units,
-                                       flatten=False,
-                                       activation='tanh',
-                                       weight_initializer=weight_initializer,
-                                       bias_initializer=bias_initializer,
-                                       prefix='pooler_')
+        # Construct BertTransformer
+        self.encoder = BertTransformer(
+            units=units,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            num_heads=num_heads,
+            attention_dropout_prob=attention_dropout_prob,
+            hidden_dropout_prob=hidden_dropout_prob,
+            output_attention=False,
+            output_all_encodings=False,
+            activation=activation,
+            layer_norm_eps=layer_norm_eps,
+            weight_initializer=weight_initializer,
+            bias_initializer=bias_initializer,
+            dtype=dtype,
+        )
+        self.encoder.hybridize()
+        # Construct word embedding
+        self.word_embed = nn.Embedding(input_dim=vocab_size,
+                                       output_dim=units,
+                                       weight_initializer=embed_initializer,
+                                       dtype=dtype)
+        self.embed_layer_norm = nn.LayerNorm(epsilon=self.layer_norm_eps)
+        self.embed_dropout = nn.Dropout(hidden_dropout_prob)
+        # Construct token type embedding
+        self.token_type_embed = nn.Embedding(input_dim=num_token_types,
+                                             output_dim=units,
+                                             weight_initializer=weight_initializer)
+        self.token_pos_embed = PositionalEmbedding(units=units,
+                                                   max_length=max_length,
+                                                   dtype=self._dtype,
+                                                   method=pos_embed_type)
+        if self.use_pooler:
+            # Construct pooler
+            self.pooler = nn.Dense(units=units,
+                                   in_units=units,
+                                   flatten=False,
+                                   activation='tanh',
+                                   weight_initializer=weight_initializer,
+                                   bias_initializer=bias_initializer)
 
     def hybrid_forward(self, F, inputs, token_types, valid_length):
         # pylint: disable=arguments-differ
@@ -394,7 +381,7 @@ class BertModel(HybridBlock):
         return cfg
 
     @classmethod
-    def from_cfg(cls, cfg, use_pooler=True, prefix=None, params=None):
+    def from_cfg(cls, cfg, use_pooler=True):
         cfg = BertModel.get_cfg().clone_merge(cfg)
         assert cfg.VERSION == 1, 'Wrong version!'
         embed_initializer = mx.init.create(*cfg.INITIALIZER.embed)
@@ -416,18 +403,14 @@ class BertModel(HybridBlock):
                    embed_initializer=embed_initializer,
                    weight_initializer=weight_initializer,
                    bias_initializer=bias_initializer,
-                   use_pooler=use_pooler,
-                   prefix=prefix,
-                   params=params)
+                   use_pooler=use_pooler)
 
 
 @use_np
 class BertForMLM(HybridBlock):
     def __init__(self, backbone_cfg,
                  weight_initializer=None,
-                 bias_initializer=None,
-                 prefix=None,
-                 params=None):
+                 bias_initializer=None):
         """
 
         Parameters
@@ -435,36 +418,29 @@ class BertForMLM(HybridBlock):
         backbone_cfg
         weight_initializer
         bias_initializer
-        prefix
-        params
-        """
-        super().__init__(prefix=prefix, params=params)
-        with self.name_scope():
-            self.backbone_model = BertModel.from_cfg(backbone_cfg, prefix='')
-            if weight_initializer is None:
-                weight_initializer = self.backbone_model.weight_initializer
-            if bias_initializer is None:
-                bias_initializer = self.backbone_model.bias_initializer
-            self.mlm_decoder = nn.HybridSequential(prefix='mlm_')
-            with self.mlm_decoder.name_scope():
-                # Extra non-linear layer
-                self.mlm_decoder.add(nn.Dense(units=self.backbone_model.units,
-                                              flatten=False,
-                                              weight_initializer=weight_initializer,
-                                              bias_initializer=bias_initializer,
-                                              prefix='proj_'))
-                self.mlm_decoder.add(get_activation(self.backbone_model.activation))
-                self.mlm_decoder.add(nn.LayerNorm(epsilon=self.backbone_model.layer_norm_eps,
-                                                  prefix='ln_'))
-                # only load the dense weights with a re-initialized bias
-                # parameters are stored in 'word_embed_bias' which is
-                # not used in original embedding
-                self.mlm_decoder.add(nn.Dense(units=self.backbone_model.vocab_size,
-                                              flatten=False,
-                                              params=self.backbone_model.word_embed.collect_params('.*weight'),
-                                              bias_initializer=bias_initializer,
-                                              prefix='score_'))
-            self.mlm_decoder.hybridize()
+                """
+        super().__init__()
+        self.backbone_model = BertModel.from_cfg(backbone_cfg)
+        if weight_initializer is None:
+            weight_initializer = self.backbone_model.weight_initializer
+        if bias_initializer is None:
+            bias_initializer = self.backbone_model.bias_initializer
+        self.mlm_decoder = nn.HybridSequential()
+        # Extra non-linear layer
+        self.mlm_decoder.add(nn.Dense(units=self.backbone_model.units,
+                                      flatten=False,
+                                      weight_initializer=weight_initializer,
+                                      bias_initializer=bias_initializer))
+        self.mlm_decoder.add(get_activation(self.backbone_model.activation))
+        self.mlm_decoder.add(nn.LayerNorm(epsilon=self.backbone_model.layer_norm_eps))
+        # only load the dense weights with a re-initialized bias
+        # parameters are stored in 'word_embed_bias' which is
+        # not used in original embedding
+        self.mlm_decoder.add(nn.Dense(units=self.backbone_model.vocab_size,
+                                      flatten=False,
+                                      bias_initializer=bias_initializer))
+        self.mlm_decoder[-1].weight = self.backbone_model.word_embed.weight
+        self.mlm_decoder.hybridize()
 
     def hybrid_forward(self, F, inputs, token_types, valid_length,
                        masked_positions):
@@ -506,8 +482,7 @@ class BertForMLM(HybridBlock):
 class BertForPretrain(HybridBlock):
     def __init__(self, backbone_cfg,
                  weight_initializer=None,
-                 bias_initializer=None,
-                 prefix=None, params=None):
+                 bias_initializer=None):
         """
 
         Parameters
@@ -516,40 +491,32 @@ class BertForPretrain(HybridBlock):
             The cfg of the backbone model
         weight_initializer
         bias_initializer
-        prefix
-        params
-        """
-        super().__init__(prefix=prefix, params=params)
-        with self.name_scope():
-            self.backbone_model = BertModel.from_cfg(backbone_cfg, prefix='')
-            if weight_initializer is None:
-                weight_initializer = self.backbone_model.weight_initializer
-            if bias_initializer is None:
-                bias_initializer = self.backbone_model.bias_initializer
-            # Construct nsp_classifier for next sentence prediction
-            self.nsp_classifier = nn.Dense(units=2,
-                                           weight_initializer=weight_initializer,
-                                           prefix='nsp_')
-            self.mlm_decoder = nn.HybridSequential(prefix='mlm_')
-            with self.mlm_decoder.name_scope():
-                # Extra non-linear layer
-                self.mlm_decoder.add(nn.Dense(units=self.backbone_model.units,
-                                              flatten=False,
-                                              weight_initializer=weight_initializer,
-                                              bias_initializer=bias_initializer,
-                                              prefix='proj_'))
-                self.mlm_decoder.add(get_activation(self.backbone_model.activation))
-                self.mlm_decoder.add(nn.LayerNorm(epsilon=self.backbone_model.layer_norm_eps,
-                                                  prefix='ln_'))
-                # only load the dense weights with a re-initialized bias
-                # parameters are stored in 'word_embed_bias' which is
-                # not used in original embedding
-                self.mlm_decoder.add(nn.Dense(units=self.backbone_model.vocab_size,
-                                              flatten=False,
-                                              params=self.backbone_model.word_embed.collect_params('.*weight'),
-                                              bias_initializer=bias_initializer,
-                                              prefix='score_'))
-            self.mlm_decoder.hybridize()
+                """
+        super().__init__()
+        self.backbone_model = BertModel.from_cfg(backbone_cfg)
+        if weight_initializer is None:
+            weight_initializer = self.backbone_model.weight_initializer
+        if bias_initializer is None:
+            bias_initializer = self.backbone_model.bias_initializer
+        # Construct nsp_classifier for next sentence prediction
+        self.nsp_classifier = nn.Dense(units=2,
+                                       weight_initializer=weight_initializer)
+        self.mlm_decoder = nn.HybridSequential()
+        # Extra non-linear layer
+        self.mlm_decoder.add(nn.Dense(units=self.backbone_model.units,
+                                      flatten=False,
+                                      weight_initializer=weight_initializer,
+                                      bias_initializer=bias_initializer))
+        self.mlm_decoder.add(get_activation(self.backbone_model.activation))
+        self.mlm_decoder.add(nn.LayerNorm(epsilon=self.backbone_model.layer_norm_eps))
+        # only load the dense weights with a re-initialized bias
+        # parameters are stored in 'word_embed_bias' which is
+        # not used in original embedding
+        self.mlm_decoder.add(nn.Dense(units=self.backbone_model.vocab_size,
+                                      flatten=False,
+                                      bias_initializer=bias_initializer))
+        self.mlm_decoder[-1].weight = self.backbone_model.word_embed.weight
+        self.mlm_decoder.hybridize()
 
     def hybrid_forward(self, F, inputs, token_types, valid_length,
                        masked_positions):

--- a/src/gluonnlp/models/electra.py
+++ b/src/gluonnlp/models/electra.py
@@ -417,7 +417,7 @@ class ElectraDiscriminator(HybridBlock):
         backbone_cfg
         weight_initializer
         bias_initializer
-                """
+        """
         super().__init__()
         self.backbone_model = ElectraModel.from_cfg(backbone_cfg)
         if weight_initializer is None:
@@ -486,7 +486,7 @@ class ElectraGenerator(HybridBlock):
             Configuration of the backbone model
         weight_initializer
         bias_initializer
-                """
+        """
         super().__init__()
         self.backbone_model = ElectraModel.from_cfg(backbone_cfg)
         if weight_initializer is None:
@@ -597,7 +597,7 @@ class ElectraForPretrain(HybridBlock):
             Temperature of gumbel distribution for sampling from generator
         weight_initializer
         bias_initializer
-                """
+        """
         super().__init__()
         self._uniform_generator = uniform_generator
         self._tied_generator = tied_generator

--- a/src/gluonnlp/models/electra.py
+++ b/src/gluonnlp/models/electra.py
@@ -107,8 +107,8 @@ class ElectraEncoder(HybridBlock):
                  layer_norm_eps=1E-12,
                  weight_initializer=TruncNorm(stdev=0.02),
                  bias_initializer='zeros',
-                 activation='gelu', prefix=None, params=None):
-        super().__init__(prefix=prefix, params=params)
+                 activation='gelu'):
+        super().__init__()
         assert units % num_heads == 0, \
             'In ElectraEncoder, The units should be divisible ' \
             'by the number of heads. Received units={}, num_heads={}' \
@@ -120,21 +120,18 @@ class ElectraEncoder(HybridBlock):
         self._output_attention = output_attention
         self._output_all_encodings = output_all_encodings
 
-        with self.name_scope():
-            self.all_encoder_layers = nn.HybridSequential(prefix='layers_')
-            with self.all_encoder_layers.name_scope():
-                for layer_idx in range(num_layers):
-                    self.all_encoder_layers.add(
-                        TransformerEncoderLayer(units=units,
-                                                hidden_size=hidden_size,
-                                                num_heads=num_heads,
-                                                attention_dropout_prob=attention_dropout_prob,
-                                                hidden_dropout_prob=hidden_dropout_prob,
-                                                layer_norm_eps=layer_norm_eps,
-                                                weight_initializer=weight_initializer,
-                                                bias_initializer=bias_initializer,
-                                                activation=activation,
-                                                prefix='{}_'.format(layer_idx)))
+        self.all_encoder_layers = nn.HybridSequential()
+        for layer_idx in range(num_layers):
+            self.all_encoder_layers.add(
+                TransformerEncoderLayer(units=units,
+                                        hidden_size=hidden_size,
+                                        num_heads=num_heads,
+                                        attention_dropout_prob=attention_dropout_prob,
+                                        hidden_dropout_prob=hidden_dropout_prob,
+                                        layer_norm_eps=layer_norm_eps,
+                                        weight_initializer=weight_initializer,
+                                        bias_initializer=bias_initializer,
+                                        activation=activation))
 
     def hybrid_forward(self, F, data, valid_length):
         """
@@ -208,15 +205,8 @@ class ElectraModel(HybridBlock):
                  weight_initializer=TruncNorm(stdev=0.02),
                  bias_initializer='zeros',
                  dtype='float32',
-                 use_pooler=True,
-                 tied_embeddings=False,
-                 word_embed_params=None,
-                 token_type_embed_params=None,
-                 token_pos_embed_params=None,
-                 embed_layer_norm_params=None,
-                 prefix=None,
-                 params=None):
-        super().__init__(prefix=prefix, params=params)
+                 use_pooler=True):
+        super().__init__()
         self._dtype = dtype
         self.use_pooler = use_pooler
         self.pos_embed_type = pos_embed_type
@@ -230,65 +220,44 @@ class ElectraModel(HybridBlock):
         self.weight_initializer = weight_initializer
         self.bias_initializer = bias_initializer
         self.layer_norm_eps = layer_norm_eps
-        with self.name_scope():
-            # Construct ElectraEncoder
-            self.encoder = ElectraEncoder(
-                units=units,
-                hidden_size=hidden_size,
-                num_layers=num_layers,
-                num_heads=num_heads,
-                attention_dropout_prob=attention_dropout_prob,
-                hidden_dropout_prob=hidden_dropout_prob,
-                output_attention=False,
-                output_all_encodings=False,
-                activation=activation,
-                layer_norm_eps=layer_norm_eps,
-                weight_initializer=weight_initializer,
-                bias_initializer=bias_initializer,
-                dtype=dtype,
-                prefix='enc_',
-            )
-            self.encoder.hybridize()
-            # Construct model embedding which consists of three parts including word embedding,
-            # type embedding and positional embeddings.
-            # The hyper-parameters "tied_embeddings" is particularly
-            # used for sharing the embeddings between the Electra generator and the
-            # Electra discriminator.
-            if tied_embeddings:
-                assert word_embed_params is not None
-                assert token_type_embed_params is not None
-                assert token_pos_embed_params is not None
-                assert embed_layer_norm_params is not None
+        # Construct ElectraEncoder
+        self.encoder = ElectraEncoder(
+            units=units,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            num_heads=num_heads,
+            attention_dropout_prob=attention_dropout_prob,
+            hidden_dropout_prob=hidden_dropout_prob,
+            output_attention=False,
+            output_all_encodings=False,
+            activation=activation,
+            layer_norm_eps=layer_norm_eps,
+            weight_initializer=weight_initializer,
+            bias_initializer=bias_initializer,
+            dtype=dtype,
+        )
+        self.encoder.hybridize()
 
-            self.word_embed = nn.Embedding(input_dim=vocab_size,
-                                           output_dim=embed_size,
-                                           weight_initializer=embed_initializer,
-                                           dtype=dtype,
-                                           params=word_embed_params,
-                                           prefix='word_embed_')
-            # Construct token type embedding
-            self.token_type_embed = nn.Embedding(input_dim=num_token_types,
-                                                 output_dim=embed_size,
-                                                 weight_initializer=weight_initializer,
-                                                 params=token_type_embed_params,
-                                                 prefix='token_type_embed_')
-            self.token_pos_embed = PositionalEmbedding(units=embed_size,
-                                                       max_length=max_length,
-                                                       dtype=self._dtype,
-                                                       method=pos_embed_type,
-                                                       params=token_pos_embed_params,
-                                                       prefix='token_pos_embed_')
-            self.embed_layer_norm = nn.LayerNorm(epsilon=self.layer_norm_eps,
-                                                 params=embed_layer_norm_params,
-                                                 prefix='embed_ln_')
+        self.word_embed = nn.Embedding(input_dim=vocab_size,
+                                       output_dim=embed_size,
+                                       weight_initializer=embed_initializer,
+                                       dtype=dtype)
+        # Construct token type embedding
+        self.token_type_embed = nn.Embedding(input_dim=num_token_types,
+                                             output_dim=embed_size,
+                                             weight_initializer=weight_initializer)
+        self.token_pos_embed = PositionalEmbedding(units=embed_size,
+                                                   max_length=max_length,
+                                                   dtype=self._dtype,
+                                                   method=pos_embed_type)
+        self.embed_layer_norm = nn.LayerNorm(epsilon=self.layer_norm_eps)
 
-            self.embed_dropout = nn.Dropout(hidden_dropout_prob)
-            if embed_size != units:
-                self.embed_factorized_proj = nn.Dense(units=units,
-                                                      flatten=False,
-                                                      weight_initializer=weight_initializer,
-                                                      bias_initializer=bias_initializer,
-                                                      prefix='embed_factorized_proj_')
+        self.embed_dropout = nn.Dropout(hidden_dropout_prob)
+        if embed_size != units:
+            self.embed_factorized_proj = nn.Dense(units=units,
+                                                  flatten=False,
+                                                  weight_initializer=weight_initializer,
+                                                  bias_initializer=bias_initializer)
 
     def hybrid_forward(self, F, inputs, token_types, valid_length=None):
         # pylint: disable=arguments-differ
@@ -403,16 +372,7 @@ class ElectraModel(HybridBlock):
         return cfg
 
     @classmethod
-    def from_cfg(cls,
-                 cfg,
-                 use_pooler=True,
-                 tied_embeddings=False,
-                 word_embed_params=None,
-                 token_type_embed_params=None,
-                 token_pos_embed_params=None,
-                 embed_layer_norm_params=None,
-                 prefix=None,
-                 params=None):
+    def from_cfg(cls, cfg, use_pooler=True):
         cfg = ElectraModel.get_cfg().clone_merge(cfg)
         assert cfg.VERSION == 1, 'Wrong version!'
         embed_initializer = mx.init.create(*cfg.INITIALIZER.embed)
@@ -435,14 +395,7 @@ class ElectraModel(HybridBlock):
                    embed_initializer=embed_initializer,
                    weight_initializer=weight_initializer,
                    bias_initializer=bias_initializer,
-                   use_pooler=use_pooler,
-                   tied_embeddings=tied_embeddings,
-                   word_embed_params=word_embed_params,
-                   token_type_embed_params=token_type_embed_params,
-                   token_pos_embed_params=token_pos_embed_params,
-                   embed_layer_norm_params=embed_layer_norm_params,
-                   prefix=prefix,
-                   params=params)
+                   use_pooler=use_pooler)
 
 
 @use_np
@@ -456,9 +409,7 @@ class ElectraDiscriminator(HybridBlock):
 
     def __init__(self, backbone_cfg,
                  weight_initializer=None,
-                 bias_initializer=None,
-                 prefix=None,
-                 params=None):
+                 bias_initializer=None):
         """
 
         Parameters
@@ -466,31 +417,25 @@ class ElectraDiscriminator(HybridBlock):
         backbone_cfg
         weight_initializer
         bias_initializer
-        prefix
-        params
-        """
-        super().__init__(prefix=prefix, params=params)
-        with self.name_scope():
-            self.backbone_model = ElectraModel.from_cfg(backbone_cfg, prefix='')
-            if weight_initializer is None:
-                weight_initializer = self.backbone_model.weight_initializer
-            if bias_initializer is None:
-                bias_initializer = self.backbone_model.bias_initializer
-            self.rtd_encoder = nn.HybridSequential(prefix='disc_')
-            with self.rtd_encoder.name_scope():
-                # Extra non-linear layer
-                self.rtd_encoder.add(nn.Dense(units=self.backbone_model.units,
-                                              flatten=False,
-                                              weight_initializer=weight_initializer,
-                                              bias_initializer=bias_initializer,
-                                              prefix='proj_'))
-                self.rtd_encoder.add(get_activation(self.backbone_model.activation))
-                self.rtd_encoder.add(nn.Dense(units=1,
-                                              flatten=False,
-                                              weight_initializer=weight_initializer,
-                                              bias_initializer=bias_initializer,
-                                              prefix='predctions_'))
-            self.rtd_encoder.hybridize()
+                """
+        super().__init__()
+        self.backbone_model = ElectraModel.from_cfg(backbone_cfg)
+        if weight_initializer is None:
+            weight_initializer = self.backbone_model.weight_initializer
+        if bias_initializer is None:
+            bias_initializer = self.backbone_model.bias_initializer
+        self.rtd_encoder = nn.HybridSequential()
+        # Extra non-linear layer
+        self.rtd_encoder.add(nn.Dense(units=self.backbone_model.units,
+                                      flatten=False,
+                                      weight_initializer=weight_initializer,
+                                      bias_initializer=bias_initializer))
+        self.rtd_encoder.add(get_activation(self.backbone_model.activation))
+        self.rtd_encoder.add(nn.Dense(units=1,
+                                      flatten=False,
+                                      weight_initializer=weight_initializer,
+                                      bias_initializer=bias_initializer))
+        self.rtd_encoder.hybridize()
 
     def hybrid_forward(self, F, inputs, token_types, valid_length):
         """Getting the scores of the replaced token detection of the whole sentence
@@ -531,72 +476,49 @@ class ElectraGenerator(HybridBlock):
     """
 
     def __init__(self, backbone_cfg,
-                 tied_embeddings=True,
-                 word_embed_params=None,
-                 token_type_embed_params=None,
-                 token_pos_embed_params=None,
-                 embed_layer_norm_params=None,
                  weight_initializer=None,
-                 bias_initializer=None,
-                 prefix=None,
-                 params=None):
+                 bias_initializer=None):
         """
 
         Parameters
         ----------
         backbone_cfg
             Configuration of the backbone model
-        tied_embeddings
-            Reuse the embeddings of discriminator
-        word_embed_params
-            The parameters to load into word embeddings
-        token_type_embed_params
-            The parameters to load into word token type embeddings
-        token_pos_embed_params
-            The parameters to load into token positional embeddings
-        embed_layer_norm_params
-            The parameters to load into token layer normalization layer of embeddings
         weight_initializer
         bias_initializer
-        prefix
-        params
-        """
-        super().__init__(prefix=prefix, params=params)
-        with self.name_scope():
-            self.backbone_model = ElectraModel.from_cfg(
-                backbone_cfg,
-                tied_embeddings=tied_embeddings,
-                word_embed_params=word_embed_params,
-                token_type_embed_params=token_type_embed_params,
-                token_pos_embed_params=token_pos_embed_params,
-                embed_layer_norm_params=embed_layer_norm_params,
-                prefix='')
-            if weight_initializer is None:
-                weight_initializer = self.backbone_model.weight_initializer
-            if bias_initializer is None:
-                bias_initializer = self.backbone_model.bias_initializer
-            self.mlm_decoder = nn.HybridSequential(prefix='gen_')
-            with self.mlm_decoder.name_scope():
-                # Extra non-linear layer
-                self.mlm_decoder.add(nn.Dense(units=self.backbone_model.embed_size,
-                                              flatten=False,
-                                              weight_initializer=weight_initializer,
-                                              bias_initializer=bias_initializer,
-                                              prefix='proj_'))
-                self.mlm_decoder.add(get_activation(self.backbone_model.activation))
-                self.mlm_decoder.add(nn.LayerNorm(epsilon=self.backbone_model.layer_norm_eps,
-                                                  prefix='ln_'))
-                # only load the dense weights with a re-initialized bias
-                # parameters are stored in 'word_embed_bias' which is
-                # not used in original embedding
-                self.mlm_decoder.add(
-                    nn.Dense(
-                        units=self.backbone_model.vocab_size,
-                        flatten=False,
-                        params=self.backbone_model.word_embed.collect_params('.*weight'),
-                        bias_initializer=bias_initializer,
-                        prefix='score_'))
-            self.mlm_decoder.hybridize()
+                """
+        super().__init__()
+        self.backbone_model = ElectraModel.from_cfg(backbone_cfg)
+        if weight_initializer is None:
+            weight_initializer = self.backbone_model.weight_initializer
+        if bias_initializer is None:
+            bias_initializer = self.backbone_model.bias_initializer
+        self.mlm_decoder = nn.HybridSequential()
+        # Extra non-linear layer
+        self.mlm_decoder.add(nn.Dense(units=self.backbone_model.embed_size,
+                                      flatten=False,
+                                      weight_initializer=weight_initializer,
+                                      bias_initializer=bias_initializer))
+        self.mlm_decoder.add(get_activation(self.backbone_model.activation))
+        self.mlm_decoder.add(nn.LayerNorm(epsilon=self.backbone_model.layer_norm_eps))
+        # only load the dense weights with a re-initialized bias
+        # parameters are stored in 'word_embed_bias' which is
+        # not used in original embedding
+        self.mlm_decoder.add(
+            nn.Dense(
+                units=self.backbone_model.vocab_size,
+                flatten=False,
+                bias_initializer=bias_initializer))
+        self.mlm_decoder[-1].weight = self.backbone_model.word_embed.weight
+        self.mlm_decoder.hybridize()
+
+    def tie_embeddings(self, word_embed_params=None, token_type_embed_params=None,
+                       token_pos_embed_params=None, embed_layer_norm_params=None):
+        self.backbone_model.word_embed.share_parameters(word_embed_params)
+        self.mlm_decoder[-1].share_parameters(word_embed_params)
+        self.backbone_model.token_type_embed.share_parameters(token_type_embed_params)
+        self.backbone_model.token_pos_embed.share_parameters(token_pos_embed_params)
+        self.backbone_model.embed_layer_norm.share_parameters(embed_layer_norm_params)
 
     def hybrid_forward(self, F, inputs, token_types, valid_length, masked_positions):
         """Getting the scores of the masked positions.
@@ -652,9 +574,7 @@ class ElectraForPretrain(HybridBlock):
                  temperature=1.0,
                  dtype='float32',
                  weight_initializer=None,
-                 bias_initializer=None,
-                 prefix=None,
-                 params=None):
+                 bias_initializer=None):
         """
 
         Parameters
@@ -677,10 +597,8 @@ class ElectraForPretrain(HybridBlock):
             Temperature of gumbel distribution for sampling from generator
         weight_initializer
         bias_initializer
-        prefix
-        params
-        """
-        super().__init__(prefix=prefix, params=params)
+                """
+        super().__init__()
         self._uniform_generator = uniform_generator
         self._tied_generator = tied_generator
         self._tied_embeddings = tied_embeddings
@@ -691,34 +609,21 @@ class ElectraForPretrain(HybridBlock):
         self.disc_cfg = disc_cfg
         self.vocab_size = disc_cfg.MODEL.vocab_size
         self.gen_cfg = get_generator_cfg(disc_cfg)
-        self.discriminator = ElectraDiscriminator(disc_cfg, prefix='electra_')
+        self.discriminator = ElectraDiscriminator(disc_cfg)
         self.disc_backbone = self.discriminator.backbone_model
-        if tied_embeddings:
-            word_embed_params = self.disc_backbone.word_embed.collect_params()
-            token_type_embed_params = self.disc_backbone.token_pos_embed.collect_params()
-            token_pos_embed_params = self.disc_backbone.token_pos_embed.collect_params()
-            embed_layer_norm_params = self.disc_backbone.embed_layer_norm.collect_params()
-        else:
-            word_embed_params = None
-            token_type_embed_params = None
-            token_pos_embed_params = None
-            embed_layer_norm_params = None
 
         if not uniform_generator and not tied_generator:
-            self.generator = ElectraGenerator(
-                self.gen_cfg,
-                tied_embeddings=tied_embeddings,
-                word_embed_params=word_embed_params,
-                token_type_embed_params=token_type_embed_params,
-                token_pos_embed_params=token_pos_embed_params,
-                embed_layer_norm_params=embed_layer_norm_params,
-                prefix='generator_')
+            self.generator = ElectraGenerator(self.gen_cfg)
+            if tied_embeddings:
+                self.generator.tie_embeddings(self.disc_backbone.word_embed.collect_params(),
+                                              self.disc_backbone.token_type_embed.collect_params(),
+                                              self.disc_backbone.token_pos_embed.collect_params(),
+                                              self.disc_backbone.embed_layer_norm.collect_params())
             self.generator.hybridize()
 
         elif tied_generator:
             # Reuse the weight of the discriminator backbone model
-            self.generator = ElectraGenerator(
-                self.gen_cfg, tied_embeddings=False, prefix='generator_')
+            self.generator = ElectraGenerator(self.gen_cfg)
             self.generator.backbone_model = self.disc_backbone
             self.generator.hybridize()
         elif uniform_generator:

--- a/src/gluonnlp/models/mobilebert.py
+++ b/src/gluonnlp/models/mobilebert.py
@@ -84,8 +84,7 @@ class MobileBertEncoderLayer(HybridBlock):
                  use_qkv_bias: bool = True,
                  weight_initializer: Optional[InitializerType] = None,
                  bias_initializer: Optional[InitializerType] = 'zeros',
-                 dtype='float32',
-                 prefix=None, params=None):
+                 dtype='float32'):
         """
 
         Parameters
@@ -110,10 +109,8 @@ class MobileBertEncoderLayer(HybridBlock):
         weight_initializer
         bias_initializer
         dtype
-        prefix
-        params
-        """
-        super().__init__(prefix=prefix, params=params)
+                """
+        super().__init__()
         self._use_bottleneck = use_bottleneck
         self._units = units
         self._real_units = real_units
@@ -122,109 +119,94 @@ class MobileBertEncoderLayer(HybridBlock):
         self._bottleneck_strategy = bottleneck_strategy
         self._dtype = dtype
         assert real_units % num_heads == 0, 'units must be divisive by the number of heads'
-        with self.name_scope():
-            self.dropout_layer = nn.Dropout(hidden_dropout_prob)
-            if use_bottleneck:
-                self.in_bottleneck_proj = nn.Dense(units=real_units,
-                                                   in_units=units,
-                                                   flatten=False,
-                                                   weight_initializer=weight_initializer,
-                                                   bias_initializer=bias_initializer,
-                                                   dtype=self._dtype,
-                                                   prefix='in_bottleneck_proj_')
-                self.in_bottleneck_ln = get_layer_norm(normalization=normalization,
-                                                       in_channels=real_units,
-                                                       epsilon=layer_norm_eps,
-                                                       prefix='in_bottleneck_ln_')
-                self.out_bottleneck_proj = nn.Dense(units=units,
-                                                    in_units=real_units,
-                                                    flatten=False,
-                                                    weight_initializer=weight_initializer,
-                                                    bias_initializer=bias_initializer,
-                                                    dtype=self._dtype,
-                                                    prefix='out_bottleneck_proj_')
-                self.out_bottleneck_ln = get_layer_norm(normalization=normalization,
-                                                        in_channels=units,
-                                                        epsilon=layer_norm_eps,
-                                                        prefix='out_bottleneck_ln_')
+        self.dropout_layer = nn.Dropout(hidden_dropout_prob)
+        if use_bottleneck:
+            self.in_bottleneck_proj = nn.Dense(units=real_units,
+                                               in_units=units,
+                                               flatten=False,
+                                               weight_initializer=weight_initializer,
+                                               bias_initializer=bias_initializer,
+                                               dtype=self._dtype)
+            self.in_bottleneck_ln = get_layer_norm(normalization=normalization,
+                                                   in_channels=real_units,
+                                                   epsilon=layer_norm_eps)
+            self.out_bottleneck_proj = nn.Dense(units=units,
+                                                in_units=real_units,
+                                                flatten=False,
+                                                weight_initializer=weight_initializer,
+                                                bias_initializer=bias_initializer,
+                                                dtype=self._dtype)
+            self.out_bottleneck_ln = get_layer_norm(normalization=normalization,
+                                                    in_channels=units,
+                                                    epsilon=layer_norm_eps)
 
-                if bottleneck_strategy == 'qk_sharing':
-                    self.shared_qk = nn.Dense(units=real_units,
-                                              in_units=units,
-                                              flatten=False,
-                                              weight_initializer=weight_initializer,
-                                              bias_initializer=bias_initializer,
-                                              dtype=self._dtype,
-                                              prefix='shared_qk_')
-                    self.shared_qk_ln = get_layer_norm(normalization=normalization,
-                                                       in_channels=real_units,
-                                                       epsilon=layer_norm_eps,
-                                                       prefix='shared_qk_ln_')
-            self.attention_proj = nn.Dense(units=real_units,
-                                           flatten=False,
-                                           in_units=real_units,
-                                           use_bias=True,
-                                           weight_initializer=weight_initializer,
-                                           bias_initializer=bias_initializer,
-                                           dtype=self._dtype,
-                                           prefix='proj_')
-            # The in_units of qkv varies according to the sharing strategy
-            self.attn_query = nn.Dense(units=real_units,
+            if bottleneck_strategy == 'qk_sharing':
+                self.shared_qk = nn.Dense(units=real_units,
+                                          in_units=units,
+                                          flatten=False,
+                                          weight_initializer=weight_initializer,
+                                          bias_initializer=bias_initializer,
+                                          dtype=self._dtype)
+                self.shared_qk_ln = get_layer_norm(normalization=normalization,
+                                                   in_channels=real_units,
+                                                   epsilon=layer_norm_eps)
+        self.attention_proj = nn.Dense(units=real_units,
                                        flatten=False,
-                                       use_bias=use_qkv_bias,
+                                       in_units=real_units,
+                                       use_bias=True,
                                        weight_initializer=weight_initializer,
                                        bias_initializer=bias_initializer,
-                                       dtype=self._dtype,
-                                       prefix='attn_query_')
-            self.attn_key = nn.Dense(units=real_units,
-                                     flatten=False,
-                                     use_bias=use_qkv_bias,
-                                     weight_initializer=weight_initializer,
-                                     bias_initializer=bias_initializer,
-                                     dtype=self._dtype,
-                                     prefix='attn_key_')
-            self.attn_value = nn.Dense(units=real_units,
-                                       flatten=False,
-                                       use_bias=use_qkv_bias,
-                                       weight_initializer=weight_initializer,
-                                       bias_initializer=bias_initializer,
-                                       dtype=self._dtype,
-                                       prefix='attn_value_')
-            self.attention_cell = \
-                MultiHeadAttentionCell(
-                    query_units=real_units,
-                    num_heads=num_heads,
-                    attention_dropout=attention_dropout_prob,
-                    scaled=True,
-                    prefix='attn_cell_',
-                    dtype=self._dtype,
-                    layout='NTK'
-                )
-            self.layer_norm = get_layer_norm(normalization=normalization,
-                                             in_channels=real_units,
-                                             epsilon=layer_norm_eps,
-                                             prefix='ln_')
+                                       dtype=self._dtype)
+        # The in_units of qkv varies according to the sharing strategy
+        self.attn_query = nn.Dense(units=real_units,
+                                   flatten=False,
+                                   use_bias=use_qkv_bias,
+                                   weight_initializer=weight_initializer,
+                                   bias_initializer=bias_initializer,
+                                   dtype=self._dtype)
+        self.attn_key = nn.Dense(units=real_units,
+                                 flatten=False,
+                                 use_bias=use_qkv_bias,
+                                 weight_initializer=weight_initializer,
+                                 bias_initializer=bias_initializer,
+                                 dtype=self._dtype)
+        self.attn_value = nn.Dense(units=real_units,
+                                   flatten=False,
+                                   use_bias=use_qkv_bias,
+                                   weight_initializer=weight_initializer,
+                                   bias_initializer=bias_initializer,
+                                   dtype=self._dtype)
+        self.attention_cell = \
+            MultiHeadAttentionCell(
+                query_units=real_units,
+                num_heads=num_heads,
+                attention_dropout=attention_dropout_prob,
+                scaled=True,
+                dtype=self._dtype,
+                layout='NTK'
+            )
+        self.layer_norm = get_layer_norm(normalization=normalization,
+                                         in_channels=real_units,
+                                         epsilon=layer_norm_eps)
 
-            self.stacked_ffn = nn.HybridSequential(prefix='stacked_ffns_')
-            with self.stacked_ffn.name_scope():
-                for ffn_idx in range(num_stacked_ffn):
-                    is_last_ffn = (ffn_idx == (num_stacked_ffn - 1))
-                    # only apply dropout on last ffn layer if use bottleneck
-                    dropout = float(hidden_dropout_prob * (not use_bottleneck) * is_last_ffn)
-                    activation_dropout = float(activation_dropout_prob * (not use_bottleneck)
-                                               * is_last_ffn)
-                    self.stacked_ffn.add(
-                        PositionwiseFFN(units=real_units,
-                                        hidden_size=hidden_size,
-                                        dropout=dropout,
-                                        activation_dropout=activation_dropout,
-                                        weight_initializer=weight_initializer,
-                                        bias_initializer=bias_initializer,
-                                        activation=activation,
-                                        normalization=normalization,
-                                        layer_norm_eps=layer_norm_eps,
-                                        dtype=self._dtype,
-                                        prefix='{}_'.format(ffn_idx)))
+        self.stacked_ffn = nn.HybridSequential()
+        for ffn_idx in range(num_stacked_ffn):
+            is_last_ffn = (ffn_idx == (num_stacked_ffn - 1))
+            # only apply dropout on last ffn layer if use bottleneck
+            dropout = float(hidden_dropout_prob * (not use_bottleneck) * is_last_ffn)
+            activation_dropout = float(activation_dropout_prob * (not use_bottleneck)
+                                       * is_last_ffn)
+            self.stacked_ffn.add(
+                PositionwiseFFN(units=real_units,
+                                hidden_size=hidden_size,
+                                dropout=dropout,
+                                activation_dropout=activation_dropout,
+                                weight_initializer=weight_initializer,
+                                bias_initializer=bias_initializer,
+                                activation=activation,
+                                normalization=normalization,
+                                layer_norm_eps=layer_norm_eps,
+                                dtype=self._dtype))
 
     def hybrid_forward(self, F, data, attn_mask):
         """
@@ -315,9 +297,8 @@ class MobileBertTransformer(HybridBlock):
                  layer_norm_eps: float = 1E-12,
                  weight_initializer: InitializerType = TruncNorm(stdev=0.02),
                  bias_initializer: InitializerType = 'zeros',
-                 dtype='float32',
-                 prefix=None, params=None):
-        super().__init__(prefix=prefix, params=params)
+                 dtype='float32'):
+        super().__init__()
         self._dtype = dtype
         self._num_layers = num_layers
         self._output_attention = output_attention
@@ -331,26 +312,23 @@ class MobileBertTransformer(HybridBlock):
             'by the number of heads. Received real_units={}, num_heads={}' \
             .format(real_units, num_heads)
 
-        with self.name_scope():
-            self.all_layers = nn.HybridSequential(prefix='layers_')
-            with self.all_layers.name_scope():
-                for layer_idx in range(num_layers):
-                    self.all_layers.add(
-                        MobileBertEncoderLayer(use_bottleneck=use_bottleneck,
-                                               units=units,
-                                               real_units=real_units,
-                                               hidden_size=hidden_size,
-                                               num_heads=num_heads,
-                                               attention_dropout_prob=attention_dropout_prob,
-                                               hidden_dropout_prob=hidden_dropout_prob,
-                                               num_stacked_ffn=num_stacked_ffn,
-                                               bottleneck_strategy=bottleneck_strategy,
-                                               layer_norm_eps=layer_norm_eps,
-                                               weight_initializer=weight_initializer,
-                                               bias_initializer=bias_initializer,
-                                               normalization=normalization,
-                                               activation=activation,
-                                               prefix='{}_'.format(layer_idx)))
+        self.all_layers = nn.HybridSequential()
+        for layer_idx in range(num_layers):
+            self.all_layers.add(
+                MobileBertEncoderLayer(use_bottleneck=use_bottleneck,
+                                       units=units,
+                                       real_units=real_units,
+                                       hidden_size=hidden_size,
+                                       num_heads=num_heads,
+                                       attention_dropout_prob=attention_dropout_prob,
+                                       hidden_dropout_prob=hidden_dropout_prob,
+                                       num_stacked_ffn=num_stacked_ffn,
+                                       bottleneck_strategy=bottleneck_strategy,
+                                       layer_norm_eps=layer_norm_eps,
+                                       weight_initializer=weight_initializer,
+                                       bias_initializer=bias_initializer,
+                                       normalization=normalization,
+                                       activation=activation))
 
     def hybrid_forward(self, F, data, valid_length):
         """
@@ -427,10 +405,8 @@ class MobileBertModel(HybridBlock):
                  trigram_embed=True,
                  use_pooler=True,
                  classifier_activation=False,
-                 dtype='float32',
-                 prefix=None,
-                 params=None):
-        super().__init__(prefix=prefix, params=params)
+                 dtype='float32'):
+        super().__init__()
         self._dtype = dtype
         self.use_bottleneck = use_bottleneck
         self.bottleneck_strategy = bottleneck_strategy
@@ -451,66 +427,58 @@ class MobileBertModel(HybridBlock):
         self.weight_initializer = weight_initializer
         self.bias_initializer = bias_initializer
         self.layer_norm_eps = layer_norm_eps
-        with self.name_scope():
-            # Construct MobileBertTransformer
-            self.encoder = MobileBertTransformer(
-                units=units,
-                hidden_size=hidden_size,
-                num_layers=num_layers,
-                num_heads=num_heads,
-                inner_size=inner_size,
-                num_stacked_ffn=num_stacked_ffn,
-                bottleneck_strategy=bottleneck_strategy,
-                attention_dropout_prob=attention_dropout_prob,
-                hidden_dropout_prob=hidden_dropout_prob,
-                output_attention=False,
-                output_all_encodings=False,
-                activation=activation,
-                normalization=normalization,
-                layer_norm_eps=layer_norm_eps,
-                weight_initializer=weight_initializer,
-                bias_initializer=bias_initializer,
-                dtype=dtype,
-                prefix='enc_',
-            )
-            self.encoder.hybridize()
-            # Construct word embedding
-            self.word_embed = nn.Embedding(input_dim=vocab_size,
-                                           output_dim=embed_size,
-                                           weight_initializer=embed_initializer,
-                                           dtype=dtype,
-                                           prefix='word_embed_')
-            if trigram_embed or embed_size != units:
-                self.embed_factorized_proj = nn.Dense(units=units,
-                                                      flatten=False,
-                                                      weight_initializer=weight_initializer,
-                                                      bias_initializer=bias_initializer,
-                                                      prefix='embed_factorized_proj_')
-            self.embed_layer_norm = get_layer_norm(normalization=normalization,
-                                                   in_channels=units,
-                                                   epsilon=self.layer_norm_eps,
-                                                   prefix='embed_ln_')
+        # Construct MobileBertTransformer
+        self.encoder = MobileBertTransformer(
+            units=units,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            num_heads=num_heads,
+            inner_size=inner_size,
+            num_stacked_ffn=num_stacked_ffn,
+            bottleneck_strategy=bottleneck_strategy,
+            attention_dropout_prob=attention_dropout_prob,
+            hidden_dropout_prob=hidden_dropout_prob,
+            output_attention=False,
+            output_all_encodings=False,
+            activation=activation,
+            normalization=normalization,
+            layer_norm_eps=layer_norm_eps,
+            weight_initializer=weight_initializer,
+            bias_initializer=bias_initializer,
+            dtype=dtype,
+        )
+        self.encoder.hybridize()
+        # Construct word embedding
+        self.word_embed = nn.Embedding(input_dim=vocab_size,
+                                       output_dim=embed_size,
+                                       weight_initializer=embed_initializer,
+                                       dtype=dtype)
+        if trigram_embed or embed_size != units:
+            self.embed_factorized_proj = nn.Dense(units=units,
+                                                  flatten=False,
+                                                  weight_initializer=weight_initializer,
+                                                  bias_initializer=bias_initializer)
+        self.embed_layer_norm = get_layer_norm(normalization=normalization,
+                                               in_channels=units,
+                                               epsilon=self.layer_norm_eps)
 
-            self.embed_dropout = nn.Dropout(hidden_dropout_prob)
-            # Construct token type embedding
-            self.token_type_embed = nn.Embedding(input_dim=num_token_types,
-                                                 output_dim=units,
-                                                 weight_initializer=weight_initializer,
-                                                 prefix='token_type_embed_')
-            self.token_pos_embed = PositionalEmbedding(units=units,
-                                                       max_length=max_length,
-                                                       dtype=self._dtype,
-                                                       method=pos_embed_type,
-                                                       prefix='token_pos_embed_')
-            if self.use_pooler and self.classifier_activation:
-                # Construct pooler
-                self.pooler = nn.Dense(units=units,
-                                       in_units=units,
-                                       flatten=False,
-                                       activation='tanh',
-                                       weight_initializer=weight_initializer,
-                                       bias_initializer=bias_initializer,
-                                       prefix='pooler_')
+        self.embed_dropout = nn.Dropout(hidden_dropout_prob)
+        # Construct token type embedding
+        self.token_type_embed = nn.Embedding(input_dim=num_token_types,
+                                             output_dim=units,
+                                             weight_initializer=weight_initializer)
+        self.token_pos_embed = PositionalEmbedding(units=units,
+                                                   max_length=max_length,
+                                                   dtype=self._dtype,
+                                                   method=pos_embed_type)
+        if self.use_pooler and self.classifier_activation:
+            # Construct pooler
+            self.pooler = nn.Dense(units=units,
+                                   in_units=units,
+                                   flatten=False,
+                                   activation='tanh',
+                                   weight_initializer=weight_initializer,
+                                   bias_initializer=bias_initializer)
 
     def hybrid_forward(self, F, inputs, token_types, valid_length):
         # pylint: disable=arguments-differ
@@ -649,9 +617,7 @@ class MobileBertModel(HybridBlock):
                  use_bottleneck=True,
                  trigram_embed=True,
                  use_pooler=True,
-                 classifier_activation=False,
-                 prefix=None,
-                 params=None):
+                 classifier_activation=False):
         cfg = MobileBertModel.get_cfg().clone_merge(cfg)
         assert cfg.VERSION == 1, 'Wrong version!'
         embed_initializer = mx.init.create(*cfg.INITIALIZER.embed)
@@ -681,9 +647,7 @@ class MobileBertModel(HybridBlock):
                    use_bottleneck=use_bottleneck,
                    trigram_embed=trigram_embed,
                    use_pooler=use_pooler,
-                   classifier_activation=classifier_activation,
-                   prefix=prefix,
-                   params=params)
+                   classifier_activation=classifier_activation)
 
 
 @use_np
@@ -692,9 +656,7 @@ class MobileBertForMLM(HybridBlock):
                  use_bottleneck=True,
                  trigram_embed=True,
                  weight_initializer=None,
-                 bias_initializer=None,
-                 prefix=None,
-                 params=None):
+                 bias_initializer=None):
         """
 
         Parameters
@@ -702,50 +664,41 @@ class MobileBertForMLM(HybridBlock):
         backbone_cfg
         weight_initializer
         bias_initializer
-        prefix
-        params
-        """
-        super().__init__(prefix=prefix, params=params)
-        with self.name_scope():
-            self.backbone_model = MobileBertModel.from_cfg(backbone_cfg,
-                                                           use_bottleneck=use_bottleneck,
-                                                           trigram_embed=trigram_embed,
-                                                           prefix='')
-            if weight_initializer is None:
-                weight_initializer = self.backbone_model.weight_initializer
-            if bias_initializer is None:
-                bias_initializer = self.backbone_model.bias_initializer
-            self.mlm_decoder = nn.HybridSequential(prefix='mlm_')
-            with self.mlm_decoder.name_scope():
-                # Extra non-linear layer
-                self.mlm_decoder.add(nn.Dense(units=self.backbone_model.units,
-                                              flatten=False,
-                                              weight_initializer=weight_initializer,
-                                              bias_initializer=bias_initializer,
-                                              prefix='proj_'))
-                self.mlm_decoder.add(get_activation(self.backbone_model.activation))
-                # use basic layer normalization for pretaining
-                self.mlm_decoder.add(nn.LayerNorm(epsilon=self.backbone_model.layer_norm_eps,
-                                                  prefix='ln_'))
-            self.mlm_decoder.hybridize()
-            # only load the dense weights with a re-initialized bias
-            # parameters are stored in 'word_embed_bias' which is
-            # not used in original embedding
-            self.embedding_table = nn.Dense(
+                """
+        super().__init__()
+        self.backbone_model = MobileBertModel.from_cfg(backbone_cfg,
+                                                       use_bottleneck=use_bottleneck,
+                                                       trigram_embed=trigram_embed)
+        if weight_initializer is None:
+            weight_initializer = self.backbone_model.weight_initializer
+        if bias_initializer is None:
+            bias_initializer = self.backbone_model.bias_initializer
+        self.mlm_decoder = nn.HybridSequential()
+        # Extra non-linear layer
+        self.mlm_decoder.add(nn.Dense(units=self.backbone_model.units,
+                                      flatten=False,
+                                      weight_initializer=weight_initializer,
+                                      bias_initializer=bias_initializer))
+        self.mlm_decoder.add(get_activation(self.backbone_model.activation))
+        # use basic layer normalization for pretaining
+        self.mlm_decoder.add(nn.LayerNorm(epsilon=self.backbone_model.layer_norm_eps))
+        self.mlm_decoder.hybridize()
+        # only load the dense weights with a re-initialized bias
+        # parameters are stored in 'word_embed_bias' which is
+        # not used in original embedding
+        self.embedding_table = nn.Dense(
+            units=self.backbone_model.vocab_size,
+            in_units=self.backbone_model.embed_size,
+            flatten=False,
+            bias_initializer=bias_initializer)
+        self.embedding_table.weight = self.backbone_model.word_embed.weight
+        if self.backbone_model.embed_size != self.backbone_model.units:
+            self.extra_table = nn.Dense(
                 units=self.backbone_model.vocab_size,
-                in_units=self.backbone_model.embed_size,
-                flatten=False,
-                params=self.backbone_model.word_embed.collect_params('.*weight'),
-                bias_initializer=bias_initializer,
-                prefix='mlm_score_')
-            if self.backbone_model.embed_size != self.backbone_model.units:
-                self.extra_table = nn.Dense(
-                    units=self.backbone_model.vocab_size,
-                    use_bias=False,
-                    in_units=self.backbone_model.units -
-                    self.backbone_model.embed_size,
-                    flatten=False,
-                    prefix='mlm_extra_score_')
+                use_bias=False,
+                in_units=self.backbone_model.units -
+                self.backbone_model.embed_size,
+                flatten=False)
 
     def hybrid_forward(self, F, inputs, token_types, valid_length,
                        masked_positions):
@@ -796,8 +749,7 @@ class MobileBertForPretrain(HybridBlock):
                  use_bottleneck=True,
                  trigram_embed=True,
                  weight_initializer=None,
-                 bias_initializer=None,
-                 prefix=None, params=None):
+                 bias_initializer=None):
         """
 
         Parameters
@@ -806,55 +758,45 @@ class MobileBertForPretrain(HybridBlock):
             The cfg of the backbone model
         weight_initializer
         bias_initializer
-        prefix
-        params
-        """
-        super().__init__(prefix=prefix, params=params)
-        with self.name_scope():
-            self.backbone_model = MobileBertModel.from_cfg(backbone_cfg,
-                                                           use_bottleneck=use_bottleneck,
-                                                           trigram_embed=trigram_embed,
-                                                           prefix='')
-            if weight_initializer is None:
-                weight_initializer = self.backbone_model.weight_initializer
-            if bias_initializer is None:
-                bias_initializer = self.backbone_model.bias_initializer
-            # Construct nsp_classifier for next sentence prediction
-            self.nsp_classifier = nn.Dense(units=2,
-                                           weight_initializer=weight_initializer,
-                                           prefix='nsp_')
-            self.mlm_decoder = nn.HybridSequential(prefix='mlm_')
-            with self.mlm_decoder.name_scope():
-                # Extra non-linear layer
-                self.mlm_decoder.add(nn.Dense(units=self.backbone_model.units,
-                                              flatten=False,
-                                              weight_initializer=weight_initializer,
-                                              bias_initializer=bias_initializer,
-                                              prefix='proj_'))
-                self.mlm_decoder.add(get_activation(self.backbone_model.activation))
-                # use basic layer normalization for pretaining
-                self.mlm_decoder.add(nn.LayerNorm(epsilon=self.backbone_model.layer_norm_eps,
-                                                  prefix='ln_'))
-            self.mlm_decoder.hybridize()
-            # only load the dense weights with a re-initialized bias
-            # parameters are stored in 'word_embed_bias' which is
-            # not used in original embedding
-            self.embedding_table = nn.Dense(
+                """
+        super().__init__()
+        self.backbone_model = MobileBertModel.from_cfg(backbone_cfg,
+                                                       use_bottleneck=use_bottleneck,
+                                                       trigram_embed=trigram_embed)
+        if weight_initializer is None:
+            weight_initializer = self.backbone_model.weight_initializer
+        if bias_initializer is None:
+            bias_initializer = self.backbone_model.bias_initializer
+        # Construct nsp_classifier for next sentence prediction
+        self.nsp_classifier = nn.Dense(units=2,
+                                       weight_initializer=weight_initializer)
+        self.mlm_decoder = nn.HybridSequential()
+        # Extra non-linear layer
+        self.mlm_decoder.add(nn.Dense(units=self.backbone_model.units,
+                                      flatten=False,
+                                      weight_initializer=weight_initializer,
+                                      bias_initializer=bias_initializer))
+        self.mlm_decoder.add(get_activation(self.backbone_model.activation))
+        # use basic layer normalization for pretaining
+        self.mlm_decoder.add(nn.LayerNorm(epsilon=self.backbone_model.layer_norm_eps))
+        self.mlm_decoder.hybridize()
+        # only load the dense weights with a re-initialized bias
+        # parameters are stored in 'word_embed_bias' which is
+        # not used in original embedding
+        self.embedding_table = nn.Dense(
+            units=self.backbone_model.vocab_size,
+            in_units=self.backbone_model.embed_size,
+            flatten=False,
+            bias_initializer=bias_initializer)
+        self.embedding_table.weight = self.backbone_model.word_embed.weight
+        if self.backbone_model.embed_size != self.backbone_model.units:
+            self.extra_table = nn.Dense(
                 units=self.backbone_model.vocab_size,
-                in_units=self.backbone_model.embed_size,
+                in_units=self.backbone_model.units -
+                self.backbone_model.embed_size,
                 flatten=False,
-                params=self.backbone_model.word_embed.collect_params('.*weight'),
-                bias_initializer=bias_initializer,
-                prefix='mlm_score_')
-            if self.backbone_model.embed_size != self.backbone_model.units:
-                self.extra_table = nn.Dense(
-                    units=self.backbone_model.vocab_size,
-                    in_units=self.backbone_model.units -
-                    self.backbone_model.embed_size,
-                    flatten=False,
-                    use_bias=False,
-                    bias_initializer=bias_initializer,
-                    prefix='mlm_extra_score_')
+                use_bias=False,
+                bias_initializer=bias_initializer)
 
     def hybrid_forward(self, F, inputs, token_types, valid_length,
                        masked_positions):

--- a/src/gluonnlp/models/mobilebert.py
+++ b/src/gluonnlp/models/mobilebert.py
@@ -109,7 +109,7 @@ class MobileBertEncoderLayer(HybridBlock):
         weight_initializer
         bias_initializer
         dtype
-                """
+        """
         super().__init__()
         self._use_bottleneck = use_bottleneck
         self._units = units
@@ -664,7 +664,7 @@ class MobileBertForMLM(HybridBlock):
         backbone_cfg
         weight_initializer
         bias_initializer
-                """
+        """
         super().__init__()
         self.backbone_model = MobileBertModel.from_cfg(backbone_cfg,
                                                        use_bottleneck=use_bottleneck,
@@ -758,7 +758,7 @@ class MobileBertForPretrain(HybridBlock):
             The cfg of the backbone model
         weight_initializer
         bias_initializer
-                """
+        """
         super().__init__()
         self.backbone_model = MobileBertModel.from_cfg(backbone_cfg,
                                                        use_bottleneck=use_bottleneck,

--- a/src/gluonnlp/models/roberta.py
+++ b/src/gluonnlp/models/roberta.py
@@ -159,7 +159,7 @@ class RobertaModel(HybridBlock):
             Whether to untie weights between embeddings and classifiers
         encoder_normalize_before
         return_all_hiddens
-                """
+        """
         super().__init__()
         self.vocab_size = vocab_size
         self.units = units

--- a/src/gluonnlp/models/transformer.py
+++ b/src/gluonnlp/models/transformer.py
@@ -164,7 +164,7 @@ class TransformerEncoderLayer(HybridBlock):
         bias_initializer
         activation
         dtype
-                """
+        """
         super().__init__()
         self._units = units
         self._hidden_size = hidden_size
@@ -276,7 +276,7 @@ class TransformerEncoder(HybridBlock):
         weight_initializer
         bias_initializer
         activation
-                """
+        """
         super().__init__()
         self._dtype = dtype
         self.num_layers = num_layers
@@ -376,7 +376,7 @@ class TransformerDecoderLayer(HybridBlock):
         weight_initializer
         bias_initializer
         dtype
-                """
+        """
         super().__init__()
         self._dtype = dtype
         self._units = units
@@ -883,7 +883,7 @@ class TransformerNMTModel(HybridBlock):
             Initializer of the bias
         dtype
             Data type of the weights
-                """
+        """
         super().__init__()
         assert src_vocab_size > 0 and tgt_vocab_size > 0,\
             'Cannot set "src_vocab_size" and "tgt_vocab_size" to negative numbers. ' \
@@ -1115,7 +1115,7 @@ class TransformerNMTInference(HybridBlock, BaseStepDecoder):
         Parameters
         ----------
         model
-                """
+        """
         super().__init__()
         self.model = model
 

--- a/src/gluonnlp/models/transformer.py
+++ b/src/gluonnlp/models/transformer.py
@@ -140,8 +140,7 @@ class TransformerEncoderLayer(HybridBlock):
                  weight_initializer: Optional[InitializerType] = None,
                  bias_initializer: Optional[InitializerType] = 'zeros',
                  activation: str = 'relu',
-                 dtype='float32',
-                 prefix=None, params=None):
+                 dtype='float32'):
         """
 
         Parameters
@@ -165,10 +164,8 @@ class TransformerEncoderLayer(HybridBlock):
         bias_initializer
         activation
         dtype
-        prefix
-        params
-        """
-        super().__init__(prefix=prefix, params=params)
+                """
+        super().__init__()
         self._units = units
         self._hidden_size = hidden_size
         self._num_heads = num_heads
@@ -178,48 +175,42 @@ class TransformerEncoderLayer(HybridBlock):
         self._pre_norm = pre_norm
         self._dtype = dtype
         assert self._units % self._num_heads == 0, 'units must be divisive by the number of heads'
-        with self.name_scope():
-            self.dropout_layer = nn.Dropout(hidden_dropout_prob)
-            self.attn_qkv = nn.Dense(3 * units,
-                                     flatten=False,
-                                     use_bias=use_qkv_bias,
-                                     in_units=units,
-                                     weight_initializer=weight_initializer,
-                                     bias_initializer=bias_initializer,
-                                     dtype=self._dtype,
-                                     prefix='attn_qkv_')
-            self.attention_proj = nn.Dense(units=units,
-                                           flatten=False,
-                                           in_units=units,
-                                           use_bias=True,
-                                           weight_initializer=weight_initializer,
-                                           bias_initializer=bias_initializer,
-                                           dtype=self._dtype,
-                                           prefix='proj_')
-            self.attention_cell =\
-                MultiHeadAttentionCell(
-                    query_units=self._units,
-                    num_heads=self._num_heads,
-                    attention_dropout=self._attention_dropout_prob,
-                    scaled=True,
-                    prefix='attn_cell_',
-                    dtype=self._dtype,
-                    layout='NTK'
-                )
-            self.layer_norm = nn.LayerNorm(epsilon=layer_norm_eps,
-                                           in_channels=units,
-                                           prefix='ln_')
-            self.ffn = PositionwiseFFN(units=units,
-                                       hidden_size=hidden_size,
-                                       dropout=hidden_dropout_prob,
-                                       activation_dropout=activation_dropout_prob,
+        self.dropout_layer = nn.Dropout(hidden_dropout_prob)
+        self.attn_qkv = nn.Dense(3 * units,
+                                 flatten=False,
+                                 use_bias=use_qkv_bias,
+                                 in_units=units,
+                                 weight_initializer=weight_initializer,
+                                 bias_initializer=bias_initializer,
+                                 dtype=self._dtype)
+        self.attention_proj = nn.Dense(units=units,
+                                       flatten=False,
+                                       in_units=units,
+                                       use_bias=True,
                                        weight_initializer=weight_initializer,
                                        bias_initializer=bias_initializer,
-                                       layer_norm_eps=layer_norm_eps,
-                                       activation=activation,
-                                       pre_norm=pre_norm,
-                                       dtype=self._dtype,
-                                       prefix='ffn_')
+                                       dtype=self._dtype)
+        self.attention_cell =\
+            MultiHeadAttentionCell(
+                query_units=self._units,
+                num_heads=self._num_heads,
+                attention_dropout=self._attention_dropout_prob,
+                scaled=True,
+                dtype=self._dtype,
+                layout='NTK'
+            )
+        self.layer_norm = nn.LayerNorm(epsilon=layer_norm_eps,
+                                       in_channels=units)
+        self.ffn = PositionwiseFFN(units=units,
+                                   hidden_size=hidden_size,
+                                   dropout=hidden_dropout_prob,
+                                   activation_dropout=activation_dropout_prob,
+                                   weight_initializer=weight_initializer,
+                                   bias_initializer=bias_initializer,
+                                   layer_norm_eps=layer_norm_eps,
+                                   activation=activation,
+                                   pre_norm=pre_norm,
+                                   dtype=self._dtype)
 
     def hybrid_forward(self, F, data, attn_mask):
         """
@@ -264,8 +255,7 @@ class TransformerEncoder(HybridBlock):
                  activation_dropout=0.0, dropout=0.1,
                  attention_dropout=0.1, layer_norm_eps=1E-5, data_norm=False,
                  pre_norm=False, weight_initializer=None, bias_initializer='zeros',
-                 activation='relu', dtype='float32',
-                 prefix=None, params=None):
+                 activation='relu', dtype='float32'):
         """
 
         Parameters
@@ -286,44 +276,37 @@ class TransformerEncoder(HybridBlock):
         weight_initializer
         bias_initializer
         activation
-        prefix
-        params
-        """
-        super(TransformerEncoder, self).__init__(prefix=prefix, params=params)
+                """
+        super().__init__()
         self._dtype = dtype
         self.num_layers = num_layers
         self._recurrent = recurrent
         self._data_norm = data_norm
         self._pre_norm = pre_norm
-        with self.name_scope():
-            self.dropout_layer = nn.Dropout(dropout)
-            if self._pre_norm:
-                self.ln_final = nn.LayerNorm(epsilon=layer_norm_eps,
-                                             in_channels=units,
-                                             prefix='ln_final_')
-            if self._data_norm:
-                self.ln_data = nn.LayerNorm(epsilon=layer_norm_eps,
-                                            in_channels=units,
-                                            prefix='ln_data_')
-            # Construct the intermediate layers
-            self.layers = nn.HybridSequential(prefix='layers_')
-            real_num_layers = 1 if recurrent else num_layers
-            with self.layers.name_scope():
-                for i in range(real_num_layers):
-                    self.layers.add(TransformerEncoderLayer(
-                        units=units,
-                        hidden_size=hidden_size,
-                        num_heads=num_heads,
-                        hidden_dropout_prob=dropout,
-                        attention_dropout_prob=attention_dropout,
-                        activation_dropout_prob=activation_dropout,
-                        layer_norm_eps=layer_norm_eps,
-                        weight_initializer=weight_initializer,
-                        bias_initializer=bias_initializer,
-                        pre_norm=pre_norm,
-                        activation=activation,
-                        dtype=dtype,
-                        prefix='{}_'.format(i)))
+        self.dropout_layer = nn.Dropout(dropout)
+        if self._pre_norm:
+            self.ln_final = nn.LayerNorm(epsilon=layer_norm_eps,
+                                         in_channels=units)
+        if self._data_norm:
+            self.ln_data = nn.LayerNorm(epsilon=layer_norm_eps,
+                                        in_channels=units)
+        # Construct the intermediate layers
+        self.layers = nn.HybridSequential()
+        real_num_layers = 1 if recurrent else num_layers
+        for i in range(real_num_layers):
+            self.layers.add(TransformerEncoderLayer(
+                units=units,
+                hidden_size=hidden_size,
+                num_heads=num_heads,
+                hidden_dropout_prob=dropout,
+                attention_dropout_prob=attention_dropout,
+                activation_dropout_prob=activation_dropout,
+                layer_norm_eps=layer_norm_eps,
+                weight_initializer=weight_initializer,
+                bias_initializer=bias_initializer,
+                pre_norm=pre_norm,
+                activation=activation,
+                dtype=dtype))
 
     def hybrid_forward(self, F, data, valid_length):
         """
@@ -372,9 +355,7 @@ class TransformerDecoderLayer(HybridBlock):
                  pre_norm: bool = False,
                  weight_initializer=None,
                  bias_initializer='zeros',
-                 dtype='float32',
-                 prefix=None,
-                 params=None):
+                 dtype='float32'):
         """
 
         Parameters
@@ -395,10 +376,8 @@ class TransformerDecoderLayer(HybridBlock):
         weight_initializer
         bias_initializer
         dtype
-        prefix
-        params
-        """
-        super(TransformerDecoderLayer, self).__init__(prefix=prefix, params=params)
+                """
+        super().__init__()
         self._dtype = dtype
         self._units = units
         if mem_units is None:
@@ -408,78 +387,66 @@ class TransformerDecoderLayer(HybridBlock):
         self._num_heads = num_heads
         self._attention_dropout = attention_dropout
         self._dtype = dtype
-        with self.name_scope():
-            self.dropout_layer = nn.Dropout(dropout)
-            if units % num_heads:
-                raise ValueError('In Transformer, units should be divided exactly by the number of '
-                                 'heads. Received units={}, num_heads={}'.format(units, num_heads))
-            self.attn_in_qkv = nn.Dense(3 * units, in_units=units,
-                                        use_bias=False,
-                                        flatten=False,
-                                        weight_initializer=weight_initializer,
-                                        bias_initializer=bias_initializer,
-                                        dtype=dtype,
-                                        prefix='attn_in_qkv_')
-            self.self_attention = MultiHeadAttentionCell(query_units=units,
-                                                         num_heads=num_heads,
-                                                         attention_dropout=self._attention_dropout,
-                                                         dtype=dtype,
-                                                         layout='NTK',
-                                                         prefix='self_attn_')
-            self.proj_in = nn.Dense(units=units, in_units=units, flatten=False,  use_bias=False,
+        self.dropout_layer = nn.Dropout(dropout)
+        if units % num_heads:
+            raise ValueError('In Transformer, units should be divided exactly by the number of '
+                             'heads. Received units={}, num_heads={}'.format(units, num_heads))
+        self.attn_in_qkv = nn.Dense(3 * units, in_units=units,
+                                    use_bias=False,
+                                    flatten=False,
                                     weight_initializer=weight_initializer,
                                     bias_initializer=bias_initializer,
-                                    dtype=dtype,
-                                    prefix='proj_in_')
-            self.attn_inter_q = nn.Dense(units,
-                                         in_units=units,
-                                         use_bias=False,
-                                         flatten=False,
-                                         weight_initializer=weight_initializer,
-                                         bias_initializer=bias_initializer,
-                                         dtype=dtype,
-                                         prefix='attn_inter_q_')
-            self.attn_inter_k = nn.Dense(units, in_units=mem_units,
-                                         use_bias=False,
-                                         flatten=False,
-                                         weight_initializer=weight_initializer,
-                                         bias_initializer=bias_initializer,
-                                         dtype=dtype,
-                                         prefix='attn_inter_k_')
-            self.attn_inter_v = nn.Dense(units, in_units=mem_units,
-                                         use_bias=False,
-                                         flatten=False,
-                                         weight_initializer=weight_initializer,
-                                         bias_initializer=bias_initializer,
-                                         dtype=dtype,
-                                         prefix='attn_inter_v_')
-            self.inter_attention = MultiHeadAttentionCell(query_units=units,
-                                                          num_heads=num_heads,
-                                                          attention_dropout=self._attention_dropout,
-                                                          dtype=dtype,
-                                                          layout='NTK',
-                                                          prefix='inter_attn_')
-            self.proj_inter = nn.Dense(units=units, in_units=units,
-                                       flatten=False, use_bias=False,
-                                       weight_initializer=weight_initializer,
-                                       bias_initializer=bias_initializer,
-                                       dtype=dtype,
-                                       prefix='proj_inter_')
-            # TODO(sxjscience) Add DType to LayerNorm
-            self.ln_in = nn.LayerNorm(epsilon=layer_norm_eps,
-                                      in_channels=units,
-                                      prefix='ln_in_')
-            self.ln_inter = nn.LayerNorm(epsilon=layer_norm_eps,
-                                         in_channels=units,
-                                         prefix='ln_inter_')
-            self.ffn = PositionwiseFFN(units=units,
-                                       hidden_size=hidden_size,
-                                       dropout=dropout,
-                                       activation_dropout=activation_dropout,
-                                       activation=activation,
-                                       pre_norm=pre_norm,
-                                       dtype=dtype,
-                                       prefix='ffn_')
+                                    dtype=dtype)
+        self.self_attention = MultiHeadAttentionCell(query_units=units,
+                                                     num_heads=num_heads,
+                                                     attention_dropout=self._attention_dropout,
+                                                     dtype=dtype,
+                                                     layout='NTK')
+        self.proj_in = nn.Dense(units=units, in_units=units, flatten=False,  use_bias=False,
+                                weight_initializer=weight_initializer,
+                                bias_initializer=bias_initializer,
+                                dtype=dtype)
+        self.attn_inter_q = nn.Dense(units,
+                                     in_units=units,
+                                     use_bias=False,
+                                     flatten=False,
+                                     weight_initializer=weight_initializer,
+                                     bias_initializer=bias_initializer,
+                                     dtype=dtype)
+        self.attn_inter_k = nn.Dense(units, in_units=mem_units,
+                                     use_bias=False,
+                                     flatten=False,
+                                     weight_initializer=weight_initializer,
+                                     bias_initializer=bias_initializer,
+                                     dtype=dtype)
+        self.attn_inter_v = nn.Dense(units, in_units=mem_units,
+                                     use_bias=False,
+                                     flatten=False,
+                                     weight_initializer=weight_initializer,
+                                     bias_initializer=bias_initializer,
+                                     dtype=dtype)
+        self.inter_attention = MultiHeadAttentionCell(query_units=units,
+                                                      num_heads=num_heads,
+                                                      attention_dropout=self._attention_dropout,
+                                                      dtype=dtype,
+                                                      layout='NTK')
+        self.proj_inter = nn.Dense(units=units, in_units=units,
+                                   flatten=False, use_bias=False,
+                                   weight_initializer=weight_initializer,
+                                   bias_initializer=bias_initializer,
+                                   dtype=dtype)
+        # TODO(sxjscience) Add DType to LayerNorm
+        self.ln_in = nn.LayerNorm(epsilon=layer_norm_eps,
+                                  in_channels=units)
+        self.ln_inter = nn.LayerNorm(epsilon=layer_norm_eps,
+                                     in_channels=units)
+        self.ffn = PositionwiseFFN(units=units,
+                                   hidden_size=hidden_size,
+                                   dropout=dropout,
+                                   activation_dropout=activation_dropout,
+                                   activation=activation,
+                                   pre_norm=pre_norm,
+                                   dtype=dtype)
 
     def hybrid_forward(self, F, data, mem, self_causal_mask, mem_attn_mask):
         """
@@ -658,8 +625,8 @@ class TransformerDecoder(HybridBlock):
                  num_heads=8, max_shift=None, rel_pos_embed=False, activation_dropout=0.0,
                  dropout=0.1, attention_dropout=0.1, layer_norm_eps=1E-5, data_norm=False,
                  pre_norm=False, weight_initializer=None, bias_initializer=None,
-                 activation='relu', dtype='float32', prefix=None, params=None):
-        super(TransformerDecoder, self).__init__(prefix=prefix, params=params)
+                 activation='relu', dtype='float32'):
+        super().__init__()
         self._dtype = dtype
         self._units = units
         self._mem_units = mem_units
@@ -669,35 +636,30 @@ class TransformerDecoder(HybridBlock):
         self.rel_pos_embed = rel_pos_embed
         self._data_norm = data_norm
         self._pre_norm = pre_norm
-        with self.name_scope():
-            self.dropout_layer = nn.Dropout(dropout)
-            if self._data_norm:
-                self.ln_data = nn.LayerNorm(epsilon=layer_norm_eps,
-                                            in_channels=units,
-                                            prefix='ln_data_')
-            if self._pre_norm:
-                self.ln_final = nn.LayerNorm(epsilon=layer_norm_eps,
-                                             in_channels=units,
-                                             prefix='ln_final_')
-            # Construct the intermediate layers
-            self.layers = nn.HybridSequential(prefix='layers_')
-            real_num_layers = 1 if recurrent else num_layers
-            with self.layers.name_scope():
-                for i in range(real_num_layers):
-                    self.layers.add(TransformerDecoderLayer(units=units,
-                                                            mem_units=mem_units,
-                                                            hidden_size=hidden_size,
-                                                            num_heads=num_heads,
-                                                            activation_dropout=activation_dropout,
-                                                            dropout=dropout,
-                                                            attention_dropout=attention_dropout,
-                                                            layer_norm_eps=layer_norm_eps,
-                                                            weight_initializer=weight_initializer,
-                                                            bias_initializer=bias_initializer,
-                                                            activation=activation,
-                                                            pre_norm=pre_norm,
-                                                            dtype=dtype,
-                                                            prefix='{}_'.format(i)))
+        self.dropout_layer = nn.Dropout(dropout)
+        if self._data_norm:
+            self.ln_data = nn.LayerNorm(epsilon=layer_norm_eps,
+                                        in_channels=units)
+        if self._pre_norm:
+            self.ln_final = nn.LayerNorm(epsilon=layer_norm_eps,
+                                         in_channels=units)
+        # Construct the intermediate layers
+        self.layers = nn.HybridSequential()
+        real_num_layers = 1 if recurrent else num_layers
+        for i in range(real_num_layers):
+            self.layers.add(TransformerDecoderLayer(units=units,
+                                                    mem_units=mem_units,
+                                                    hidden_size=hidden_size,
+                                                    num_heads=num_heads,
+                                                    activation_dropout=activation_dropout,
+                                                    dropout=dropout,
+                                                    attention_dropout=attention_dropout,
+                                                    layer_norm_eps=layer_norm_eps,
+                                                    weight_initializer=weight_initializer,
+                                                    bias_initializer=bias_initializer,
+                                                    activation=activation,
+                                                    pre_norm=pre_norm,
+                                                    dtype=dtype))
 
     def hybrid_forward(self, F, data, valid_length, mem_data, mem_valid_length):
         """
@@ -852,8 +814,7 @@ class TransformerNMTModel(HybridBlock):
                  embed_initializer=mx.init.Xavier('gaussian', 'in', 1),
                  weight_initializer=mx.init.Xavier('uniform', 'avg', 3),
                  bias_initializer='zeros',
-                 dtype='float32',
-                 prefix=None, params=None):
+                 dtype='float32'):
         """
 
         Parameters
@@ -922,10 +883,8 @@ class TransformerNMTModel(HybridBlock):
             Initializer of the bias
         dtype
             Data type of the weights
-        prefix
-        params
-        """
-        super(TransformerNMTModel, self).__init__(prefix=prefix, params=params)
+                """
+        super().__init__()
         assert src_vocab_size > 0 and tgt_vocab_size > 0,\
             'Cannot set "src_vocab_size" and "tgt_vocab_size" to negative numbers. ' \
             'Are you creating ' \
@@ -948,80 +907,71 @@ class TransformerNMTModel(HybridBlock):
             assert shared_embed is False, 'Cannot share embedding when the enc_units and dec_units ' \
                                           'are different! enc_units={},' \
                                           ' dec_units={}'.format(enc_units, dec_units)
-        with self.name_scope():
-            self.src_embed_layer = nn.Embedding(input_dim=src_vocab_size,
-                                                output_dim=enc_units,
-                                                prefix='src_embed_',
-                                                weight_initializer=embed_initializer,
-                                                dtype=self._dtype)
-            self.tgt_embed_layer = nn.Embedding(input_dim=tgt_vocab_size,
-                                                output_dim=dec_units,
-                                                prefix='tgt_embed_',
-                                                params=self.src_embed_layer.params
-                                                if shared_embed else None,
-                                                weight_initializer=embed_initializer,
-                                                dtype=self._dtype)
-            if pos_embed_type is not None:
-                self.src_pos_embed_layer = PositionalEmbedding(units=enc_units,
-                                                               max_length=max_src_length,
-                                                               dtype=self._dtype,
-                                                               method=pos_embed_type,
-                                                               prefix='src_pos_embed_')
-                self.tgt_pos_embed_layer = PositionalEmbedding(units=dec_units,
-                                                               max_length=max_tgt_length,
-                                                               dtype=self._dtype,
-                                                               method=pos_embed_type,
-                                                               prefix='tgt_pos_embed_')
-            self.encoder = TransformerEncoder(num_layers=enc_num_layers,
-                                              recurrent=enc_recurrent,
-                                              units=enc_units,
-                                              hidden_size=enc_hidden_size,
-                                              num_heads=enc_num_heads,
-                                              activation_dropout=activation_dropout,
-                                              dropout=dropout,
-                                              attention_dropout=attention_dropout,
-                                              layer_norm_eps=layer_norm_eps,
-                                              weight_initializer=weight_initializer,
-                                              bias_initializer=bias_initializer,
-                                              activation=enc_activation,
-                                              data_norm=data_norm,
-                                              pre_norm=enc_pre_norm,
-                                              dtype=self._dtype,
-                                              prefix='enc_')
-            self.decoder = TransformerDecoder(num_layers=dec_num_layers,
-                                              recurrent=dec_recurrent,
-                                              units=dec_units,
-                                              mem_units=enc_units,
-                                              hidden_size=dec_hidden_size,
-                                              num_heads=dec_num_heads,
-                                              activation_dropout=activation_dropout,
-                                              dropout=dropout,
-                                              attention_dropout=attention_dropout,
-                                              layer_norm_eps=layer_norm_eps,
-                                              weight_initializer=weight_initializer,
-                                              bias_initializer=bias_initializer,
-                                              activation=dec_activation,
-                                              data_norm=data_norm,
-                                              pre_norm=dec_pre_norm,
-                                              dtype=self._dtype,
-                                              prefix='dec_')
-            if tie_weights:
-                self.tgt_final_layer =\
-                    nn.Dense(tgt_vocab_size, flatten=False,
-                             bias_initializer=bias_initializer,
-                             use_bias=False,
-                             dtype=self._dtype,
-                             params=self.tgt_embed_layer.collect_params(),
-                             prefix='tgt_final_')
-            else:
-                self.tgt_final_layer = \
-                    nn.Dense(tgt_vocab_size,
-                             flatten=False,
-                             weight_initializer=weight_initializer,
-                             bias_initializer=bias_initializer,
-                             use_bias=False,
-                             dtype=self._dtype,
-                             prefix='tgt_final_')
+        self.src_embed_layer = nn.Embedding(input_dim=src_vocab_size,
+                                            output_dim=enc_units,
+                                            weight_initializer=embed_initializer,
+                                            dtype=self._dtype)
+        self.tgt_embed_layer = nn.Embedding(input_dim=tgt_vocab_size,
+                                            output_dim=dec_units,
+                                            weight_initializer=embed_initializer,
+                                            dtype=self._dtype)
+        if shared_embed:
+            self.tgt_embed_layer.weight = self.src_embed_layer.weight
+        if pos_embed_type is not None:
+            self.src_pos_embed_layer = PositionalEmbedding(units=enc_units,
+                                                           max_length=max_src_length,
+                                                           dtype=self._dtype,
+                                                           method=pos_embed_type)
+            self.tgt_pos_embed_layer = PositionalEmbedding(units=dec_units,
+                                                           max_length=max_tgt_length,
+                                                           dtype=self._dtype,
+                                                           method=pos_embed_type)
+        self.encoder = TransformerEncoder(num_layers=enc_num_layers,
+                                          recurrent=enc_recurrent,
+                                          units=enc_units,
+                                          hidden_size=enc_hidden_size,
+                                          num_heads=enc_num_heads,
+                                          activation_dropout=activation_dropout,
+                                          dropout=dropout,
+                                          attention_dropout=attention_dropout,
+                                          layer_norm_eps=layer_norm_eps,
+                                          weight_initializer=weight_initializer,
+                                          bias_initializer=bias_initializer,
+                                          activation=enc_activation,
+                                          data_norm=data_norm,
+                                          pre_norm=enc_pre_norm,
+                                          dtype=self._dtype)
+        self.decoder = TransformerDecoder(num_layers=dec_num_layers,
+                                          recurrent=dec_recurrent,
+                                          units=dec_units,
+                                          mem_units=enc_units,
+                                          hidden_size=dec_hidden_size,
+                                          num_heads=dec_num_heads,
+                                          activation_dropout=activation_dropout,
+                                          dropout=dropout,
+                                          attention_dropout=attention_dropout,
+                                          layer_norm_eps=layer_norm_eps,
+                                          weight_initializer=weight_initializer,
+                                          bias_initializer=bias_initializer,
+                                          activation=dec_activation,
+                                          data_norm=data_norm,
+                                          pre_norm=dec_pre_norm,
+                                          dtype=self._dtype)
+        if tie_weights:
+            self.tgt_final_layer =\
+                nn.Dense(tgt_vocab_size, flatten=False,
+                         bias_initializer=bias_initializer,
+                         use_bias=False,
+                         dtype=self._dtype)
+            self.tgt_final_layer.weight = self.tgt_embed_layer.weight
+        else:
+            self.tgt_final_layer = \
+                nn.Dense(tgt_vocab_size,
+                         flatten=False,
+                         weight_initializer=weight_initializer,
+                         bias_initializer=bias_initializer,
+                         use_bias=False,
+                         dtype=self._dtype)
         self.encoder.hybridize()
         self.decoder.hybridize()
 
@@ -1122,7 +1072,7 @@ class TransformerNMTModel(HybridBlock):
             return transformer_nmt_cfg_reg.create(key)
 
     @classmethod
-    def from_cfg(cls, cfg, prefix=None, params=None):
+    def from_cfg(cls, cfg):
         cfg = cls.get_cfg().clone_merge(cfg)
         embed_initializer = mx.init.create(*cfg.INITIALIZER.embed)
         weight_initializer = mx.init.create(*cfg.INITIALIZER.weight)
@@ -1154,23 +1104,19 @@ class TransformerNMTModel(HybridBlock):
                    dec_pre_norm=cfg.MODEL.DECODER.pre_norm,
                    embed_initializer=embed_initializer,
                    weight_initializer=weight_initializer,
-                   bias_initializer=bias_initializer,
-                   prefix=prefix,
-                   params=params)
+                   bias_initializer=bias_initializer)
 
 
 @use_np
 class TransformerNMTInference(HybridBlock, BaseStepDecoder):
-    def __init__(self, model, prefix=None, params=None):
+    def __init__(self, model):
         """
 
         Parameters
         ----------
         model
-        prefix
-        params
-        """
-        super(TransformerNMTInference, self).__init__(prefix=prefix, params=params)
+                """
+        super().__init__()
         self.model = model
 
     def initialize(self, **kwargs):

--- a/src/gluonnlp/models/transformer_xl.py
+++ b/src/gluonnlp/models/transformer_xl.py
@@ -1,7 +1,7 @@
 import numpy as np
 import mxnet as mx
 from mxnet import use_np
-from mxnet.gluon import nn, Block, HybridBlock
+from mxnet.gluon import nn, Block, HybridBlock, Parameter
 from ..attention_cell import multi_head_dot_attn, gen_self_attn_mask, gen_mem_attn_mask,\
     RelAttentionScoreCell, MultiHeadAttentionCell
 from ..layers import get_activation, PositionalEmbedding, PositionwiseFFN,\
@@ -26,9 +26,8 @@ class TransformerXLDecoderLayer(HybridBlock):
                  bias_initializer='zeros',
                  pre_norm=False,
                  dtype='float32',
-                 layout='NT',
-                 prefix=None, params=None):
-        super().__init__(prefix=prefix, params=params)
+                 layout='NT'):
+        super().__init__()
         self._pre_norm = pre_norm
         self._dtype = dtype
         self._num_heads = num_heads
@@ -41,54 +40,46 @@ class TransformerXLDecoderLayer(HybridBlock):
         else:
             raise NotImplementedError
         assert units % num_heads == 0
-        with self.name_scope():
-            self.dropout_layer = nn.Dropout(dropout)
-            self.attn_query = nn.Dense(units, in_units=units,
-                                       use_bias=False, flatten=False,
-                                       weight_initializer=weight_initializer,
-                                       bias_initializer=bias_initializer,
-                                       dtype=dtype,
-                                       prefix='attn_query_')
-            self.attn_kv = nn.Dense(2 * units, in_units=units,
-                                    use_bias=False, flatten=False,
-                                    weight_initializer=weight_initializer,
-                                    bias_initializer=bias_initializer,
-                                    dtype=dtype,
-                                    prefix='attn_kv_')
-            self.rel_pos_score_cell = RelAttentionScoreCell(query_units=units,
-                                                            num_heads=num_heads,
-                                                            bidirectional=False,
-                                                            method='transformer_xl',
-                                                            dropout=dropout,
-                                                            dtype=dtype,
-                                                            layout=self._cell_layout,
-                                                            prefix='rel_pos_score_cell_')
-            self.attn_cell = MultiHeadAttentionCell(query_units=units,
-                                                    num_heads=num_heads,
-                                                    attention_dropout=attention_dropout,
-                                                    dtype=dtype,
-                                                    layout=self._cell_layout,
-                                                    prefix='attn_cell_')
-            self.out_proj = nn.Dense(units, in_units=units,
-                                     use_bias=False, flatten=False,
-                                     weight_initializer=weight_initializer,
-                                     bias_initializer=bias_initializer,
-                                     dtype=dtype,
-                                     prefix='out_proj_')
-            self.layer_norm = nn.LayerNorm(epsilon=layer_norm_eps,
-                                           in_channels=units,
-                                           prefix='ln_')
-            self.ffn = PositionwiseFFN(units=units,
-                                       hidden_size=hidden_size,
-                                       activation=activation,
-                                       activation_dropout=activation_dropout,
-                                       dropout=dropout,
-                                       weight_initializer=weight_initializer,
-                                       bias_initializer=bias_initializer,
-                                       layer_norm_eps=layer_norm_eps,
-                                       pre_norm=pre_norm,
-                                       dtype=dtype,
-                                       prefix='ffn_')
+        self.dropout_layer = nn.Dropout(dropout)
+        self.attn_query = nn.Dense(units, in_units=units,
+                                   use_bias=False, flatten=False,
+                                   weight_initializer=weight_initializer,
+                                   bias_initializer=bias_initializer,
+                                   dtype=dtype)
+        self.attn_kv = nn.Dense(2 * units, in_units=units,
+                                use_bias=False, flatten=False,
+                                weight_initializer=weight_initializer,
+                                bias_initializer=bias_initializer,
+                                dtype=dtype)
+        self.rel_pos_score_cell = RelAttentionScoreCell(query_units=units,
+                                                        num_heads=num_heads,
+                                                        bidirectional=False,
+                                                        method='transformer_xl',
+                                                        dropout=dropout,
+                                                        dtype=dtype,
+                                                        layout=self._cell_layout)
+        self.attn_cell = MultiHeadAttentionCell(query_units=units,
+                                                num_heads=num_heads,
+                                                attention_dropout=attention_dropout,
+                                                dtype=dtype,
+                                                layout=self._cell_layout)
+        self.out_proj = nn.Dense(units, in_units=units,
+                                 use_bias=False, flatten=False,
+                                 weight_initializer=weight_initializer,
+                                 bias_initializer=bias_initializer,
+                                 dtype=dtype)
+        self.layer_norm = nn.LayerNorm(epsilon=layer_norm_eps,
+                                       in_channels=units)
+        self.ffn = PositionwiseFFN(units=units,
+                                   hidden_size=hidden_size,
+                                   activation=activation,
+                                   activation_dropout=activation_dropout,
+                                   dropout=dropout,
+                                   weight_initializer=weight_initializer,
+                                   bias_initializer=bias_initializer,
+                                   layer_norm_eps=layer_norm_eps,
+                                   pre_norm=pre_norm,
+                                   dtype=dtype)
 
     def hybrid_forward(self, F, data, mem, rel_positions, mask, query_r_bias, query_k_bias):
         """
@@ -173,36 +164,32 @@ class TransformerXLDecoder(HybridBlock):
                  layout='NT',
                  pre_norm=False,
                  weight_initializer=None,
-                 bias_initializer=None,
-                 prefix=None, params=None):
-        super().__init__(prefix=prefix, params=params)
-        with self.name_scope():
-            self.query_k_bias = self.params.get('query_k_bias',
-                                                shape=(num_heads, units // num_heads),
-                                                init=bias_initializer,
-                                                allow_deferred_init=True)
-            self.query_r_bias = self.params.get('query_r_bias',
-                                                shape=(num_heads, units // num_heads),
-                                                init=bias_initializer,
-                                                allow_deferred_init=True)
-            self.decoder_layers = nn.HybridSequential(prefix='l')
-            with self.decoder_layers.name_scope():
-                for i in range(num_layers):
-                    self.decoder_layers.add(
-                        TransformerXLDecoderLayer(units=units,
-                                                  hidden_size=hidden_size,
-                                                  num_heads=num_heads,
-                                                  activation_dropout=activation_dropout,
-                                                  dropout=dropout,
-                                                  attention_dropout=attention_dropout,
-                                                  layer_norm_eps=layernorm_eps,
-                                                  activation=activation,
-                                                  dtype=dtype,
-                                                  layout=layout,
-                                                  pre_norm=pre_norm,
-                                                  weight_initializer=weight_initializer,
-                                                  bias_initializer=bias_initializer,
-                                                  prefix='{}_'.format(i)))
+                 bias_initializer=None):
+        super().__init__()
+        self.query_k_bias = Parameter('query_k_bias',
+                                      shape=(num_heads, units // num_heads),
+                                      init=bias_initializer,
+                                      allow_deferred_init=True)
+        self.query_r_bias = Parameter('query_r_bias',
+                                      shape=(num_heads, units // num_heads),
+                                      init=bias_initializer,
+                                      allow_deferred_init=True)
+        self.decoder_layers = nn.HybridSequential()
+        for i in range(num_layers):
+            self.decoder_layers.add(
+                TransformerXLDecoderLayer(units=units,
+                                          hidden_size=hidden_size,
+                                          num_heads=num_heads,
+                                          activation_dropout=activation_dropout,
+                                          dropout=dropout,
+                                          attention_dropout=attention_dropout,
+                                          layer_norm_eps=layernorm_eps,
+                                          activation=activation,
+                                          dtype=dtype,
+                                          layout=layout,
+                                          pre_norm=pre_norm,
+                                          weight_initializer=weight_initializer,
+                                          bias_initializer=bias_initializer))
 
     def hybrid_forward(self, F, data, mem_l, rel_positions, mask, **params):
         """
@@ -249,8 +236,8 @@ class TransformerXLDecoder(HybridBlock):
 
 @use_np
 class TransformerXLForLM(Block):
-    def __init__(self, cfg=None, prefix=None, params=None):
-        super().__init__(prefix=prefix, params=params)
+    def __init__(self, cfg=None):
+        super().__init__()
         if cfg is None:
             cfg = TransformerXLForLM.get_cfg()
         else:
@@ -265,53 +252,49 @@ class TransformerXLForLM(Block):
         self._units = cfg.MODEL.units
         self._dtype = cfg.MODEL.dtype
         assert cfg.MODEL.units % cfg.MODEL.num_heads == 0
-        with self.name_scope():
-            self.word_emb = AdaptiveEmbedding(vocab_size=cfg.MODEL.vocab_size,
-                                              embed_size=cfg.MODEL.embed_units,
-                                              units=cfg.MODEL.units,
-                                              cutoffs=cfg.MODEL.cutoffs,
-                                              div_val=cfg.MODEL.div_val,
-                                              scaled=True,
-                                              embedding_initializer=embed_initializer,
-                                              weight_initializer=weight_initializer,
-                                              dtype=cfg.MODEL.dtype,
-                                              prefix='word_emb_')
-            self.dropout_layer = nn.Dropout(cfg.MODEL.dropout)
-            self.decoder = TransformerXLDecoder(num_layers=cfg.MODEL.num_layers,
-                                                units=cfg.MODEL.units,
-                                                hidden_size=cfg.MODEL.hidden_size,
-                                                num_heads=cfg.MODEL.num_heads,
-                                                activation_dropout=cfg.MODEL.activation_dropout,
-                                                dropout=cfg.MODEL.dropout,
-                                                attention_dropout=cfg.MODEL.attention_dropout,
-                                                layernorm_eps=cfg.MODEL.layernorm_eps,
-                                                activation=cfg.MODEL.activation,
-                                                dtype=cfg.MODEL.dtype,
-                                                layout=cfg.MODEL.layout,
-                                                pre_norm=cfg.MODEL.pre_norm,
-                                                weight_initializer=weight_initializer,
-                                                bias_initializer=bias_initializer,
-                                                prefix='decoder_')
-            if cfg.MODEL.tie_weights and cfg.MODEL.tie_projs:
-                crit_params = self.word_emb.collect_params('(.*_embed|.*_inter_proj)')
-            elif cfg.MODEL.tie_weights and not cfg.MODEL.tie_projs:
-                crit_params = self.word_emb.collect_params('.*_embed')
-            elif not cfg.MODEL.tie_weights and cfg.MODEL.tie_projs:
-                crit_params = self.word_emb.collect_params('.*_inter_proj')
-            else:
-                crit_params = None
-            self.crit = ProjectedAdaptiveLogSoftmaxWithLoss(
-                vocab_size=cfg.MODEL.vocab_size,
-                embed_size=cfg.MODEL.embed_units,
-                in_units=cfg.MODEL.units,
-                cutoffs=cfg.MODEL.cutoffs,
-                div_val=cfg.MODEL.div_val,
-                dtype=cfg.MODEL.dtype,
-                use_bias=True,
-                weight_initializer=weight_initializer,
-                bias_initializer=bias_initializer,
-                params=crit_params,
-                prefix='crit_')
+        self.word_emb = AdaptiveEmbedding(vocab_size=cfg.MODEL.vocab_size,
+                                          embed_size=cfg.MODEL.embed_units,
+                                          units=cfg.MODEL.units,
+                                          cutoffs=cfg.MODEL.cutoffs,
+                                          div_val=cfg.MODEL.div_val,
+                                          scaled=True,
+                                          embedding_initializer=embed_initializer,
+                                          weight_initializer=weight_initializer,
+                                          dtype=cfg.MODEL.dtype)
+        self.dropout_layer = nn.Dropout(cfg.MODEL.dropout)
+        self.decoder = TransformerXLDecoder(num_layers=cfg.MODEL.num_layers,
+                                            units=cfg.MODEL.units,
+                                            hidden_size=cfg.MODEL.hidden_size,
+                                            num_heads=cfg.MODEL.num_heads,
+                                            activation_dropout=cfg.MODEL.activation_dropout,
+                                            dropout=cfg.MODEL.dropout,
+                                            attention_dropout=cfg.MODEL.attention_dropout,
+                                            layernorm_eps=cfg.MODEL.layernorm_eps,
+                                            activation=cfg.MODEL.activation,
+                                            dtype=cfg.MODEL.dtype,
+                                            layout=cfg.MODEL.layout,
+                                            pre_norm=cfg.MODEL.pre_norm,
+                                            weight_initializer=weight_initializer,
+                                            bias_initializer=bias_initializer)
+        if cfg.MODEL.tie_weights and cfg.MODEL.tie_projs:
+            crit_params = self.word_emb.collect_params('(.*_embed|.*_inter_proj)')
+        elif cfg.MODEL.tie_weights and not cfg.MODEL.tie_projs:
+            crit_params = self.word_emb.collect_params('.*_embed')
+        elif not cfg.MODEL.tie_weights and cfg.MODEL.tie_projs:
+            crit_params = self.word_emb.collect_params('.*_inter_proj')
+        else:
+            crit_params = None
+        self.crit = ProjectedAdaptiveLogSoftmaxWithLoss(
+            vocab_size=cfg.MODEL.vocab_size,
+            embed_size=cfg.MODEL.embed_units,
+            in_units=cfg.MODEL.units,
+            cutoffs=cfg.MODEL.cutoffs,
+            div_val=cfg.MODEL.div_val,
+            dtype=cfg.MODEL.dtype,
+            use_bias=True,
+            weight_initializer=weight_initializer,
+            bias_initializer=bias_initializer)
+        self.crit.share_parameters(crit_params)
 
     @property
     def cfg(self):
@@ -358,8 +341,8 @@ class TransformerXLForLM(Block):
         return config
 
     @classmethod
-    def from_cfg(cls, cfg, prefix=None, params=None):
-        return cls(cfg=cfg, prefix=prefix, params=params)
+    def from_cfg(cls, cfg):
+        return cls(cfg=cfg)
 
     @property
     def state_batch_axis(self):

--- a/src/gluonnlp/optimizer.py
+++ b/src/gluonnlp/optimizer.py
@@ -79,7 +79,7 @@ class AdamW(optimizer.Optimizer):
     """
     def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999, epsilon=1e-6,
                  correct_bias=True, use_fused_step=True, **kwargs):
-        super(AdamW, self).__init__(use_fused_step=use_fused_step,
+        super().__init__(use_fused_step=use_fused_step,
                                     learning_rate=learning_rate,
                                     **kwargs)
         self.beta1 = beta1

--- a/src/gluonnlp/sequence_sampler.py
+++ b/src/gluonnlp/sequence_sampler.py
@@ -100,9 +100,8 @@ class BeamSearchScorer(HybridBlock):
     def __init__(self, alpha: float = 1.0,
                  K: float = 5.0,
                  from_logits: bool = False,
-                 temperature: float = 1.0,
-                 prefix=None, params=None):
-        super().__init__(prefix=prefix, params=params)
+                 temperature: float = 1.0):
+        super().__init__()
         self._alpha = float(alpha)
         self._K = K
         self._temperature = temperature
@@ -129,7 +128,7 @@ class BeamSearchScorer(HybridBlock):
             The scores of all the candidates. Shape (d1, d2, ..., dn, V), where V is the size
             of the vocabulary.
         """
-        return super(BeamSearchScorer, self).__call__(outputs, scores, step)
+        return super().__call__(outputs, scores, step)
 
     def hybrid_forward(self, F, outputs, scores, step):  # pylint: disable=arguments-differ
         if not self._from_logits:
@@ -251,7 +250,7 @@ def _choose_states(F, states, indices, state_batch_axis=None):
 
 class _BeamSearchStepUpdate(HybridBlock):
     def __init__(self, beam_size, vocab_size, eos_id, scorer, state_batch_axis,
-                 stochastic=False, prefix=None, params=None):
+                 stochastic=False):
         """
 
         Parameters
@@ -265,7 +264,7 @@ class _BeamSearchStepUpdate(HybridBlock):
         prefix : None
         params : None
         """
-        super(_BeamSearchStepUpdate, self).__init__(prefix=prefix, params=params)
+        super().__init__()
         self._beam_size = beam_size
         self._vocab_size = vocab_size
         self._eos_id = eos_id

--- a/src/gluonnlp/sequence_sampler.py
+++ b/src/gluonnlp/sequence_sampler.py
@@ -629,9 +629,8 @@ class BeamSearchSampler:
 
 class _MultinomialStepUpdate(HybridBlock):
     def __init__(self, beam_size, vocab_size, eos_id, state_batch_axis,
-                 sampling_topp=-1.0, sampling_topk=-1, temperature=1.0,
-                 prefix=None, params=None):
-        super(_MultinomialStepUpdate, self).__init__(prefix=prefix, params=params)
+                 sampling_topp=-1.0, sampling_topk=-1, temperature=1.0):
+        super().__init__()
         self._beam_size = beam_size
         self._vocab_size = vocab_size
         self._eos_id = eos_id

--- a/src/gluonnlp/utils/misc.py
+++ b/src/gluonnlp/utils/misc.py
@@ -104,7 +104,7 @@ class AverageSGDTracker(object):
                 'All shapes of the tracked parameters must be given.' \
                 ' The shape of {} is {}, and it has not been fully initialized.' \
                 ' You should call step after the first forward of the model.'.format(k, v.shape)
-        ctx = self._track_params.list_ctx()[0]
+        ctx = next(iter(self._track_params.values())).list_ctx()[0]
         if self._average_params is None:
             self._average_params = OrderedDict([(k, v.data(ctx).copy()) for k, v in self._track_params.items()])
         self._n_steps += 1

--- a/tests/test_attention_cell.py
+++ b/tests/test_attention_cell.py
@@ -173,8 +173,8 @@ def test_dot_product_attention(scaled, normalized):
 @pytest.mark.seed(123)
 def test_gen_attn_mask():
     class GenSelfAttnMask(HybridBlock):
-        def __init__(self, dtype, attn_type, prefix=None, params=None):
-            super(GenSelfAttnMask, self).__init__(prefix=prefix, params=params)
+        def __init__(self, dtype, attn_type):
+            super().__init__()
             self._dtype = dtype
             self._attn_type = attn_type
 
@@ -183,8 +183,8 @@ def test_gen_attn_mask():
                                       dtype=self._dtype, attn_type=self._attn_type)
 
     class GenMemAttnMask(HybridBlock):
-        def __init__(self, dtype, prefix=None, params=None):
-            super(GenMemAttnMask, self).__init__(prefix=prefix, params=params)
+        def __init__(self, dtype):
+            super().__init__()
             self._dtype = dtype
 
         def hybrid_forward(self, F, mem, mem_valid_length, data, valid_length):
@@ -348,9 +348,7 @@ def test_multi_head_rel_attn_score(num_heads, method, bidirectional, hybridize):
             score_cell.initialize()
             if hybridize:
                 score_cell.hybridize()
-            for k, param in score_cell.collect_params().items():
-                param_k = k[len(score_cell.prefix):]
-                param.set_data(base_score_cell.collect_params().get(param_k).data())
+            score_cell.load_dict({name: param.data() for name, param in base_score_cell.collect_params().items()})
             query.attach_grad()
             query.grad[:] = 0
             with mx.autograd.record():

--- a/tests/test_gluon_block.py
+++ b/tests/test_gluon_block.py
@@ -1,7 +1,7 @@
 import mxnet as mx
 import numpy as np
 from numpy.testing import assert_allclose
-from mxnet.gluon import HybridBlock
+from mxnet.gluon import HybridBlock, Constant
 from mxnet.gluon.data import DataLoader
 import itertools
 mx.npx.set_np()
@@ -9,9 +9,9 @@ mx.npx.set_np()
 
 def test_const():
     class Foo(HybridBlock):
-        def __init__(self, prefix=None, params=None):
-            super(Foo, self).__init__(prefix=prefix, params=params)
-            self.weight = self.params.get_constant('const', np.ones((10, 10)))
+        def __init__(self):
+            super().__init__()
+            self.weight = Constant(np.ones((10, 10)))
 
         def hybrid_forward(self, F, x, weight):
             return x, weight.astype(np.float32)
@@ -35,8 +35,8 @@ def test_scalar():
 
 def test_gluon_nonzero_hybridize():
     class Foo(HybridBlock):
-        def __init__(self, prefix=None, params=None):
-            super(Foo, self).__init__(prefix=prefix, params=params)
+        def __init__(self):
+            super().__init__()
 
         def hybrid_forward(self, F, x):
             dat = F.np._internal.nonzero(x)

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -7,7 +7,7 @@ mx.npx.set_np()
 
 def test_truncnorm_string_alias_works():
     try:
-        layer = nn.Dense(prefix="test_layer", in_units=1, units=1, weight_initializer='truncnorm')
+        layer = nn.Dense(in_units=1, units=1, weight_initializer='truncnorm')
         layer.initialize()
     except RuntimeError:
         pytest.fail('Layer couldn\'t be initialized')
@@ -16,7 +16,7 @@ def test_truncnorm_string_alias_works():
 def test_truncnorm_all_values_inside_boundaries():
     mean = 0
     std = 0.01
-    layer = nn.Dense(prefix="test_layer", in_units=1, units=1000)
+    layer = nn.Dense(in_units=1, units=1000)
     layer.initialize(init=initializer.TruncNorm(mean, std))
     assert (layer.weight.data() <= 2 * std).asnumpy().all()
     assert (layer.weight.data() >= -2 * std).asnumpy().all()
@@ -27,7 +27,7 @@ def test_truncnorm_generates_values_with_defined_mean_and_std():
 
     mean = 10
     std = 5
-    layer = nn.Dense(prefix="test_layer", in_units=1, units=100000)
+    layer = nn.Dense(in_units=1, units=100000)
     layer.initialize(init=initializer.TruncNorm(mean, std))
     samples = layer.weight.data().reshape((-1, )).asnumpy()
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -120,7 +120,7 @@ def test_adaptive_embedding(vocab_size, cutoffs, embed_size, units, div_val):
                           [1000, None, 1.0]])
 @pytest.mark.parametrize('embed_size', [128])
 @pytest.mark.parametrize('in_units', [16])
-# TODO(leezu): This test even passes without sharing the parameters. It needs to be improved.
+# TODO This test even passes without sharing the parameters. It needs to be improved.
 def test_projected_adaptive_softmax(vocab_size, cutoffs, embed_size, in_units, div_val):
     layer = ProjectedAdaptiveLogSoftmaxWithLoss(vocab_size=vocab_size, cutoffs=cutoffs,
                                                 embed_size=embed_size, in_units=in_units,

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -120,6 +120,7 @@ def test_adaptive_embedding(vocab_size, cutoffs, embed_size, units, div_val):
                           [1000, None, 1.0]])
 @pytest.mark.parametrize('embed_size', [128])
 @pytest.mark.parametrize('in_units', [16])
+# TODO(leezu): This test even passes without sharing the parameters. It needs to be improved.
 def test_projected_adaptive_softmax(vocab_size, cutoffs, embed_size, in_units, div_val):
     layer = ProjectedAdaptiveLogSoftmaxWithLoss(vocab_size=vocab_size, cutoffs=cutoffs,
                                                 embed_size=embed_size, in_units=in_units,
@@ -141,23 +142,22 @@ def test_projected_adaptive_softmax(vocab_size, cutoffs, embed_size, in_units, d
                                             cutoffs=cutoffs,
                                             embed_size=embed_size,
                                             in_units=in_units,
-                                            div_val=div_val,
-                                            params=embed_layer.collect_params('.*_inter_proj'))
+                                            div_val=div_val)
+    layer_with_shared_proj.share_parameters(embed_layer.collect_params('.*_inter_proj'))
     layer_with_shared_embed = \
         ProjectedAdaptiveLogSoftmaxWithLoss(vocab_size=vocab_size,
                                             cutoffs=cutoffs,
                                             embed_size=embed_size,
                                             in_units=in_units,
-                                            div_val=div_val,
-                                            params=embed_layer.collect_params('.*_embed'))
+                                            div_val=div_val)
+    layer_with_shared_embed.share_parameters(embed_layer.collect_params('.*_embed'))
     layer_with_shared_proj_embed = \
         ProjectedAdaptiveLogSoftmaxWithLoss(vocab_size=vocab_size,
                                             cutoffs=cutoffs,
                                             embed_size=embed_size,
                                             in_units=in_units,
-                                            div_val=div_val,
-                                            params=embed_layer.collect_params(
-                                                '(.*_embed|.*_inter_proj)'))
+                                            div_val=div_val)
+    layer_with_shared_proj_embed.share_parameters(embed_layer.collect_params('(.*_embed|.*_inter_proj)'))
     embed_layer.initialize()
     embed_layer.hybridize()
     layer_with_shared_proj.initialize()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,25 +11,25 @@ def test_list_backbone_names():
     assert len(list_backbone_names()) > 0
 
 
-def test_get_backbone():
-    for name in list_backbone_names():
-        with tempfile.TemporaryDirectory() as root:
-            model_cls, cfg, tokenizer, local_params_path, _ = get_backbone(name, root=root)
-            net = model_cls.from_cfg(cfg)
-            net.load_parameters(local_params_path)
-            net.hybridize()
-            num_params, num_fixed_params = count_parameters(net.collect_params())
-            assert num_params > 0
+@pytest.mark.parametrize('name', list_backbone_names())
+def test_get_backbone(name):
+    with tempfile.TemporaryDirectory() as root:
+        model_cls, cfg, tokenizer, local_params_path, _ = get_backbone(name, root=root)
+        net = model_cls.from_cfg(cfg)
+        net.load_parameters(local_params_path)
+        net.hybridize()
+        num_params, num_fixed_params = count_parameters(net.collect_params())
+        assert num_params > 0
 
-            # Test for model export + save
-            batch_size = 1
-            sequence_length = 4
-            inputs = mx.np.random.randint(0, 10, (batch_size, sequence_length))
-            token_types = mx.np.random.randint(0, 2, (batch_size, sequence_length))
-            valid_length = mx.np.random.randint(1, sequence_length, (batch_size,))
-            if 'roberta' in name or 'xlmr' in name:
-                out = net(inputs, valid_length)
-            else:
-                out = net(inputs, token_types, valid_length)
-            mx.npx.waitall()
-            net.export(os.path.join(root, 'model'))
+        # Test for model export + save
+        batch_size = 1
+        sequence_length = 4
+        inputs = mx.np.random.randint(0, 10, (batch_size, sequence_length))
+        token_types = mx.np.random.randint(0, 2, (batch_size, sequence_length))
+        valid_length = mx.np.random.randint(1, sequence_length, (batch_size,))
+        if 'roberta' in name or 'xlmr' in name:
+            out = net(inputs, valid_length)
+        else:
+            out = net(inputs, token_types, valid_length)
+        mx.npx.waitall()
+        net.export(os.path.join(root, 'model'))

--- a/tests/test_models_electra.py
+++ b/tests/test_models_electra.py
@@ -26,17 +26,14 @@ def test_bert_get_pretrained(model_name):
         electra_disc_model.backbone_model.load_parameters(backbone_params_path)
 
         gen_cfg = get_generator_cfg(cfg)
-        word_embed_params = electra_disc_model.backbone_model.word_embed.collect_params()
-        token_type_embed_params = electra_disc_model.backbone_model.token_pos_embed.collect_params()
-        token_pos_embed_params = electra_disc_model.backbone_model.token_pos_embed.collect_params()
-        embed_layer_norm_params = electra_disc_model.backbone_model.embed_layer_norm.collect_params()
-        electra_gen_model = ElectraGenerator(gen_cfg,
-                            tied_embeddings=True,
-                            word_embed_params=word_embed_params,
-                            token_type_embed_params=token_type_embed_params,
-                            token_pos_embed_params=token_pos_embed_params,
-                            embed_layer_norm_params=embed_layer_norm_params,
-                            )
+        electra_gen_model = ElectraGenerator(gen_cfg)
         electra_gen_model.load_parameters(gen_params_path)
-        electra_gen_model = ElectraGenerator(cfg, tied_embeddings=False)
+        electra_gen_model.tie_embeddings(
+            electra_disc_model.backbone_model.word_embed.collect_params(),
+            electra_disc_model.backbone_model.token_type_embed.collect_params(),
+            electra_disc_model.backbone_model.token_pos_embed.collect_params(),
+            electra_disc_model.backbone_model.embed_layer_norm.collect_params())
+
+
+        electra_gen_model = ElectraGenerator(cfg)
         electra_gen_model.backbone_model.load_parameters(backbone_params_path)

--- a/tests/test_models_transformer.py
+++ b/tests/test_models_transformer.py
@@ -19,9 +19,9 @@ def test_transformer_encoder_decoder(pre_norm, num_enc_layers, num_dec_layers):
     tgt_seq_length = 15
     units = 32
     enc = TransformerEncoder(units=units, hidden_size=64, num_layers=num_enc_layers, num_heads=4,
-                             dropout=0.0, pre_norm=pre_norm, prefix='enc_')
+                             dropout=0.0, pre_norm=pre_norm)
     dec = TransformerDecoder(units=units, hidden_size=64, num_layers=num_dec_layers, num_heads=4,
-                             dropout=0.0, pre_norm=pre_norm, prefix='dec_')
+                             dropout=0.0, pre_norm=pre_norm)
     enc.hybridize()
     dec.hybridize()
     enc.initialize()

--- a/tests/test_sequence_sampler.py
+++ b/tests/test_sequence_sampler.py
@@ -40,8 +40,8 @@ def test_beam_search_score(length, alpha, K, batch_size, vocab_size, from_logits
 @pytest.mark.parametrize('early_return', [False, True])
 def test_beam_search(early_return):
     class SimpleStepDecoder(HybridBlock):
-        def __init__(self, vocab_size=5, hidden_units=4, prefix=None, params=None):
-            super(SimpleStepDecoder, self).__init__(prefix=prefix, params=params)
+        def __init__(self, vocab_size=5, hidden_units=4):
+            super().__init__()
             self.x2h_map = nn.Embedding(input_dim=vocab_size, output_dim=hidden_units)
             self.h2h_map = nn.Dense(units=hidden_units, flatten=False)
             self.vocab_map = nn.Dense(units=vocab_size, flatten=False)
@@ -98,8 +98,8 @@ def test_beam_search(early_return):
 @pytest.mark.parametrize('early_return', [False, True])
 def test_beam_search_stochastic(early_return):
     class SimpleStepDecoder(HybridBlock):
-        def __init__(self, vocab_size=5, hidden_units=4, prefix=None, params=None):
-            super(SimpleStepDecoder, self).__init__(prefix=prefix, params=params)
+        def __init__(self, vocab_size=5, hidden_units=4):
+            super().__init__()
             self.x2h_map = nn.Embedding(input_dim=vocab_size, output_dim=hidden_units)
             self.h2h_map = nn.Dense(units=hidden_units, flatten=False)
             self.vocab_map = nn.Dense(units=vocab_size, flatten=False)

--- a/tests/test_sequence_sampler.py
+++ b/tests/test_sequence_sampler.py
@@ -164,8 +164,8 @@ def test_beam_search_stochastic(early_return):
 @pytest.mark.parametrize('sampling_paras', [(-1.0, -1), (0.05, -1), (-1.0, 1), (-1.0, 3)])
 def test_multinomial_sampling(early_return, sampling_paras):
     class SimpleStepDecoder(HybridBlock):
-        def __init__(self, vocab_size=5, hidden_units=4, prefix=None, params=None):
-            super(SimpleStepDecoder, self).__init__(prefix=prefix, params=params)
+        def __init__(self, vocab_size=5, hidden_units=4):
+            super().__init__()
             self.x2h_map = nn.Embedding(input_dim=vocab_size, output_dim=hidden_units)
             self.h2h_map = nn.Dense(units=hidden_units, flatten=False)
             self.vocab_map = nn.Dense(units=vocab_size, flatten=False)

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -18,10 +18,8 @@ def test_average_sgd_tracker():
     moving_avg_param = None
     net_final_moving_avg_param = None
     for use_moving_avg in [False, True]:
-        net = nn.HybridSequential(prefix='net_')
-        with net.name_scope():
-            net.add(nn.Dense(10))
-            net.add(nn.Dense(3))
+        net = nn.HybridSequential()
+        net.add(nn.Dense(10), nn.Dense(3))
         net.initialize(init=mx.init.One())
         net.hybridize()
         trainer = mx.gluon.Trainer(net.collect_params(), 'adam')


### PR DESCRIPTION
- Remove params and prefix arguments for MXNet 2 and update
  parameter sharing implementation
- Remove Block.name_scope() for MXNet 2
- Remove self.params.get() and self.params.get_constant()

CI will pass once https://github.com/apache/incubator-mxnet/pull/18619 is merged

Please review the API changes. Scripts are not updated by this PR, but at least some will be updated and included here following verification of fine-tuning performance and NMT training. Note that it's not required to re-generate the parameter files.

Thanks to @acphile for his hard work on the Gluon API refactor on the MXNet side (https://github.com/apache/incubator-mxnet/commit/cb54a4a99463b23b8abaa2629661954c4ba3c60b)
