### PR TITLE
Fix typo in test_bert.py

### DIFF
--- a/tests/test_models_albert.py
+++ b/tests/test_models_albert.py
@@ -109,13 +109,13 @@ def test_albert_for_mlm_model(compute_layout):
     token_types = mx.np.random.randint(0, cfg.MODEL.num_token_types, (batch_size, seq_length))
     valid_length = mx.np.random.randint(seq_length // 2, seq_length, (batch_size,))
     masked_positions = mx.np.random.randint(0, seq_length // 2, (batch_size, num_mask))
-    contextual_embeddings, pooled_out, mlm_scores = albert_mlm_model(inputs, token_types, valid_length, masked_positions)
-    contextual_embeddings_tn, pooled_out_tn, mlm_scores_tn = albert_mlm_tn_model(inputs.T, token_types.T, valid_length, masked_positions)
+    contextual_embeddings, pooled_out, mlm_score = albert_mlm_model(inputs, token_types, valid_length, masked_positions)
+    contextual_embeddings_tn, pooled_out_tn, mlm_score_tn = albert_mlm_tn_model(inputs.T, token_types.T, valid_length, masked_positions)
     assert_allclose(np.swapaxes(contextual_embeddings_tn.asnumpy(), 0, 1),
                     contextual_embeddings.asnumpy(), 1E-4, 1E-4)
     assert_allclose(pooled_out_tn.asnumpy(), pooled_out.asnumpy(), 1E-4, 1E-4)
-    assert_allclose(mlm_scores_tn.asnumpy(), mlm_scores.asnumpy(), 1E-4, 1E-4)
-    assert mlm_scores.shape == (batch_size, num_mask, cfg.MODEL.vocab_size)
+    assert_allclose(mlm_score_tn.asnumpy(), mlm_score.asnumpy(), 1E-4, 1E-4)
+    assert mlm_score.shape == (batch_size, num_mask, cfg.MODEL.vocab_size)
 
 
 @pytest.mark.parametrize('compute_layout', ['auto', 'NT', 'TN'])
@@ -142,16 +142,16 @@ def test_albert_for_pretrain_model(compute_layout):
     token_types = mx.np.random.randint(0, cfg.MODEL.num_token_types, (batch_size, seq_length))
     valid_length = mx.np.random.randint(seq_length // 2, seq_length, (batch_size,))
     masked_positions = mx.np.random.randint(0, seq_length // 2, (batch_size, num_mask))
-    contextual_embeddings, pooled_out, sop_score, mlm_scores =\
+    contextual_embeddings, pooled_out, sop_score, mlm_score =\
         albert_pretrain_model(inputs, token_types, valid_length, masked_positions)
-    contextual_embeddings_tn, pooled_out_tn, sop_score_tn, mlm_scores_tn = \
+    contextual_embeddings_tn, pooled_out_tn, sop_score_tn, mlm_score_tn = \
         albert_pretrain_model_tn(inputs.T, token_types.T, valid_length, masked_positions)
     assert_allclose(np.swapaxes(contextual_embeddings_tn.asnumpy(), 0, 1),
                     contextual_embeddings.asnumpy(), 1E-4, 1E-4)
     assert_allclose(pooled_out_tn.asnumpy(), pooled_out.asnumpy(), 1E-4, 1E-4)
     assert_allclose(sop_score.asnumpy(), sop_score_tn.asnumpy(), 1E-4, 1E-4)
-    assert_allclose(mlm_scores.asnumpy(), mlm_scores_tn.asnumpy(), 1E-4, 1E-4)
-    assert mlm_scores.shape == (batch_size, num_mask, cfg.MODEL.vocab_size)
+    assert_allclose(mlm_score.asnumpy(), mlm_score_tn.asnumpy(), 1E-4, 1E-4)
+    assert mlm_score.shape == (batch_size, num_mask, cfg.MODEL.vocab_size)
     assert sop_score.shape == (batch_size, 2)
 
 

--- a/tests/test_models_bert.py
+++ b/tests/test_models_bert.py
@@ -74,12 +74,12 @@ def test_bert_small_cfg(compute_layout, ctx):
         bert_pretrain_model = BertForPretrain(cfg)
         bert_pretrain_model.initialize()
         bert_pretrain_model.hybridize()
-        contextual_embedding, pooled_out, nsp_score, mlm_scores =\
+        contextual_embedding, pooled_out, nsp_score, mlm_score =\
             bert_pretrain_model(inputs, token_types, valid_length, masked_positions)
         bert_pretrain_model_tn = BertForPretrain(cfg_tn)
         bert_pretrain_model_tn.share_parameters(bert_pretrain_model.collect_params())
         bert_pretrain_model_tn.hybridize()
-        contextual_embedding_tn, pooled_out_tn, nsp_score_tn, mlm_scores_tn = \
+        contextual_embedding_tn, pooled_out_tn, nsp_score_tn, mlm_score_tn = \
             bert_pretrain_model_tn(inputs.T, token_types.T, valid_length, masked_positions)
         assert_allclose(contextual_embedding.asnumpy(),
                         mx.np.swapaxes(contextual_embedding_tn, 0, 1).asnumpy(),

--- a/tests/test_models_mobilebert.py
+++ b/tests/test_models_mobilebert.py
@@ -60,16 +60,16 @@ def test_mobilebert_model_small_cfg(compute_layout, ctx):
         mobile_bert_mlm_model_tn = MobileBertForMLM(cfg_tn)
         mobile_bert_mlm_model_tn.share_parameters(mobile_bert_mlm_model.collect_params())
         mobile_bert_model_tn.hybridize()
-        contextual_embedding, pooled_out, mlm_scores = mobile_bert_mlm_model(inputs, token_types,
+        contextual_embedding, pooled_out, mlm_score = mobile_bert_mlm_model(inputs, token_types,
                                                                              valid_length,
                                                                              masked_positions)
-        contextual_embedding_tn, pooled_out_tn, mlm_scores_tn =\
+        contextual_embedding_tn, pooled_out_tn, mlm_score_tn =\
             mobile_bert_mlm_model_tn(inputs.T, token_types.T, valid_length, masked_positions)
         assert_allclose(contextual_embedding.asnumpy(),
                         np.swapaxes(contextual_embedding_tn.asnumpy(), 0, 1),
                         1E-3, 1E-3)
         assert_allclose(pooled_out_tn.asnumpy(), pooled_out.asnumpy(), 1E-3, 1E-3)
-        assert_allclose(mlm_scores_tn.asnumpy(), mlm_scores.asnumpy(), 1E-3, 1E-3)
+        assert_allclose(mlm_score_tn.asnumpy(), mlm_score.asnumpy(), 1E-3, 1E-3)
 
         # Test for MobileBertForPretrain
         mobile_bert_pretrain_model = MobileBertForPretrain(cfg)
@@ -78,16 +78,16 @@ def test_mobilebert_model_small_cfg(compute_layout, ctx):
         mobile_bert_pretrain_model_tn = MobileBertForPretrain(cfg_tn)
         mobile_bert_pretrain_model_tn.share_parameters(mobile_bert_pretrain_model.collect_params())
         mobile_bert_pretrain_model_tn.hybridize()
-        contextual_embedding, pooled_out, nsp_score, mlm_scores =\
+        contextual_embedding, pooled_out, nsp_score, mlm_score =\
             mobile_bert_pretrain_model(inputs, token_types, valid_length, masked_positions)
-        contextual_embedding_tn, pooled_out_tn, nsp_score_tn, mlm_scores_tn = \
+        contextual_embedding_tn, pooled_out_tn, nsp_score_tn, mlm_score_tn = \
             mobile_bert_pretrain_model_tn(inputs.T, token_types.T, valid_length, masked_positions)
         assert_allclose(contextual_embedding.asnumpy(),
                         np.swapaxes(contextual_embedding_tn.asnumpy(), 0, 1),
                         1E-3, 1E-3)
         assert_allclose(pooled_out.asnumpy(), pooled_out_tn.asnumpy(), 1E-3, 1E-3)
         assert_allclose(nsp_score.asnumpy(), nsp_score_tn.asnumpy(), 1E-3, 1E-3)
-        assert_allclose(mlm_scores.asnumpy(), mlm_scores_tn.asnumpy(), 1E-3, 1E-3)
+        assert_allclose(mlm_score.asnumpy(), mlm_score_tn.asnumpy(), 1E-3, 1E-3)
 
         # Test for fp16
         if ctx.device_type == 'gpu':

--- a/tests/test_models_roberta.py
+++ b/tests/test_models_roberta.py
@@ -57,17 +57,17 @@ def test_robert_small_config(compute_layout, ctx):
         roberta_mlm_model = RobertaForMLM(cfg)
         roberta_mlm_model.initialize()
         roberta_mlm_model.hybridize()
-        contextual_embedding, pooled_out, mlm_scores = roberta_mlm_model(inputs, valid_length,
+        contextual_embedding, pooled_out, mlm_score = roberta_mlm_model(inputs, valid_length,
                                                                          masked_positions)
         roberta_mlm_model_tn = RobertaForMLM(cfg_tn)
         roberta_mlm_model_tn.share_parameters(roberta_mlm_model.collect_params())
         roberta_mlm_model_tn.hybridize()
-        contextual_embedding_tn, pooled_out_tn, mlm_scores_tn =\
+        contextual_embedding_tn, pooled_out_tn, mlm_score_tn =\
             roberta_mlm_model_tn(inputs.T, valid_length.T, masked_positions)
         assert_allclose(np.swapaxes(contextual_embedding_tn.asnumpy(), 0, 1),
                         contextual_embedding.asnumpy(), 1E-3, 1E-3)
         assert_allclose(pooled_out_tn.asnumpy(), pooled_out.asnumpy(), 1E-3, 1E-3)
-        assert_allclose(mlm_scores_tn.asnumpy(), mlm_scores.asnumpy(), 1E-3, 1E-3)
+        assert_allclose(mlm_score_tn.asnumpy(), mlm_score.asnumpy(), 1E-3, 1E-3)
 
         # Test for fp16
         if ctx.device_type == 'gpu':


### PR DESCRIPTION
## Description ##
In `test_bert.py` we assert about `mlm_score` instead of `mlm_scores` in the latter part of the test.
To avoid similar copy-paste errors in the future, consistently use `mlm_score` in the tests.