### PR TITLE
Add NaturalQuestions to datasets

### DIFF
--- a/scripts/datasets/question_answering/README.md
+++ b/scripts/datasets/question_answering/README.md
@@ -55,12 +55,12 @@ See more useful scripts in [Offical Github](https://github.com/mandarjoshi90/tri
 Run the following command to download TriviaQA
 
 ```bash
-python3 prepare_triviaqa.py --version rc         # Download TriviaQA version 1.0 for RC (2.5G)
-python3 prepare_triviaqa.py --version unfiltered # Download unfiltered TriviaQA version 1.0 (604M)
+python3 prepare_triviaqa.py --type rc         # Download TriviaQA version 1.0 for RC (2.5G)
+python3 prepare_triviaqa.py --type unfiltered # Download unfiltered TriviaQA version 1.0 (604M)
 
 # Or download with command-line toolkits
-nlp_data prepare_triviaqa --version rc
-nlp_data prepare_triviaqa --version unfiltered
+nlp_data prepare_triviaqa --type rc
+nlp_data prepare_triviaqa --type unfiltered
 ```
 
 Directory structure of the triviaqa (rc and unfiltered) dataset will be as follows:
@@ -118,10 +118,7 @@ python3 prepare_naturalquestions.py
 # Or download with command-line toolkits
 nlp_data prepare_naturalquestions
 ```
-
-
-
-Directory structure of the hotpotqa dataset will be as follows
+Directory structure of the NaturalQuestions dataset will be as follows
 
 ```
 NaturalQuestions

--- a/scripts/datasets/question_answering/README.md
+++ b/scripts/datasets/question_answering/README.md
@@ -109,15 +109,24 @@ hotpotqa
 
 NaturalQuestions is an open domain QA dataset. This dataset contains questions from real users. For more details about this dataset, check out https://ai.google.com/research/NaturalQuestions
 
-Run the following command to download NaturalQuestions
+Run the following command to download NaturalQuestions and extract gz files.
 
 ```
-python3 prepare_naturalquestions.py
+python3 prepare_naturalquestions.py --extract
 # Download NaturalQuestions simplified version 1.0(5.4G)
+
+# Or download with command-line toolkits
+nlp_data prepare_naturalquestions --extract
+```
+
+If you do not want to extract gz files, just run:
+```
+python3 prepare_naturalquestions.py
 
 # Or download with command-line toolkits
 nlp_data prepare_naturalquestions
 ```
+
 Directory structure of the NaturalQuestions dataset will be as follows
 
 ```

--- a/scripts/datasets/question_answering/README.md
+++ b/scripts/datasets/question_answering/README.md
@@ -104,3 +104,28 @@ hotpotqa
 ├── hotpot_dev_distractor_v1.json
 ├── hotpot_test_fullwiki_v1.json
 ```
+
+## NaturalQuestions
+
+NaturalQuestions is an open domain QA dataset. This dataset contains questions from real users. For more details about this dataset, check out https://ai.google.com/research/NaturalQuestions
+
+Run the following command to download NaturalQuestions
+
+```
+python3 prepare_naturalquestions.py
+# Download NaturalQuestions simplified version 1.0(5.4G)
+
+# Or download with command-line toolkits
+nlp_data prepare_naturalquestions
+```
+
+
+
+Directory structure of the hotpotqa dataset will be as follows
+
+```
+NaturalQuestions
+├── v1.0-simplified_simplified-nq-train.jsonl
+├── nq-dev-all.jsonl
+```
+

--- a/scripts/datasets/question_answering/prepare_naturalquestions.py
+++ b/scripts/datasets/question_answering/prepare_naturalquestions.py
@@ -1,0 +1,82 @@
+import logging
+import os
+import argparse
+import ast
+import gzip
+from gluonnlp.utils.misc import download, load_checksum_stats
+from gluonnlp.base import get_data_home_dir, get_repo_url
+
+
+_CURR_DIR = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+_BASE_DATASET_PATH = os.path.join(get_data_home_dir(), 'NaturalQuestions')
+_URL_FILE_STATS_PATH = os.path.join(_CURR_DIR, '..', 'url_checksums', 'naturalquestions.txt')
+_URL_FILE_STATS = load_checksum_stats(_URL_FILE_STATS_PATH)
+
+_CITATIONS = """
+@article{47761,
+title	= {Natural Questions: a Benchmark for Question Answering Research},
+author	= {Tom Kwiatkowski and Jennimaria Palomaki and Olivia Redfield and Michael Collins and Ankur Parikh and Chris Alberti and Danielle Epstein and Illia Polosukhin and Matthew Kelcey and Jacob Devlin and Kenton Lee and Kristina N. Toutanova and Llion Jones and Ming-Wei Chang and Andrew Dai and Jakob Uszkoreit and Quoc Le and Slav Petrov},
+year	= {2019},
+journal	= {Transactions of the Association of Computational Linguistics}
+}
+"""
+
+_URLS = {
+    'train': get_repo_url() + 'NaturalQuestions/v1.0-simplified_simplified-nq-train.jsonl.gz',
+    'dev': get_repo_url() + 'NaturalQuestions/nq-dev-all.jsonl.gz',
+    # 'all': get_repo_url() + 'NaturalQuestions/*'
+}
+
+
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description='Downloading the NaturalQuestions Dataset.')
+    parser.add_argument('--all', type=ast.literal_eval, default=False)
+    parser.add_argument('--save-path', type=str, default='NaturalQuestions')
+    parser.add_argument('--cache-path', type=str, default=_BASE_DATASET_PATH,
+                        help='The path to download the dataset.')
+    parser.add_argument('--overwrite', action='store_true')
+    return parser
+
+
+def main(args):
+    def extract(gz_path):
+        logging.info(f'Extracting {gz_path}, this can cost long time because the file is large')
+        try:
+            f_name = gz_path.replace(".gz", "")
+            g_file = gzip.GzipFile(gz_path)
+            open(f_name, "wb+").write(g_file.read())
+            g_file.close()
+            os.remove(gz_path)
+        except Exception  as e:
+            print(e)
+    if not os.path.exists(args.save_path):
+        os.makedirs(args.save_path)
+    if args.all:
+        pass
+    else:
+        for url in _URLS.values():
+            file_name = url[url.rfind('/') + 1:]
+            file_hash = _URL_FILE_STATS[url]
+            download(url, path=os.path.join(args.cache_path, file_name), sha1_hash=file_hash)
+            if not os.path.exists(os.path.join(args.save_path, file_name))\
+                    or (args.overwrite and args.save_path != args.cache_path):
+                os.symlink(os.path.join(args.cache_path, file_name),
+                           os.path.join(args.save_path, file_name))
+            extract(os.path.join(args.save_path, file_name))
+
+
+def cli_main():
+    parser = get_parser()
+    args = parser.parse_args()
+    main(args)
+
+
+if __name__ == '__main__':
+    cli_main()
+
+
+
+
+

