### PR TITLE
[Tokenizer] Fix huggingface wordpiece warning

### DIFF
--- a/src/gluonnlp/data/tokenizers/huggingface.py
+++ b/src/gluonnlp/data/tokenizers/huggingface.py
@@ -643,19 +643,14 @@ class HuggingFaceWordPieceTokenizer(LegacyHuggingFaceTokenizer):
                                       'mask_token': self._mask_token}
             self._vocab = Vocab(all_tokens, unk_token=self._unk_token, **default_special_tokens)
             all_tokens = self._vocab.all_tokens
-        # for safety, also use temp file when using wordpiece vocab file
-        # for situation that original all_tokens not cotain special tokens
-        # (vocab file of BERT do not contain all special tokens)
-        temp_hf_vocab_file = str(uuid4()) + '.hf_vocab'
-        with open(temp_hf_vocab_file, 'w', encoding='utf-8') as ftv:
-            ftv.write('\n'.join(all_tokens))
+        hf_vocab = {ele: i for i, ele in enumerate(all_tokens)}
         self._vocab.mask_token_id = self._vocab.mask_id
         assert [self._unk_token, self._sep_token, self._cls_token, self._pad_token,
                 self._mask_token] == \
                [self._vocab.unk_token, self._vocab.sep_token, self._vocab.cls_token,
                 self._vocab.pad_token, self._vocab.mask_token]
         self._model = tokenizers.BertWordPieceTokenizer(
-            vocab=temp_hf_vocab_file if temp_hf_vocab_file else self._vocab_file,
+            vocab=hf_vocab,
             unk_token=self._unk_token,
             sep_token=self._sep_token,
             cls_token=self._cls_token,
@@ -665,7 +660,6 @@ class HuggingFaceWordPieceTokenizer(LegacyHuggingFaceTokenizer):
             handle_chinese_chars=self._handle_chinese_chars,
             strip_accents=self._strip_accents, lowercase=self._lowercase,
             wordpieces_prefix=self._wordpieces_prefix)
-        os.remove(temp_hf_vocab_file)
 
     def __repr__(self):
         ret = '{}(\n' \


### PR DESCRIPTION
## Description ##
Fix the huggingface wordpiece tokenizer. I noticed that the previous implementation may trigger a warning in AutoGluon.


## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
