### PR TITLE
Add fp16 support for Bert QA inference

### DIFF
--- a/scripts/question_answering/run_squad.py
+++ b/scripts/question_answering/run_squad.py
@@ -314,7 +314,10 @@ def get_network(model_name,
     # Create the network
     Model, cfg, tokenizer, download_params_path, _ = \
         get_backbone(model_name, load_backbone=not backbone_path)
-    backbone = Model.from_cfg(cfg, use_pooler=False, dtype=dtype)
+    cfg.defrost()
+    cfg.MODEL.dtype = dtype
+    cfg.freeze()
+    backbone = Model.from_cfg(cfg, use_pooler=False)
     # Load local backbone parameters if backbone_path provided.
     # Otherwise, download backbone parameters from gluon zoo.
 

--- a/scripts/question_answering/run_squad.py
+++ b/scripts/question_answering/run_squad.py
@@ -314,10 +314,7 @@ def get_network(model_name,
     # Create the network
     Model, cfg, tokenizer, download_params_path, _ = \
         get_backbone(model_name, load_backbone=not backbone_path)
-    cfg.defrost()
-    cfg.MODEL.dtype = dtype
-    cfg.freeze()
-    backbone = Model.from_cfg(cfg, use_pooler=False)
+    backbone = Model.from_cfg(cfg, use_pooler=False, dtype=dtype)
     # Load local backbone parameters if backbone_path provided.
     # Otherwise, download backbone parameters from gluon zoo.
 

--- a/src/gluonnlp/attention_cell.py
+++ b/src/gluonnlp/attention_cell.py
@@ -388,7 +388,8 @@ def multi_head_dot_attn(F, query, key, value,
                         scaled: bool = True, normalized: bool = False,
                         eps: float = 1E-6, query_head_units: Optional[int] = None,
                         layout: str = 'NKT',
-                        use_einsum: bool = False):
+                        use_einsum: bool = False,
+                        dtype=np.float32):
     """Multihead dot product attention between the query, key, value.
 
     scaled is False, normalized is False:
@@ -497,7 +498,7 @@ def multi_head_dot_attn(F, query, key, value,
             scores = scores + edge_scores
         if scaled:
             scores = scores / scale
-        attn_weights = masked_softmax(F, scores, mask, axis=-1)
+        attn_weights = masked_softmax(F, scores, mask, dtype=dtype, axis=-1)
         attn_weights = F.npx.dropout(attn_weights, p=dropout)
         # 3. Calculate the context vector
         # (B, N, L_query, L_mem) X (B, N, L_mem, C_V) --> (B, L_query, N * C_V)
@@ -522,7 +523,7 @@ def multi_head_dot_attn(F, query, key, value,
             scores = scores + edge_scores
         if scaled:
             scores = scores / scale
-        attn_weights = masked_softmax(F, scores, mask)
+        attn_weights = masked_softmax(F, scores, mask, dtype=dtype)
         attn_weights = F.npx.dropout(attn_weights, p=dropout)
         # 3. Calculate the context vector
         # (B, N, L_query, L_mem) X (B, L_mem, N, C_V) --> (B, L_query, N * C_V)
@@ -553,7 +554,7 @@ def multi_head_dot_attn(F, query, key, value,
             scores = scores + edge_scores
         if scaled:
             scores = scores / scale
-        attn_weights = masked_softmax(F, scores, mask)
+        attn_weights = masked_softmax(F, scores, mask, dtype=dtype)
         attn_weights = F.npx.dropout(attn_weights, p=dropout)
         # 3. Calculate the context vector
         # (B, N, L_query, L_mem) X (L_mem, B, N, C_V) --> (L_query, B, N * C_V)
@@ -628,7 +629,8 @@ class MultiHeadAttentionCell(HybridBlock):
                                    scaled=self._scaled, normalized=self._normalized,
                                    eps=self._eps,
                                    query_head_units=self._query_head_units,
-                                   layout=self._layout, use_einsum=self._use_einsum)
+                                   layout=self._layout, use_einsum=self._use_einsum,
+                                   dtype=self._dtype)
 
     def __repr__(self):
         s = '{name}(\n' \

--- a/src/gluonnlp/models/bert.py
+++ b/src/gluonnlp/models/bert.py
@@ -395,7 +395,7 @@ class BertModel(HybridBlock):
         return cfg
 
     @classmethod
-    def from_cfg(cls, cfg, use_pooler=True, prefix=None, params=None, dtype='float32'):
+    def from_cfg(cls, cfg, use_pooler=True, prefix=None, params=None):
         cfg = BertModel.get_cfg().clone_merge(cfg)
         assert cfg.VERSION == 1, 'Wrong version!'
         embed_initializer = mx.init.create(*cfg.INITIALIZER.embed)
@@ -413,7 +413,7 @@ class BertModel(HybridBlock):
                    pos_embed_type=cfg.MODEL.pos_embed_type,
                    activation=cfg.MODEL.activation,
                    layer_norm_eps=cfg.MODEL.layer_norm_eps,
-                   dtype=dtype,
+                   dtype=cfg.MODEL.dtype,
                    embed_initializer=embed_initializer,
                    weight_initializer=weight_initializer,
                    bias_initializer=bias_initializer,

--- a/src/gluonnlp/models/bert.py
+++ b/src/gluonnlp/models/bert.py
@@ -146,6 +146,7 @@ class BertTransformer(HybridBlock):
                                               weight_initializer=weight_initializer,
                                               bias_initializer=bias_initializer,
                                               activation=activation,
+                                              dtype=self._dtype,
                                               prefix='{}_'.format(layer_idx)))
 
     def hybrid_forward(self, F, data, valid_length):
@@ -394,7 +395,7 @@ class BertModel(HybridBlock):
         return cfg
 
     @classmethod
-    def from_cfg(cls, cfg, use_pooler=True, prefix=None, params=None):
+    def from_cfg(cls, cfg, use_pooler=True, prefix=None, params=None, dtype='float32'):
         cfg = BertModel.get_cfg().clone_merge(cfg)
         assert cfg.VERSION == 1, 'Wrong version!'
         embed_initializer = mx.init.create(*cfg.INITIALIZER.embed)
@@ -412,7 +413,7 @@ class BertModel(HybridBlock):
                    pos_embed_type=cfg.MODEL.pos_embed_type,
                    activation=cfg.MODEL.activation,
                    layer_norm_eps=cfg.MODEL.layer_norm_eps,
-                   dtype=cfg.MODEL.dtype,
+                   dtype=dtype,
                    embed_initializer=embed_initializer,
                    weight_initializer=weight_initializer,
                    bias_initializer=bias_initializer,

--- a/src/gluonnlp/models/bert.py
+++ b/src/gluonnlp/models/bert.py
@@ -395,7 +395,7 @@ class BertModel(HybridBlock):
         return cfg
 
     @classmethod
-    def from_cfg(cls, cfg, use_pooler=True, prefix=None, params=None):
+    def from_cfg(cls, cfg, use_pooler=True, prefix=None, params=None, dtype='float32'):
         cfg = BertModel.get_cfg().clone_merge(cfg)
         assert cfg.VERSION == 1, 'Wrong version!'
         embed_initializer = mx.init.create(*cfg.INITIALIZER.embed)
@@ -413,7 +413,7 @@ class BertModel(HybridBlock):
                    pos_embed_type=cfg.MODEL.pos_embed_type,
                    activation=cfg.MODEL.activation,
                    layer_norm_eps=cfg.MODEL.layer_norm_eps,
-                   dtype=cfg.MODEL.dtype,
+                   dtype=dtype,
                    embed_initializer=embed_initializer,
                    weight_initializer=weight_initializer,
                    bias_initializer=bias_initializer,


### PR DESCRIPTION
## Description ##
Adding FP16 in QA-BERT inference

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Added option to use fp16 data type in run_squad script for evaluation (--eval_dtype). Will cast the network.
- [x] Propagated the datatype to masked_softmax, where was using fp32 always and causing nans if fp16 was selected

## Comments ##

cc @dmlc/gluon-nlp-team, @sxjscience 
