### PR TITLE
Add sorting of chunks to evaluation

### DIFF
--- a/scripts/question_answering/run_squad.py
+++ b/scripts/question_answering/run_squad.py
@@ -837,6 +837,7 @@ def evaluate(args, last=True):
 
     logging.info('Prepare dev data')
     dev_features = get_squad_features(args, tokenizer, segment='dev')
+    dev_features.sort(key=lambda x: x.qas_id)
     dev_data_path = os.path.join(args.data_dir, 'dev-v{}.json'.format(args.version))
     dataset_processor = SquadDatasetProcessor(tokenizer=tokenizer,
                                               doc_stride=args.doc_stride,
@@ -848,6 +849,7 @@ def evaluate(args, last=True):
         chunk_features = dataset_processor.process_sample(feature)
         dev_all_chunk_features.extend(chunk_features)
         dev_chunk_feature_ptr.append(dev_chunk_feature_ptr[-1] + len(chunk_features))
+    dev_all_chunk_features.sort(key=lambda x: x.valid_length)
 
     def eval_validation(ckpt_name, best_eval):
         """
@@ -912,6 +914,8 @@ def evaluate(args, last=True):
         all_predictions = collections.OrderedDict()
         all_nbest_json = collections.OrderedDict()
         no_answer_score_json = collections.OrderedDict()
+        all_results.sort(key=lambda x: x.qas_id)
+        dev_all_chunk_features.sort(key=lambda x: x.qas_id)
         for index, (left_index, right_index) in enumerate(zip(dev_chunk_feature_ptr[:-1],
                                                               dev_chunk_feature_ptr[1:])):
             chunked_features = dev_all_chunk_features[left_index:right_index]


### PR DESCRIPTION
## Description ##
This change introduces sorting of chunks before executing evaluation to reduce padding to minimum and in this way improve performance.

### How the change works ###
As every input feature has unique qas_id it can be used for sorting. With the sorting evaluation function goes like this:

1. sort input features by qas_id
2. chunk data
3. sort chunks by their length (to reduce padding to minimum)
4. perform inference
5. sort chunks and results by qas_id
6. evaluate data

Step number 1 is performed so that chunks and their inference results can be easily put in proper order in step number 5 for evaluation in step 6.

## Performance ##
Results for max_seq_length=128, doc_stride=32:
no sort:
![image](https://user-images.githubusercontent.com/59650839/162547734-2db83fce-e801-481d-8c41-4b960318ddac.png)

sorted:
![image](https://user-images.githubusercontent.com/59650839/162547739-66c5323c-bf15-474d-b77f-efcf08f92f9a.png)

Performance did not improve much due to most of the chunks being of same 128 length due to relatively small values of max_seq_length and doc_stride.

Results for max_seq_length=512, doc_stride=128 (default values in run_squad.py script):
no sort:
![image](https://user-images.githubusercontent.com/59650839/162547845-8a6faeda-77e1-4e99-8cd1-5ae9bcfcfd89.png)

sorted:
![image](https://user-images.githubusercontent.com/59650839/162547852-b0ec7489-64c5-4ba1-aee4-b514753df30c.png)

As you can see the performance improved significantly (~20%) without any loss of accuracy.

cc @dmlc/gluon-nlp-team
