### PR TITLE
[WIP] distributed training

### DIFF
--- a/src/gluonnlp/utils/misc.py
+++ b/src/gluonnlp/utils/misc.py
@@ -637,6 +637,20 @@ def init_comm(backend, gpus):
         is_master_node = rank == local_rank
         ctx_l = [mx.gpu(local_rank)]
         logging.info('GPU communication supported by horovod')
+    elif backend == 'byteps':
+        try:
+            import byteps.mxnet as bps
+        except ImportError:
+            logging.info('BytePS must be installed.')
+            sys.exit(1)
+        bps.init()
+        store = None
+        num_workers = bps.size()
+        rank = bps.rank()
+        local_rank = bps.local_rank()
+        is_master_node = rank == local_rank
+        ctx_l = [mx.gpu(local_rank)]
+        logging.info('GPU communication supported by BytePS')
     else:
         store = mx.kv.create(backend)
         num_workers = store.num_workers


### PR DESCRIPTION
## Description ##
Based on this branch (https://github.com/ZiyueHuang/byteps/tree/mx2), we can perform distributed training for the electra model (and other models). However, there are two issues:

* We should first call `trainer._init_params()` before the first iteration (forward/backward) to synchronize the parameters across all workers, otherwise `trainer` will call `_init_params` inside `allreduce_grads` (see mxnet/python/mxnet/gluon/trainer.py), thus the synchronization of the parameters actually happen after the first forward/backward computation, meaning that in the first iteration the gradients on different workers are computed w.r.t. different parameters. But in practice this may not be a severe problem, as only the first gradient descent step is not totally correct.

When the model in gluon-nlp confirms to the new coding standard (removing defer_init for all parameters @sxjscience ), then we can directly call `trainer._init_params` after `model.initialize`.

Actually I am a little confused about the semantic meaning of defer_init in the numpy mode, because shape with zeros (such as `(0, 5)`) in the numpy mode will be treated as scalar tensors' shape and zero-size tensors' shape, instead of as unknown in the legacy mode.


* I found that we have to build MXNet and BytePS from source on our target machine. Using `pip install mxnet` (I have tried several wheels in August) will not work for BytePS, either core dump immediately after `import bps.mxnet` due to undefined symbols (seems because some symbols are not exported into binary, fixed after 0820 wheel), or mysterious segfault (maybe due to c++ ABI issues or other compiler issues, as the mxnet wheels and BytePS (which is setup on our target machine) may not be compiled using the same version of gcc. Besides, there are no related compiler flags such as D_GLIBCXX_USE_CXX11_ABI for MXNet in BytePS's setup.py).

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
