### PR TITLE
Set default ctx in conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -228,5 +228,8 @@ def pytest_collection_modifyitems(config, items):
 
 
 def pytest_generate_tests(metafunc):
+    devices = metafunc.config.option.device
+    if not devices:
+        devices = ['cpu']
     if 'ctx' in metafunc.fixturenames:
-        metafunc.parametrize("ctx", [getattr(mx, device)() for device in metafunc.config.option.device])
+        metafunc.parametrize("ctx", [getattr(mx, device)() for device in devices])


### PR DESCRIPTION
Otherwise all tests with `ctx` argument are skipped if no `ctx` is specified on the command line.