### PR TITLE
[GLUON] turn off deduplicate option in save_parameters

### DIFF
--- a/scripts/conversion_toolkits/convert_electra.py
+++ b/scripts/conversion_toolkits/convert_electra.py
@@ -400,15 +400,15 @@ def convert_tf_model(model_dir, save_dir, test_conversion, model_size, gpu, elec
                     ele_valid_length = valid_length[i]
                     assert_allclose(contextual_embedding[i, :ele_valid_length, :].asnumpy(),
                                     tf_contextual_embedding[i, :ele_valid_length, :], 1E-3, 1E-3)
-            model.save_parameters(os.path.join(save_dir, 'model.params'), deduplicate=True)
+            model.save_parameters(os.path.join(save_dir, 'model.params'))
             logging.info('Convert the backbone model in {} to {}/{}'.format(model_dir,
                                                                             save_dir, 'model.params'))
         elif convert_type == 'disc':
-            model.save_parameters(os.path.join(save_dir, 'disc_model.params'), deduplicate=True)
+            model.save_parameters(os.path.join(save_dir, 'disc_model.params'))
             logging.info(
                 'Convert the discriminator model in {} to {}/{}'.format(model_dir, save_dir, 'disc_model.params'))
         elif convert_type == 'gen':
-            model.save_parameters(os.path.join(save_dir, 'gen_model.params'), deduplicate=True)
+            model.save_parameters(os.path.join(save_dir, 'gen_model.params'))
             logging.info('Convert the generator model in {} to {}/{}'.format(model_dir,
                                                                              save_dir, 'gen_model.params'))
 

--- a/scripts/conversion_toolkits/convert_fairseq_bart.py
+++ b/scripts/conversion_toolkits/convert_fairseq_bart.py
@@ -298,7 +298,7 @@ def convert_fairseq_model(args):
     if args.test:
         test_model(fairseq_bart, gluon_bart, args.gpu)
 
-    gluon_bart.save_parameters(os.path.join(args.save_dir, 'model.params'), deduplicate=True)
+    gluon_bart.save_parameters(os.path.join(args.save_dir, 'model.params'))
     logging.info('Convert the BART MLM model in {} to {}'.
                  format(os.path.join(args.fairseq_model_path, 'model.pt'),
                         os.path.join(args.save_dir, 'model.params')))

--- a/scripts/conversion_toolkits/convert_fairseq_roberta.py
+++ b/scripts/conversion_toolkits/convert_fairseq_roberta.py
@@ -359,12 +359,12 @@ def convert_fairseq_model(args):
     if args.test:
         test_model(fairseq_roberta, gluon_roberta, args.gpu)
 
-    gluon_roberta.save_parameters(os.path.join(args.save_dir, 'model_mlm.params'), deduplicate=True)
+    gluon_roberta.save_parameters(os.path.join(args.save_dir, 'model_mlm.params'))
     logging.info('Convert the RoBERTa MLM model in {} to {}'.
                  format(os.path.join(args.fairseq_model_path, 'model.pt'),
                         os.path.join(args.save_dir, 'model_mlm.params')))
     gluon_roberta.backbone_model.save_parameters(
-        os.path.join(args.save_dir, 'model.params'), deduplicate=True)
+        os.path.join(args.save_dir, 'model.params'))
     logging.info('Convert the RoBERTa backbone model in {} to {}'.
                  format(os.path.join(args.fairseq_model_path, 'model.pt'),
                         os.path.join(args.save_dir, 'model.params')))

--- a/scripts/conversion_toolkits/convert_fairseq_xlmr.py
+++ b/scripts/conversion_toolkits/convert_fairseq_xlmr.py
@@ -100,12 +100,12 @@ def convert_fairseq_model(args):
     if args.test:
         test_model(fairseq_xlmr, gluon_xlmr, args.gpu)
 
-    gluon_xlmr.save_parameters(os.path.join(args.save_dir, 'model_mlm.params'), deduplicate=True)
+    gluon_xlmr.save_parameters(os.path.join(args.save_dir, 'model_mlm.params'))
     logging.info('Convert the RoBERTa MLM model in {} to {}'.
                  format(os.path.join(args.fairseq_model_path, 'model.pt'), \
                         os.path.join(args.save_dir, 'model_mlm.params')))
     gluon_xlmr.backbone_model.save_parameters(
-        os.path.join(args.save_dir, 'model.params'), deduplicate=True)
+        os.path.join(args.save_dir, 'model.params'))
     logging.info('Convert the RoBERTa backbone model in {} to {}'.
                  format(os.path.join(args.fairseq_model_path, 'model.pt'), \
                         os.path.join(args.save_dir, 'model.params')))

--- a/scripts/conversion_toolkits/convert_mobilebert.py
+++ b/scripts/conversion_toolkits/convert_mobilebert.py
@@ -311,9 +311,9 @@ def convert_tf_model(model_dir, save_dir, test_conversion, gpu, mobilebert_dir):
             ele_valid_length = valid_length[i]
             assert_allclose(contextual_embedding[i, :ele_valid_length, :].asnumpy(),
                             tf_contextual_embedding[i, :ele_valid_length, :], 1E-2, 1E-2)
-    model.backbone_model.save_parameters(os.path.join(save_dir, 'model.params'), deduplicate=True)
+    model.backbone_model.save_parameters(os.path.join(save_dir, 'model.params'))
     logging.info('Convert the backbone model in {} to {}/{}'.format(model_dir, save_dir, 'model.params'))
