### PR TITLE
Speed up downloads from S3 bucket

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ if VERSION.endswith('dev'):
 
 
 requirements = [
+    'boto3',
     'numpy<1.20.0',
     'sacremoses>=0.0.38',
     'yacs>=0.1.6',
@@ -76,7 +77,6 @@ setup(
     install_requires=requirements,
     extras_require={
         'extras': [
-            'boto3',
             'tqdm',
             'jieba',
             'subword_nmt',

--- a/src/gluonnlp/base.py
+++ b/src/gluonnlp/base.py
@@ -57,7 +57,7 @@ def get_model_zoo_checksum_dir():
 def get_repo_url():
     """Return the base URL for Gluon dataset and model repository """
     # TODO(sxjscience) Revise later by calling gluon.utils._get_repo_url
-    default_repo = 'https://gluonnlp-numpy-data.s3-accelerate.amazonaws.com/'
+    default_repo = 's3://gluonnlp-numpy-data'
     repo_url = os.environ.get('MXNET_GLUON_REPO', default_repo)
     if repo_url[-1] != '/':
         repo_url = repo_url + '/'

--- a/src/gluonnlp/utils/lazy_imports.py
+++ b/src/gluonnlp/utils/lazy_imports.py
@@ -141,13 +141,14 @@ def try_import_langid():
 def try_import_boto3():
     try:
         import boto3
+        import botocore
     except ImportError:
         raise ImportError('"boto3" is not installed. To enable fast downloading in EC2. You should '
                           'install boto3 and correctly configure the S3. '
                           'See https://boto3.readthedocs.io/ for more information. '
                           'If you are using EC2, downloading from s3:// will '
                           'be multiple times faster than using the traditional http/https URL.')
-    return boto3
+    return boto3, botocore
 
 
 def try_import_jieba():

--- a/src/gluonnlp/utils/misc.py
+++ b/src/gluonnlp/utils/misc.py
@@ -363,8 +363,11 @@ def download(url: str,
     """
     is_s3 = url.startswith(S3_PREFIX)
     if is_s3:
-        boto3 = try_import_boto3()
+        boto3, botocore = try_import_boto3()
         s3 = boto3.resource('s3')
+        if boto3.session.Session().get_credentials() is None:
+            from botocore.handlers import disable_signing
+            s3.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
         components = url[len(S3_PREFIX):].split('/')
         if len(components) < 2:
             raise ValueError('Invalid S3 url. Received url={}'.format(url))

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -15,7 +15,7 @@ mx.npx.set_np()
 def s3_enabled():
     from gluonnlp.utils.lazy_imports import try_import_boto3
     try:
-        boto3 = try_import_boto3()
+        boto3, botocore = try_import_boto3()
         s3 = boto3.resource('s3')
         for bucket in s3.buckets.all():
             print(bucket.name)


### PR DESCRIPTION
Rely on boto3 by default for downloads from S3. Handle unauthenticated access to S3 via botocore if needed.