### PR TITLE
[BUGFIX] fix padding detection bug when processing out of vocabulary tokens

### DIFF
--- a/scripts/bert/embedding.py
+++ b/scripts/bert/embedding.py
@@ -181,7 +181,7 @@ class BertEmbedding:
             oov_len = 1
             for token_id, sequence_output in zip(token_ids, sequence_outputs):
                 # [PAD] token, sequence is finished.
-                if padding_idx and token_id == padding_idx:
+                if padding_idx is not None and token_id == padding_idx:
                     break
                 # [CLS], [SEP]
                 if cls_idx and token_id == cls_idx:


### PR DESCRIPTION
[BUGFIX] fix padding detection bug when processing out of vocabulary tokens.
The fix can handle zero valued padding_idx in RoBERTa model.

## Description ##
Fix padding detection bug when processing out of vocabulary tokens.
The fix can handle zero valued padding_idx in RoBERTa model.
## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
