### PR TITLE
[CI][BUGFIX] Custom Step for Uploading Code Coverage in Pull Request Event

### DIFF
--- a/.github/workflows/unittests-gpu.yml
+++ b/.github/workflows/unittests-gpu.yml
@@ -81,16 +81,17 @@ jobs:
 
       - name: Upload coverage to Codecov(For pull request)
         if: ${{ (failure() || success()) && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
-        uses: codecov/codecov-action@v1.0.10
-        with:
-          file: ./coverage.xml
-
-      - name: Upload coverage to Codecov(For push)
-        if: ${{ (failure() || success()) && github.event_name == 'push' }}
         run: |
           curl -s https://codecov.io/bash -o codecov.sh
           bash codecov.sh -f ./coverage.xml -n -F -C ${{ github.event.pull_request.head.sha }} -P ${{ github.event.pull_request.number }}
 
+
+      - name: Upload coverage to Codecov(For push)
+        if: ${{ (failure() || success()) && github.event_name == 'push' }}
+        uses: codecov/codecov-action@v1.0.10
+        with:
+          file: ./coverage.xml
+        
       - name: Upload Cloud Watch Log Stream 
         if: ${{ failure() || success() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/unittests-gpu.yml
+++ b/.github/workflows/unittests-gpu.yml
@@ -79,12 +79,17 @@ jobs:
           cat jobid.log | xargs -i aws s3api wait object-exists --bucket gluon-nlp-dev --key batch/{}/temp/coverage.xml
           cat jobid.log | xargs -i aws s3 cp s3://gluon-nlp-dev/batch/{}/temp/coverage.xml ./coverage.xml
 
-      - name: Upload coverage to Codecov
-        if: ${{ failure() || success() }}
+      - name: Upload coverage to Codecov(For pull request)
+        if: ${{ (failure() || success()) && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
         uses: codecov/codecov-action@v1.0.10
         with:
-          env_vars: OS,PYTHON
           file: ./coverage.xml
+
+      - name: Upload coverage to Codecov(For push)
+        if: ${{ (failure() || success()) && github.event_name == 'push' }}
+        run: |
+          curl -s https://codecov.io/bash -o codecov.sh
+          bash codecov.sh -f ./coverage.xml -n -F -C ${{ github.event.pull_request.head.sha }} -P ${{ github.event.pull_request.number }}
 
       - name: Upload Cloud Watch Log Stream 
         if: ${{ failure() || success() }}

--- a/.github/workflows/unittests-gpu.yml
+++ b/.github/workflows/unittests-gpu.yml
@@ -79,18 +79,16 @@ jobs:
           cat jobid.log | xargs -i aws s3api wait object-exists --bucket gluon-nlp-dev --key batch/{}/temp/coverage.xml
           cat jobid.log | xargs -i aws s3 cp s3://gluon-nlp-dev/batch/{}/temp/coverage.xml ./coverage.xml
 
-      - name: Upload coverage to Codecov(For pull request)
-        if: ${{ (failure() || success()) && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
+      - name: Upload coverage to Codecov
         run: |
           curl -s https://codecov.io/bash -o codecov.sh
-          bash codecov.sh -f ./coverage.xml -n -F -C ${{ github.event.pull_request.head.sha }} -P ${{ github.event.pull_request.number }}
-
-
-      - name: Upload coverage to Codecov(For push)
-        if: ${{ (failure() || success()) && github.event_name == 'push' }}
-        uses: codecov/codecov-action@v1.0.10
-        with:
-          file: ./coverage.xml
+          if [ "$EVENT_NAME" == "push" ]; then \
+              bash codecov.sh -f ./coverage.xml -n -F -C ${{ github.event.pull_request.head.sha }} -P ${{ github.event.pull_request.number }}; \
+          else \
+              bash codecov.sh -f ./coverage.xml -n -F; \
+          fi          
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         
       - name: Upload Cloud Watch Log Stream 
         if: ${{ failure() || success() }}

--- a/.github/workflows/unittests-gpu.yml
+++ b/.github/workflows/unittests-gpu.yml
@@ -83,9 +83,9 @@ jobs:
         run: |
           curl -s https://codecov.io/bash -o codecov.sh
           if [ "$EVENT_NAME" == "push" ]; then \
-              bash codecov.sh -f ./coverage.xml -n -F -C ${{ github.event.pull_request.head.sha }} -P ${{ github.event.pull_request.number }}; \
-          else \
               bash codecov.sh -f ./coverage.xml -n -F; \
+          else \
+              bash codecov.sh -f ./coverage.xml -n -F -C ${{ github.event.pull_request.head.sha }} -P ${{ github.event.pull_request.number }}; \
           fi          
         env:
           EVENT_NAME: ${{ github.event_name }}


### PR DESCRIPTION
## Description ##
Get `HTTP 400`  response code and error message `pr must match pattern ^(\d+|false|null|undefined|true)$` when uploading code coverage report for all the pull requests in GPU CI workflow. 

Probably because we are using `pull_request_target` event to deal with PR in GPU CI workflow and `GITHUB_REF` always refers to `refs/head` rather than format `refs/pull/#/merge`, which means it's not possible for codecov-action to get the pr number from `GITHUB_REF`. 

As suggested in [this issue](https://github.com/codecov/codecov-action/issues/69), we can customize the step for uploading code coverage in `pull_request_target` event. 


## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
