### PR TITLE
[FEATURE] relax spm sanity check; add t5 tokenizer tests

### DIFF
--- a/src/gluonnlp/data/tokenizers/sentencepiece.py
+++ b/src/gluonnlp/data/tokenizers/sentencepiece.py
@@ -131,12 +131,11 @@ class SentencepieceTokenizer(BaseTokenizerWithVocab):
         else:
             self._vocab = load_vocab(vocab)
         # Sanity check
-        assert self._vocab.all_tokens == sp_model_all_tokens
+        assert len(self._vocab.all_tokens) >= len(sp_model_all_tokens)
+        assert self._vocab.all_tokens[:len(sp_model_all_tokens)] == sp_model_all_tokens
         for token in self._vocab.special_tokens:
             piece_id = self._sp_model.piece_to_id(token)
-            if self._sp_model.is_unknown(piece_id):
-                assert self._vocab[token] == self._sp_model.unk_id()
-            else:
+            if not self._sp_model.is_unknown(piece_id):
                 assert self._sp_model.is_control(piece_id), \
                     'Vocab mismatch! "{}" is a special token in the given vocab but not in the ' \
                     'sentencepiece model!'.format(token)

--- a/src/gluonnlp/op.py
+++ b/src/gluonnlp/op.py
@@ -244,7 +244,6 @@ def relative_position_bucket(relative_position,
 
     Parameters
     ----------
-    F
     relative_position
         Shape (...,)
     bidirectional


### PR DESCRIPTION
## Description ##
This PR modifies the sanity check in SentencepieceTokenizer to ensure easier insertion of additional special tokens, which later would help add <extra_id>s corresponding to noise span sentinels as in T5 tokenizer. Accordingly, model and vocab for T5-base have been uploaded to S3 for some new test cases. 

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage

### Changes ###
- Relaxed spm sanity check
- Test cases for T5 tokenizer
- A Simple fix to an op.py docstring

cc @dmlc/gluon-nlp-team
