### PR TITLE
fix squad loss

### DIFF
--- a/scripts/question_answering/run_squad.py
+++ b/scripts/question_answering/run_squad.py
@@ -580,7 +580,7 @@ def train(args):
                     sel_answerable_logits = answerable_logits[batch_idx, is_impossible]
                     span_loss = - 0.5 * (sel_start_logits + sel_end_logits).mean()
                     answerable_loss = -0.5 * sel_answerable_logits.mean()
-                    loss = span_loss + answerable_loss
+                    loss = (span_loss + answerable_loss) / (len(ctx_l) * num_accumulated)
                     loss_l.append(loss)
                     span_loss_l.append(span_loss)
                     answerable_loss_l.append(answerable_loss)


### PR DESCRIPTION
## Description ##
We should additionally normalize the loss by `num_accumulated * len(ctx_l)`. I observed this issue since the grad_norm in the finetune log is very large (around 70), while in the pretraining log it is usually around 2.

To see why the current version is wrong intuitively, consider two commands `python3 run_squad.py --batch_size 12 --num_accumulated 1 ...` and `python3 run_squad.py --batch_size 1 --num_accumulated 12 ...`, they should give the same results when using MXNet Trainer. But this is not true currently, by `print(total_norm)`, you can observe that the grad_norm is much larger (nearly 10 times) in the second command than the first command. Meanwhile, note that the other operations (`clip_grad_global_norm` and `trainer.update`) are the same across these two commands, thus the behaviors of them will diverge, and this divergence will be more significant if `max_grad_norm` is larger. *The reason* is that the aggregated gradients are first normalized (by batch_size) in the mini-batch (see `span_loss = ....mean(), answerable_loss = ....mean()`) and then accumulate by `num_accumulated * len(ctx_l)` times. Also, note that `num_workers` is the number of machines (not the number of GPUs) when using MXNet Trainer.

Then why would the current version also give satisfied results? Because for most of the times, grad_norm is much larger (more than `num_accumulated * len(ctx_l)` times) than `max_grad_norm`, then it will make no difference whether we normalize the loss in the correct way, since the gradients would be clipped to `max_grad_norm` anyway. But things would be different when grad_norm is not so large or `max_grad_norm` is large.

I tested it on BERT base model, and the performance are the same before/after this PR. I think it is because the grad_norm is much larger  than `max_grad_norm=0.1`.

cc @sxjscience 


## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
