### PR TITLE
[TVM][BUGFIX] Change graph_runtime to graph_executor & Fix MosesNormalizer

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -74,7 +74,7 @@ jobs:
           mkdir -p build
           cp cmake/config.cmake build
           echo set\(USE_LLVM ON\) >> build/config.cmake
-          echo set\(USE_GRAPH_RUNTIME ON\) >> build/config.cmake
+          echo set\(USE_GRAPH_EXECUTOR ON\) >> build/config.cmake
           echo set\(USE_BLAS openblas\) >> build/config.cmake
           cd build
           cmake .. -G Ninja

--- a/docs/tutorials/deep_learning_compiler/tvm_basic.md
+++ b/docs/tutorials/deep_learning_compiler/tvm_basic.md
@@ -65,7 +65,7 @@ cls_embedding
 _TVM_RT_CACHE = dict()
 
 
-def compile_tvm_graph_runtime(model, model_name, cfg,
+def compile_tvm_graph_executor(model, model_name, cfg,
                               batch_size, seq_length, dtype, instance_type):
     layout = cfg.MODEL.layout
     compute_layout = cfg.MODEL.compute_layout
@@ -74,7 +74,7 @@ def compile_tvm_graph_runtime(model, model_name, cfg,
         return _TVM_RT_CACHE[key]
     tvm = try_import_tvm()
     from tvm import relay
-    from tvm.contrib import graph_runtime
+    from tvm.contrib import graph_executor
     from gluonnlp.utils.tvm_utils import get_ec2_tvm_flags, update_tvm_convert_map
     flags = get_ec2_tvm_flags()[instance_type]
     update_tvm_convert_map()
@@ -128,15 +128,15 @@ def compile_tvm_graph_runtime(model, model_name, cfg,
         ctx = tvm.gpu()
     else:
         ctx = tvm.cpu()
-    rt = graph_runtime.GraphModule(lib["default"](ctx))
+    rt = graph_executor.GraphModule(lib["default"](ctx))
     _TVM_RT_CACHE[key] = rt
     return rt
 ```
 
 
 ```{.python .input}
-rt = compile_tvm_graph_runtime(model, model_name, cfg, token_ids.shape[0],
-                               token_ids.shape[1], 'float32', 'g4')
+rt = compile_tvm_graph_executor(model, model_name, cfg, token_ids.shape[0],
+                                token_ids.shape[1], 'float32', 'g4')
 ```
 
 

--- a/scripts/benchmarks/benchmark_utils.py
+++ b/scripts/benchmarks/benchmark_utils.py
@@ -607,14 +607,14 @@ def bytes_to_mega_bytes(memory_amount: int) -> int:
 _TVM_RT_CACHE = dict()
 
 
-def compile_tvm_graph_runtime(model, model_name, layout, compute_layout,
+def compile_tvm_graph_executor(model, model_name, layout, compute_layout,
                               batch_size, seq_length, dtype, instance_type):
     key = (model_name, layout, compute_layout, batch_size, seq_length, dtype, instance_type)
     if key in _TVM_RT_CACHE:
         return _TVM_RT_CACHE[key]
     tvm = try_import_tvm()
     from tvm import relay
-    from tvm.contrib import graph_runtime
+    from tvm.contrib import graph_executor
     from gluonnlp.utils.tvm_utils import get_ec2_tvm_flags, update_tvm_convert_map
     flags = get_ec2_tvm_flags()[instance_type]
     update_tvm_convert_map()
@@ -668,7 +668,7 @@ def compile_tvm_graph_runtime(model, model_name, layout, compute_layout,
         ctx = tvm.gpu()
     else:
         ctx = tvm.cpu()
-    rt = graph_runtime.GraphModule(lib["default"](ctx))
+    rt = graph_executor.GraphModule(lib["default"](ctx))
     _TVM_RT_CACHE[key] = rt
     return rt
 
@@ -820,7 +820,7 @@ class GluonNLPBackboneBenchmark:
                 ctx = tvm.gpu()
             else:
                 ctx = tvm.cpu()
-            rt = compile_tvm_graph_runtime(model=model, model_name=model_name,
+            rt = compile_tvm_graph_executor(model=model, model_name=model_name,
                                            layout=self._layout, compute_layout=self._compute_layout,
                                            batch_size=batch_size, seq_length=sequence_length,
                                            instance_type=self._instance_type,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if VERSION.endswith('dev'):
 requirements = [
     'boto3',
     'numpy<1.20.0',
-    'sacremoses>=0.0.38',
+    'sacremoses>=0.0.38,<0.0.44',
     'yacs>=0.1.6',
     'sacrebleu',
     'flake8',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -73,11 +73,10 @@ def test_get_backbone(name, ctx):
 @pytest.mark.parametrize('layout', ['NT', 'TN'])
 @pytest.mark.skipif(not tvm_enabled(),
                     reason='TVM is not supported. So this test is skipped.')
-# @pytest.mark.skip('TVM issue https://github.com/dmlc/gluon-nlp/issues/1425.')
 def test_tvm_integration(model_name, batch_size, seq_length, layout, ctx):
     tvm = try_import_tvm()
     from tvm import relay
-    from tvm.contrib import graph_runtime
+    from tvm.contrib import graph_executor
     from gluonnlp.utils.tvm_utils import get_ec2_tvm_flags, update_tvm_convert_map
     update_tvm_convert_map()
     tvm_recommended_flags = get_ec2_tvm_flags()
@@ -161,7 +160,7 @@ def test_tvm_integration(model_name, batch_size, seq_length, layout, ctx):
             ctx = tvm.gpu()
         else:
             ctx = tvm.cpu()
-        rt = graph_runtime.GraphModule(lib["default"](ctx))
+        rt = graph_executor.GraphModule(lib["default"](ctx))
         if 'bart' in model_name:
             rt.set_input(data0=token_ids.asnumpy(), data1=valid_length.asnumpy(), data2=token_ids.asnumpy(), data3=valid_length.asnumpy())
         elif 'roberta' in model_name:

--- a/tools/docker/install/install_tvm_cpu.sh
+++ b/tools/docker/install/install_tvm_cpu.sh
@@ -24,12 +24,12 @@ cd ${WORKDIR}
 git clone https://github.com/apache/incubator-tvm tvm --recursive
 cd ${WORKDIR}/tvm
 # checkout a hash-tag
-git checkout 790344c6ef035947caaaf1cd812ade8d862802aa
+git checkout bf862d4c4355eae4f18d89b3b6b98ed0a2c18e9c
 
 mkdir -p build
 cp cmake/config.cmake build
 echo set\(USE_LLVM llvm-config-10\) >> build/config.cmake
-echo set\(USE_GRAPH_RUNTIME ON\) >> build/config.cmake
+echo set\(USE_GRAPH_EXECUTOR ON\) >> build/config.cmake
 echo set\(USE_BLAS openblas\) >> build/config.cmake
 
 cd build

--- a/tools/docker/install/install_tvm_gpu.sh
+++ b/tools/docker/install/install_tvm_gpu.sh
@@ -24,7 +24,7 @@ cd ${WORKDIR}
 git clone https://github.com/apache/incubator-tvm tvm --recursive
 cd ${WORKDIR}/tvm
 # checkout a hash-tag
-git checkout 790344c6ef035947caaaf1cd812ade8d862802aa
+git checkout bf862d4c4355eae4f18d89b3b6b98ed0a2c18e9c
 
 
 mkdir -p build
@@ -33,7 +33,7 @@ echo set\(USE_LLVM llvm-config-10\) >> build/config.cmake
 echo set\(USE_CUDA ON\) >> build/config.cmake
 echo set\(USE_CUDNN ON\) >> build/config.cmake
 echo set\(USE_CUBLAS ON\) >> build/config.cmake
-echo set\(USE_GRAPH_RUNTIME ON\) >> build/config.cmake
+echo set\(USE_GRAPH_EXECUTOR ON\) >> build/config.cmake
 echo set\(USE_BLAS openblas\) >> build/config.cmake
 
 cd build

--- a/tools/docker/ubuntu18.04-gpu.Dockerfile
+++ b/tools/docker/ubuntu18.04-gpu.Dockerfile
@@ -35,7 +35,7 @@ RUN bash /install/install_tvm_gpu.sh
 RUN python3 -m pip install -U --pre "mxnet-cu102>=2.0.0b20210121" -f https://dist.mxnet.io/python --user
 
 # Install PyTorch
-RUN python3 -m pip install "torch==1.7.1+cu102" torchvision -f https://download.pytorch.org/whl/torch_stable.html
+RUN python3 -m pip install "torch==1.8.1+cu102" torchvision -f https://download.pytorch.org/whl/torch_stable.html
 
 # Install Horovod
 RUN bash /install/install_horovod.sh


### PR DESCRIPTION
## Description ##
TVM will deprecate graph_runtime and use graph_executor. https://github.com/apache/tvm/blob/bf862d4c4355eae4f18d89b3b6b98ed0a2c18e9c/python/tvm/contrib/graph_runtime.py#L24-L29

When building gpu docker, the log shows 
```
Defaulting to user installation because normal site-packages is not writeable
Looking in links: https://download.pytorch.org/whl/torch_stable.html
ERROR: Could not find a version that satisfies the requirement torch==1.7.1+cu102
ERROR: No matching distribution found for torch==1.7.1+cu102
```
So, I changed to torch==1.8.1+cu102 @leezu 
Also fix sacremoses version to <0.0.44, because the contributors of sacremoses didn't update their release for 0.0.44 on github. Updates will be tracked in #1548 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

cc @dmlc/gluon-nlp-team
