### PR TITLE
[DOC] Remove warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -j 4 -W --keep-going
+SPHINXOPTS    = -W --keep-going
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build


### PR DESCRIPTION
## Description ##
Currently, GluonNLP CI for docs building will always fail because of the following errors. 
`WARNING: the mxtheme extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit`
`WARNING: doing serial read`
We may have two possible solutions. 

1. Disable parallel building.  
2. Update `mxtheme` extension to make parallel read safe. 

This PR will disable parallel building to remove these warnings. 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