--- a/scripts/datasets/question_answering/prepare_naturalquestions.py
+++ b/scripts/datasets/question_answering/prepare_naturalquestions.py
@@ -23,8 +23,7 @@ journal	= {Transactions of the Association of Computational Linguistics}
 
 _URLS = {
     'train': get_repo_url() + 'NaturalQuestions/v1.0-simplified_simplified-nq-train.jsonl.gz',
-    'dev': get_repo_url() + 'NaturalQuestions/nq-dev-all.jsonl.gz',
-    # 'all': get_repo_url() + 'NaturalQuestions/*'
+    'dev': get_repo_url() + 'NaturalQuestions/nq-dev-all.jsonl.gz'
 }
 
 
@@ -37,6 +36,7 @@ def get_parser():
     parser.add_argument('--cache-path', type=str, default=_BASE_DATASET_PATH,
                         help='The path to download the dataset.')
     parser.add_argument('--overwrite', action='store_true')
+    parser.add_argument('--extract', action='store_true')
     return parser
 
 
@@ -64,7 +64,8 @@ def main(args):
                     or (args.overwrite and args.save_path != args.cache_path):
                 os.symlink(os.path.join(args.cache_path, file_name),
                            os.path.join(args.save_path, file_name))
-            extract(os.path.join(args.save_path, file_name))
+            if args.extract:
+                extract(os.path.join(args.save_path, file_name))
 
 
 def cli_main():

--- a/scripts/datasets/question_answering/prepare_naturalquestions.py
+++ b/scripts/datasets/question_answering/prepare_naturalquestions.py
@@ -6,7 +6,7 @@ import gzip
 from gluonnlp.utils.misc import download, load_checksum_stats
 from gluonnlp.base import get_data_home_dir, get_repo_url
 
-
+logger = logging.getLogger(__name__)
 _CURR_DIR = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
 _BASE_DATASET_PATH = os.path.join(get_data_home_dir(), 'NaturalQuestions')
 _URL_FILE_STATS_PATH = os.path.join(_CURR_DIR, '..', 'url_checksums', 'naturalquestions.txt')
@@ -42,7 +42,7 @@ def get_parser():
 
 def main(args):
     def extract(gz_path):
-        logging.info(f'Extracting {gz_path}, this can cost long time because the file is large')
+        logging.warning(f'Extracting {gz_path}, this can cost long time because the file is large')
         try:
             f_name = gz_path.replace(".gz", "")
             g_file = gzip.GzipFile(gz_path)

--- a/scripts/datasets/question_answering/prepare_naturalquestions.py
+++ b/scripts/datasets/question_answering/prepare_naturalquestions.py
@@ -31,7 +31,6 @@ _URLS = {
 
 def get_parser():
     parser = argparse.ArgumentParser(description='Downloading the NaturalQuestions Dataset.')
-    parser.add_argument('--all', type=ast.literal_eval, default=False)
     parser.add_argument('--save-path', type=str, default='NaturalQuestions')
     parser.add_argument('--cache-path', type=str, default=_BASE_DATASET_PATH,
                         help='The path to download the dataset.')

--- a/scripts/datasets/url_checksums/naturalquestions.txt
+++ b/scripts/datasets/url_checksums/naturalquestions.txt
@@ -1,0 +1,2 @@
+s3://gluonnlp-numpy-data/NaturalQuestions/v1.0-simplified_simplified-nq-train.jsonl.gz 9ae896ea4b29370fe157aea61a088ffdc0fbda8f 4715820286
+s3://gluonnlp-numpy-data/NaturalQuestions/nq-dev-all.jsonl.gz b4cc081a2d065f84d630a1338dead7faad77eeff 1068038975


### PR DESCRIPTION
## Description ##
This PR commits the script for downloading NaturalQuestions from s3 bucket. And also, instructions for using this script is written in README.md.

Additionally, I found that if we want to download triviaqa data, we should use command```python3 prepare_triviaqa.py --type {rc,unfiltered}``` rather than ```python3 prepare_triviaqa.py --version {rc,unfiltered}```which README.md shows. So I update this part in README.md too. 

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage

cc @dmlc/gluon-nlp-team
