### PR TITLE
adjust implementation of relative position encoding

### DIFF
--- a/src/gluonnlp/op.py
+++ b/src/gluonnlp/op.py
@@ -231,16 +231,14 @@ def relative_position_bucket(relative_position,
                              bidirectional: bool = True,
                              num_buckets: int = 32,
                              max_distance: int = 128):
-    """Map the relative position to buckets. The major difference between our implementation and
-    that in [mesh_tensorflow](https://github.com/tensorflow/mesh/blob/c59988047e49b4d2af05603e3170724cdbadc467/mesh_tensorflow/transformer/transformer_layers.py#L595-L637)
-    is that we use 'query_i - mem_j' as the (i, j)th location in relative_position.
+    """Map the relative position to buckets. The implementation is consistent with that
+    in [mesh_tensorflow](https://github.com/tensorflow/mesh/blob/c59988047e49b4d2af05603e3170724cdbadc467/mesh_tensorflow/transformer/transformer_layers.py#L595-L637)
+    where relative position is defined as `mem_i - query_j`. Thus, a positive value indicates 
+    that the memory slot is in a later timestamp than the query slot. 
 
-    Thus, a positive value means that the query slot is in a later timestamp than the memory slot.
-    However, in mesh transformer, it is treated as `mem_i - query_j` (reversed).
-
-    The implementation uses the first half of the bucket (num_buckets // 2) to store the
-    exact increments in positions and the second half of the bucket
-    (num_buckets - num_buckets // 2) to store the bucketing values in the logarithm order.
+    After handling the bidirectional case (see below), the implementation uses the first half 
+    of buckets to store exact differences and the second half to store the differences after 
+    a logrithmic transformation. 
 
     Parameters
     ----------
@@ -249,8 +247,8 @@ def relative_position_bucket(relative_position,
         Shape (...,)
     bidirectional
         Whether we are dealing with bidirectional attention.
-        If it's bidirectional, we will use the first half to map the positions of the
-        positive shifts and the second half to map the positions of the negative shifts.
+        If it's bidirectional, positive shifts are mappd to [0, num_buckets // 2), 
+        and negative shifts are mapped to [num_buckets // 2, num_buckets). 
     num_buckets
         The number of buckets.
     max_distance
@@ -263,6 +261,7 @@ def relative_position_bucket(relative_position,
         It has the same shape as the `relative_position`. It will have int32 type.
     """
     ret = 0
+    relative_position = -relative_position
     if bidirectional:
         assert num_buckets % 2 == 0, 'When bidirectional is True, the number of buckets must be ' \
                                      'divisible by 2.'

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -218,7 +218,7 @@ def test_bucket_positional_embedding(units, num_buckets, bidirectional, max_dist
             assert_allclose(mx.np.linalg.norm(out[buckets == i].std(axis=0)).asnumpy(), 0,
                             1E-5, 1E-5)
     if bidirectional:
-        assert mx.np.all(buckets[relative_positions < 0] >= num_buckets // 2).asnumpy()
+        assert mx.np.all(buckets[relative_positions > 0] >= num_buckets // 2).asnumpy()
     out_of_bound_cnt = buckets[relative_positions > max_distance].sum()
     if out_of_bound_cnt.asnumpy() > 0:
         assert buckets[relative_positions > max_distance].std().asnumpy() == 0


### PR DESCRIPTION
## Description ##

This version aligns the implementation of relative position encoding with that in mesh_tensorflow. It would also help program T5 model in the future. 

## Changes ##
- Define relative position as `mem_i - query_j` in lieu of previous `query_i - mem_j `
- Rephrase documentation

cc @dmlc/gluon-nlp-team