-    model.save_parameters(os.path.join(save_dir, 'model_mlm.params'), deduplicate=True)
+    model.save_parameters(os.path.join(save_dir, 'model_mlm.params'))
     logging.info('Convert the MLM and NSP model in {} to {}/{}'.format(model_dir,
                                                                        save_dir, 'model_mlm.params'))
 

--- a/scripts/conversion_toolkits/convert_tf_hub_model.py
+++ b/scripts/conversion_toolkits/convert_tf_hub_model.py
@@ -483,7 +483,7 @@ def convert_tf_model(hub_model_dir, save_dir, test_conversion, model_type, gpu):
     if not has_mlm:
         if test_conversion:
             check_backbone(model, tf_token_outputs_np)
-        model.save_parameters(os.path.join(save_dir, 'model.params'), deduplicate=True)
+        model.save_parameters(os.path.join(save_dir, 'model.params'))
         logging.info('Convert the backbone model in {} to {}/{}'.format(hub_model_dir,
                                                                         save_dir, 'model.params'))
     else:
@@ -504,10 +504,10 @@ def convert_tf_model(hub_model_dir, save_dir, test_conversion, model_type, gpu):
                     assert_allclose(contextual_embedding[i, :ele_valid_length, :].asnumpy(),
                                     tf_contextual_embedding[i, :ele_valid_length, :], tolerance, tolerance)
         model.backbone_model.save_parameters(os.path.join(
-            save_dir, 'model.params'), deduplicate=True)
+            save_dir, 'model.params'))
         logging.info('Convert the backbone model in {} to {}/{}'.format(hub_model_dir,
                                                                         save_dir, 'model.params'))
-        model.save_parameters(os.path.join(save_dir, 'model_mlm.params'), deduplicate=True)
+        model.save_parameters(os.path.join(save_dir, 'model_mlm.params'))
         logging.info('Convert the MLM model in {} to {}/{}'.format(hub_model_dir,
                                                                    save_dir, 'model_mlm.params'))
 

--- a/scripts/machine_translation/train_transformer.py
+++ b/scripts/machine_translation/train_transformer.py
@@ -504,7 +504,7 @@ def train(args):
     logging.info(beam_search_sampler)
     if args.comm_backend == 'horovod':
         hvd.broadcast_parameters(param_dict, root_rank=0)
-    
+
     # Construct the trainer
     if args.lr is None:
         base_lr = 2.0 / math.sqrt(args.num_units) / math.sqrt(args.warmup_steps)
@@ -775,12 +775,10 @@ def train(args):
             if local_rank == 0:
                 if args.max_update <= 0:
                     model.save_parameters(os.path.join(args.save_dir,
-                                                       'epoch{}.params'.format(epoch_id)),
-                                          deduplicate=True)
+                                                       'epoch{}.params'.format(epoch_id)))
                 else:
                     model.save_parameters(os.path.join(args.save_dir,
-                                                       'iter{}.params'.format(train_iter + 1)),
-                                          deduplicate=True)
+                                                       'iter{}.params'.format(train_iter + 1)))
 
             avg_val_loss, ntokens, pred_sentences, pred_lengths, sentence_ids\
                 = validation(model, val_data_loader, inference_model, beam_search_sampler,
@@ -837,8 +835,7 @@ def train(args):
 
     if args.num_averages > 0:
         model_averager.copy_back(param_dict)  # TODO(sxjscience) Rewrite using update
-        model.save_parameters(os.path.join(args.save_dir, 'average.params'),
-                              deduplicate=True)
+        model.save_parameters(os.path.join(args.save_dir, 'average.params'))
 
 
 if __name__ == '__main__':

--- a/tests/process_cli/test_average_checkpoint.py
+++ b/tests/process_cli/test_average_checkpoint.py
@@ -18,14 +18,14 @@ def test_avg_ckpt():
     for key in params.keys():
         gd_avg[key] = params[key].data().asnumpy()
     model.save_parameters(os.path.join(_CURR_DIR, 'update0.params'))
-    
+
     for i in range(1, num_ckpts):
         model.initialize(force_reinit=True)
         params = model.collect_params()
         for key in gd_avg.keys():
             gd_avg[key] += params[key].data().asnumpy()
         model.save_parameters(os.path.join(_CURR_DIR, 'update{}.params'.format(i)))
-    
+
     for key in gd_avg.keys():
         gd_avg[key] /= num_ckpts
 
@@ -42,9 +42,9 @@ def test_avg_ckpt():
     args.checkpoints = [os.path.join(_CURR_DIR, 'update{}.params'.format(i)) \
                         for i in range(0, num_ckpts)]
     average_checkpoint.main(args)
-    
+
     model.load_parameters(os.path.join(_CURR_DIR, 'avg.params'))
     params = model.collect_params()
-    
+
     for key in gd_avg.keys():
         assert_allclose(gd_avg[key], params[key].data().asnumpy(), 1E-7, 1E-7)


### PR DESCRIPTION
## Description ##
this is a proposal to turn off deduplicate option in save_parameters

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] this is a proposal to turn off deduplicate option in save_parameters

## Comments ##
- Turning on deduplication is known to cause issue when a model with shared parameters is saved and then loaded in a model where the parameter that is removed gets used.

@sxjscience @leezu feel free to comment if there's any concern with such change.

cc @dmlc/gluon-nlp-team
