### PR TITLE
fix prepare_openwebtext

### DIFF
--- a/scripts/datasets/pretrain_corpus/prepare_openwebtext.py
+++ b/scripts/datasets/pretrain_corpus/prepare_openwebtext.py
@@ -57,7 +57,7 @@ def extract_files(full_name, output_dir, shuffle=False):
         with tarfile.open(full_name) as t:
             txt_names = t.getnames()
             if shuffle:
-                txt_names = random.shuffle(txt_names)
+                random.shuffle(txt_names)
             for txt_name in txt_names:
                 f = t.extractfile(txt_name)
                 for line in f.readlines():


### PR DESCRIPTION
## Description ##
The current implementation will raise `TypeError: 'NoneType' object is not iterable`, since `random.shuffle()` shuffles the input in place and returns `None`.

cc @szhengac @sxjscience 

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
