### PR TITLE
[Benchmark] Update HuggingFace benchmarking

### DIFF
--- a/scripts/benchmarks/benchmark_hf.py
+++ b/scripts/benchmarks/benchmark_hf.py
@@ -123,10 +123,6 @@ def main():
                 p = Process(target=benchmark.run)
                 p.start()
                 p.join()
-                # try:
-                #     benchmark.run()
-                # except Exception as exp:
-                #     logging.info(exp)
 
                 try:
                     train_time_df = pd.read_csv('{}.train_time.csv'.format(prefix))
@@ -178,11 +174,6 @@ def main():
                     p = Process(target=benchmark.run)
                     p.start()
                     p.join()
-                    # try:
-                    #     benchmark.run()
-                    # except Exception as exp:
-                    #     print(exp)
-                    #     logging.info(exp)
 
                     try:
                         inference_time_df = pd.read_csv('{}.inference_time.csv'.format(prefix))


### PR DESCRIPTION
## Description ##
I noticed that we need to manually disable multiprocessing.

Also, the original huggingface benchmark has not called `torch.cuda.synchronize()`. The comparison won't be fair because the CUDA calls are async. I added the `torch.cuda.synchronize()` in the benchmarking script. (See HF implemenation https://github.com/huggingface/transformers/blob/ab17758874f62c03b6e5627f846a697920b16dd8/src/transformers/benchmark/benchmark.py#L171-L194).

@Cli212

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @dmlc/gluon-nlp-team
